### PR TITLE
lxd: Add storage and network options to project create

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2614,3 +2614,7 @@ This API extension enables setting an {config:option}`server-oidc:oidc.scopes` c
 This configuration option can be used to request additional scopes that might be required for retrieving {ref}`identity provider groups <identity-provider-groups>` from the identity provider.
 Additionally, the optional scopes `profile` and `offline_access` can be unset via this setting.
 Note that the `openid` and `email` scopes are always required.
+
+## `project_default_network_and_storage`
+
+Adds flags --network and --storage. The --network flag adds a network device connected to the specified network to the default profile. The --storage flag adds a root disk device using the specified storage pool to the default profile.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4641,6 +4641,16 @@ definitions:
                 example: foo
                 type: string
                 x-go-name: Name
+            network:
+                description: Add a network device connected to the specified network to the default profile
+                example: lxdbr0
+                type: string
+                x-go-name: Network
+            storage:
+                description: Add a root disk device using the specified storage pool to the default profile
+                example: default
+                type: string
+                x-go-name: StoragePool
         type: object
         x-go-package: github.com/canonical/lxd/shared/api
     Resources:

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -83,9 +83,11 @@ func (c *cmdProject) command() *cobra.Command {
 
 // Create.
 type cmdProjectCreate struct {
-	global     *cmdGlobal
-	project    *cmdProject
-	flagConfig []string
+	global      *cmdGlobal
+	project     *cmdProject
+	flagConfig  []string
+	flagStorage string
+	flagNetwork string
 }
 
 func (c *cmdProjectCreate) command() *cobra.Command {
@@ -100,6 +102,8 @@ lxc project create p1 < config.yaml
     Create a project with configuration from config.yaml`))
 
 	cmd.Flags().StringArrayVarP(&c.flagConfig, "config", "c", nil, i18n.G("Config key/value to apply to the new project")+"``")
+	cmd.Flags().StringVarP(&c.flagStorage, "storage", "s", "", i18n.G("Add a storage pool to be used as the root device in the default profile")+"``")
+	cmd.Flags().StringVarP(&c.flagNetwork, "network", "n", "", i18n.G("Add a NIC device to the default profile connected to the specified network")+"``")
 
 	cmd.RunE = c.run
 
@@ -152,6 +156,8 @@ func (c *cmdProjectCreate) run(cmd *cobra.Command, args []string) error {
 	project := api.ProjectsPost{}
 	project.Name = resource.name
 	project.ProjectPut = stdinData
+	project.StoragePool = c.flagStorage
+	project.Network = c.flagNetwork
 
 	if project.Config == nil {
 		project.Config = map[string]string{}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -588,6 +588,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -602,6 +607,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -732,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -754,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -857,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -882,12 +891,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -930,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1015,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1032,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1113,7 +1122,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1157,31 +1166,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1209,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1217,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1288,7 +1297,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1296,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1304,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1322,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1354,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1365,17 +1374,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1457,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1506,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1509,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,9 +1551,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1564,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1657,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1660,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1680,9 +1689,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1691,9 +1700,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1748,10 +1757,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1765,27 +1774,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1797,25 +1806,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1825,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1912,7 +1921,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1933,11 +1942,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1959,7 +1968,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2027,7 +2036,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2043,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2052,16 +2061,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2104,12 +2113,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2119,12 +2128,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2134,11 +2143,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2166,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2191,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2203,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2397,7 +2406,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2405,7 +2414,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2413,11 +2422,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2433,7 +2442,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2458,16 +2467,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2531,7 +2540,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2579,7 +2588,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2591,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2603,7 +2612,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2643,7 +2652,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2655,11 +2664,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2737,7 +2746,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2787,7 +2796,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2801,7 +2810,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2851,7 +2860,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2859,7 +2868,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2881,11 +2890,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3011,7 +3020,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3019,7 +3028,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3037,9 +3046,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3075,7 +3084,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3085,7 +3094,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3097,8 +3106,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3147,7 +3156,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3262,7 +3271,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3394,7 +3403,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3406,11 +3415,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3469,7 +3478,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3770,17 +3779,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3834,7 +3843,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3882,9 +3891,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3939,12 +3948,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3953,9 +3962,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3963,11 +3972,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4004,8 +4013,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4042,7 +4051,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4050,11 +4059,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4076,12 +4085,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4093,11 +4102,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4109,9 +4118,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4133,8 +4142,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4142,7 +4151,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4277,7 +4286,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4286,7 +4295,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4306,15 +4315,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4324,7 +4333,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4337,16 +4346,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4358,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4371,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4401,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4413,12 +4422,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4463,7 +4472,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4484,16 +4493,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4583,17 +4592,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4610,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4624,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4661,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4670,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4683,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4740,7 +4749,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4769,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4792,7 +4801,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4847,7 +4856,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4883,7 +4892,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4927,7 +4936,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4960,7 +4969,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4968,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4986,7 +4995,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5013,7 +5022,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5028,11 +5037,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5054,7 +5063,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5117,7 +5126,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5125,7 +5134,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5179,11 +5188,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5192,7 +5201,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5313,11 +5322,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5352,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5429,7 +5438,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5441,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5485,7 +5494,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5574,7 +5583,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5590,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5662,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5775,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5797,7 +5806,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5820,7 +5829,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5846,18 +5855,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5903,7 +5912,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5940,7 +5949,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5999,7 +6008,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6014,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6038,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6059,11 +6068,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6114,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6129,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6137,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6196,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6206,7 +6215,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6218,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6257,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6286,7 +6295,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6294,7 +6303,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6350,7 +6359,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6362,11 +6371,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6402,7 +6411,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6414,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6435,11 +6444,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6458,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6481,7 +6490,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6530,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6563,9 +6572,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6589,19 +6598,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6610,11 +6619,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6773,17 +6782,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6791,7 +6800,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6803,7 +6812,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6878,8 +6887,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6887,7 +6896,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6895,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7017,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7052,37 +7061,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7090,40 +7099,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7139,7 +7148,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7151,20 +7160,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7216,7 +7225,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7228,11 +7237,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7300,7 +7309,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7592,7 +7601,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7600,7 +7609,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7692,7 +7701,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7700,13 +7709,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7769,7 +7778,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -617,7 +617,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -656,7 +656,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -858,6 +858,11 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -875,6 +880,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Profil %s erstellt\n"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -1010,7 +1019,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1034,7 +1043,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1083,11 +1092,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1144,17 +1153,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1170,12 +1179,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1218,7 +1227,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1314,7 +1323,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1331,12 +1340,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1418,7 +1427,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1462,31 +1471,31 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1515,7 +1524,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1525,24 +1534,24 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1598,7 +1607,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1606,7 +1615,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1616,13 +1625,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1635,7 +1644,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1659,12 +1668,12 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1679,17 +1688,17 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1782,7 +1791,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1830,7 +1839,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1845,7 +1854,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1879,9 +1888,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1901,7 +1910,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1993,7 +2002,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2007,7 +2016,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2028,9 +2037,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -2039,9 +2048,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2096,10 +2105,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2113,27 +2122,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2147,26 +2156,26 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, fuzzy, c-format
 msgid "Device %s added to %s"
 msgstr "Gerät %s wurde zu %s hinzugefügt\n"
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
@@ -2176,25 +2185,25 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2278,7 +2287,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Display profiles from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2299,11 +2308,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
@@ -2326,7 +2335,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2408,7 +2417,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2425,7 +2434,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2435,16 +2444,16 @@ msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2488,12 +2497,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2503,12 +2512,12 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2518,7 +2527,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2527,7 +2536,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2559,8 +2568,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2584,7 +2593,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2599,12 +2608,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2797,7 +2806,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2805,7 +2814,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2813,11 +2822,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2834,7 +2843,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2859,16 +2868,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2934,7 +2943,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2987,7 +2996,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3001,7 +3010,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3015,7 +3024,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3063,7 +3072,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3077,11 +3086,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3160,7 +3169,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3212,7 +3221,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3226,7 +3235,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3278,7 +3287,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3286,7 +3295,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3310,11 +3319,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3442,7 +3451,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -3451,7 +3460,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3470,9 +3479,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3513,7 +3522,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3523,7 +3532,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3535,8 +3544,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3588,7 +3597,7 @@ msgstr "Aliasse:\n"
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3709,7 +3718,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 #, fuzzy
 msgid "List instance devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3860,7 +3869,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3874,12 +3883,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3939,7 +3948,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4282,17 +4291,17 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4349,7 +4358,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4405,9 +4414,9 @@ msgstr "Fehlende Zusammenfassung."
 msgid "Missing listen address"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 #, fuzzy
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
@@ -4467,12 +4476,12 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4482,9 +4491,9 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4493,12 +4502,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4537,8 +4546,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4578,7 +4587,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4588,11 +4597,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4615,12 +4624,12 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4632,11 +4641,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4648,9 +4657,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4672,8 +4681,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4681,7 +4690,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4819,7 +4828,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4829,7 +4838,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4851,15 +4860,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, fuzzy, c-format
 msgid "No value found in %q"
 msgstr "kein Wert in %q gefunden\n"
@@ -4869,7 +4878,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4883,16 +4892,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4904,7 +4913,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4917,7 +4926,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4947,7 +4956,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4959,12 +4968,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5011,7 +5020,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5034,16 +5043,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5138,17 +5147,17 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -5166,7 +5175,7 @@ msgstr "Eigenschaften:\n"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5180,7 +5189,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5196,7 +5205,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5217,7 +5226,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5226,7 +5235,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5239,7 +5248,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5299,7 +5308,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -5330,7 +5339,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5354,7 +5363,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5411,7 +5420,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5453,7 +5462,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5504,7 +5513,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5541,7 +5550,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5550,17 +5559,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5570,7 +5579,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5598,7 +5607,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5615,12 +5624,12 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5644,7 +5653,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5709,7 +5718,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5717,7 +5726,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5775,12 +5784,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5789,7 +5798,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5917,12 +5926,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5959,12 +5968,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6045,7 +6054,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6059,7 +6068,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6106,7 +6115,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
@@ -6209,7 +6218,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -6227,12 +6236,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -6304,16 +6313,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6423,22 +6432,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6448,7 +6457,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6471,7 +6480,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6497,18 +6506,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6558,7 +6567,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 #, fuzzy
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
@@ -6596,7 +6605,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6656,7 +6665,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6671,12 +6680,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6695,8 +6704,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6719,11 +6728,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6776,7 +6785,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6791,7 +6800,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6799,7 +6808,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6860,7 +6869,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6870,7 +6879,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6882,13 +6891,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6922,7 +6931,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6952,7 +6961,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6962,7 +6971,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset all profiles on the target instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7029,7 +7038,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7043,12 +7052,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -7090,7 +7099,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7104,7 +7113,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7126,12 +7135,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7151,12 +7160,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7174,7 +7183,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7227,7 +7236,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -7265,9 +7274,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7295,7 +7304,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
@@ -7303,7 +7312,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -7312,10 +7321,10 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7332,7 +7341,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7340,7 +7349,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7645,8 +7654,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7656,7 +7665,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7664,7 +7673,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7680,7 +7689,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7704,7 +7713,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7865,8 +7874,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7884,7 +7893,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -7901,7 +7910,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -8128,7 +8137,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8195,7 +8204,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8206,7 +8215,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8215,7 +8224,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8224,7 +8233,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8233,7 +8242,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8241,7 +8250,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8250,7 +8259,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8258,7 +8267,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
@@ -8274,7 +8283,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8282,7 +8291,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8290,7 +8299,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8299,7 +8308,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8308,7 +8317,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8316,7 +8325,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8324,7 +8333,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 #, fuzzy
 msgid "[<remote>:]<profile>"
@@ -8333,7 +8342,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8341,7 +8350,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8373,7 +8382,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8397,8 +8406,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8406,7 +8415,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8414,7 +8423,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8422,7 +8431,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8530,7 +8539,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8555,7 +8564,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8564,7 +8573,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8632,7 +8641,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8928,7 +8937,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8936,7 +8945,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9028,7 +9037,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9036,13 +9045,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9105,7 +9114,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -608,6 +613,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "  Χρήση δικτύου:"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -738,7 +747,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +769,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -804,11 +813,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -863,16 +872,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -888,12 +897,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -936,7 +945,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1022,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1039,12 +1048,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1120,7 +1129,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1164,31 +1173,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1216,7 +1225,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1224,24 +1233,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1295,7 +1304,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1303,7 +1312,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1311,12 +1320,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1329,7 +1338,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1352,12 +1361,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1372,17 +1381,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1465,7 +1474,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1507,7 +1516,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1519,7 +1528,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1552,9 +1561,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1574,7 +1583,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1662,7 +1671,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1675,7 +1684,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1695,9 +1704,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1706,9 +1715,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1763,10 +1772,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1780,27 +1789,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -1813,25 +1822,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1841,24 +1850,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1932,7 +1941,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1953,11 +1962,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1979,7 +1988,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2052,7 +2061,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2069,7 +2078,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2078,16 +2087,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2130,12 +2139,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2145,12 +2154,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2160,11 +2169,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2192,8 +2201,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2217,7 +2226,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2229,11 +2238,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2423,7 +2432,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2431,7 +2440,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2439,11 +2448,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2459,7 +2468,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2484,16 +2493,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2557,7 +2566,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2610,7 +2619,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2623,7 +2632,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2636,7 +2645,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2681,7 +2690,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2694,11 +2703,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2776,7 +2785,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2826,7 +2835,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2840,7 +2849,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2890,7 +2899,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2898,7 +2907,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2920,11 +2929,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3050,7 +3059,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3058,7 +3067,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3076,9 +3085,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3114,7 +3123,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3124,7 +3133,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3136,8 +3145,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3186,7 +3195,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3303,7 +3312,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3435,7 +3444,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3447,11 +3456,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3510,7 +3519,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3825,17 +3834,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3893,7 +3902,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3946,9 +3955,9 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4004,12 +4013,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4018,9 +4027,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -4028,11 +4037,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
@@ -4070,8 +4079,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4108,7 +4117,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4116,11 +4125,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4142,12 +4151,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4159,11 +4168,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4175,9 +4184,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4199,8 +4208,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4208,7 +4217,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4345,7 +4354,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4354,7 +4363,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4374,15 +4383,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4392,7 +4401,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4405,16 +4414,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4426,7 +4435,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4439,7 +4448,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4469,7 +4478,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4481,12 +4490,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4531,7 +4540,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
@@ -4553,16 +4562,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4652,17 +4661,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4679,7 +4688,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4693,7 +4702,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4709,7 +4718,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4730,7 +4739,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4739,7 +4748,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4752,7 +4761,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4809,7 +4818,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4838,7 +4847,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4861,7 +4870,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4916,7 +4925,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4955,7 +4964,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -5001,7 +5010,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5034,7 +5043,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5042,15 +5051,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5060,7 +5069,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5087,7 +5096,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5102,11 +5111,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5129,7 +5138,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5192,7 +5201,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5200,7 +5209,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5255,11 +5264,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5268,7 +5277,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5394,11 +5403,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5434,11 +5443,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5516,7 +5525,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5529,7 +5538,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5574,7 +5583,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5670,7 +5679,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5688,11 +5697,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5761,15 +5770,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5874,21 +5883,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5896,7 +5905,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5919,7 +5928,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5945,18 +5954,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6039,7 +6048,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6098,7 +6107,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6113,12 +6122,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6137,8 +6146,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6159,11 +6168,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6214,7 +6223,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6229,7 +6238,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6237,7 +6246,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6296,7 +6305,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6306,7 +6315,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6318,13 +6327,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6357,7 +6366,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6386,7 +6395,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -6395,7 +6404,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6459,7 +6468,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6472,11 +6481,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6518,7 +6527,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6531,7 +6540,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6552,11 +6561,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6575,12 +6584,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6598,7 +6607,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6647,7 +6656,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6680,9 +6689,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6706,19 +6715,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6727,11 +6736,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6890,17 +6899,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6908,7 +6917,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6920,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6995,8 +7004,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7004,7 +7013,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -7012,7 +7021,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7134,7 +7143,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7169,37 +7178,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7207,40 +7216,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7256,7 +7265,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7268,20 +7277,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7333,7 +7342,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7345,11 +7354,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7417,7 +7426,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7709,7 +7718,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7717,7 +7726,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7809,7 +7818,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7817,13 +7826,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7886,7 +7895,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -610,7 +610,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -646,7 +646,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -834,6 +834,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -851,6 +856,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Perfil %s creado"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -982,7 +991,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -1005,7 +1014,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1050,11 +1059,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1109,16 +1118,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1134,12 +1143,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1183,7 +1192,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1272,7 +1281,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1289,12 +1298,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1372,7 +1381,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1416,31 +1425,31 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1469,7 +1478,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1478,24 +1487,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1549,7 +1558,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1557,7 +1566,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1565,12 +1574,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1584,7 +1593,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1608,12 +1617,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1628,17 +1637,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1727,7 +1736,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1769,7 +1778,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1781,7 +1790,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1815,9 +1824,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1837,7 +1846,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1926,7 +1935,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1939,7 +1948,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1959,9 +1968,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1970,9 +1979,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2027,10 +2036,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2044,27 +2053,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2077,25 +2086,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2105,25 +2114,25 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2198,7 +2207,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Display profiles from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2219,11 +2228,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
@@ -2246,7 +2255,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2319,7 +2328,7 @@ msgstr "Perfil %s creado"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2336,7 +2345,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2345,16 +2354,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2397,12 +2406,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2412,12 +2421,12 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2427,12 +2436,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2460,8 +2469,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2486,7 +2495,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2500,11 +2509,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2694,7 +2703,7 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2702,7 +2711,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2710,11 +2719,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2731,7 +2740,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2756,16 +2765,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2830,7 +2839,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2883,7 +2892,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2896,7 +2905,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2909,7 +2918,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2954,7 +2963,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2967,11 +2976,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3050,7 +3059,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3102,7 +3111,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3116,7 +3125,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3166,7 +3175,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3174,7 +3183,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3197,11 +3206,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3330,7 +3339,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3339,7 +3348,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3357,9 +3366,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3396,7 +3405,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3406,7 +3415,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3418,8 +3427,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3471,7 +3480,7 @@ msgstr "Aliases:"
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
@@ -3592,7 +3601,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3727,7 +3736,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3740,11 +3749,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3804,7 +3813,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4121,17 +4130,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4188,7 +4197,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4244,9 +4253,9 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing listen address"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4305,12 +4314,12 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4319,9 +4328,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -4330,11 +4339,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -4374,8 +4383,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4413,7 +4422,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4421,11 +4430,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4447,12 +4456,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4464,11 +4473,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4480,9 +4489,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4504,8 +4513,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4513,7 +4522,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4648,7 +4657,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4657,7 +4666,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4677,15 +4686,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4695,7 +4704,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4708,16 +4717,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4729,7 +4738,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4742,7 +4751,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4784,12 +4793,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4834,7 +4843,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
@@ -4856,16 +4865,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4959,17 +4968,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4986,7 +4995,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5000,7 +5009,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5016,7 +5025,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5037,7 +5046,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5046,7 +5055,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5059,7 +5068,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5116,7 +5125,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -5147,7 +5156,7 @@ msgstr "Aliases:"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5170,7 +5179,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5227,7 +5236,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5266,7 +5275,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -5312,7 +5321,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5346,7 +5355,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5354,15 +5363,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5372,7 +5381,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5400,7 +5409,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -5417,11 +5426,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
@@ -5509,7 +5518,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5517,7 +5526,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5573,11 +5582,11 @@ msgstr "Perfil %s creado"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5586,7 +5595,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5712,11 +5721,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5752,11 +5761,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5834,7 +5843,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5847,7 +5856,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5892,7 +5901,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5989,7 +5998,7 @@ msgstr "Perfil %s creado"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -6007,11 +6016,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6080,15 +6089,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6194,21 +6203,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6216,7 +6225,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6239,7 +6248,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6265,18 +6274,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6324,7 +6333,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6361,7 +6370,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6420,7 +6429,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6435,12 +6444,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6459,8 +6468,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6481,11 +6490,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
@@ -6537,7 +6546,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6552,7 +6561,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6560,7 +6569,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6621,7 +6630,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6631,7 +6640,7 @@ msgstr "Expira: %s"
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6643,13 +6652,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6682,7 +6691,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6712,7 +6721,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -6721,7 +6730,7 @@ msgstr "Perfil %s creado"
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6785,7 +6794,7 @@ msgstr "Perfil %s creado"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6798,11 +6807,11 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6844,7 +6853,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6857,7 +6866,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6878,12 +6887,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6902,12 +6911,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6925,7 +6934,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6974,7 +6983,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -7007,9 +7016,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7033,21 +7042,21 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7058,12 +7067,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7256,19 +7265,19 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7278,7 +7287,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7293,7 +7302,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7385,8 +7394,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7396,7 +7405,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7406,7 +7415,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7554,7 +7563,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7597,44 +7606,44 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7644,48 +7653,48 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7705,7 +7714,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7720,23 +7729,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7801,7 +7810,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7816,12 +7825,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7889,7 +7898,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8181,7 +8190,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8189,7 +8198,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8281,7 +8290,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8289,13 +8298,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8358,7 +8367,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -615,7 +615,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -653,7 +653,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -854,6 +854,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -871,6 +876,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Clé de configuration invalide"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -1014,7 +1023,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -1038,7 +1047,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1086,11 +1095,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1147,17 +1156,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1173,12 +1182,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1221,7 +1230,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1310,7 +1319,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1329,12 +1338,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1412,7 +1421,7 @@ msgstr "Profils %s appliqués à %s"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1456,31 +1465,31 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1517,7 +1526,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1527,24 +1536,24 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1600,7 +1609,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1608,7 +1617,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1618,13 +1627,13 @@ msgstr "Copie de l'image : %s"
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1638,7 +1647,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1662,12 +1671,12 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
@@ -1682,17 +1691,17 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1802,7 +1811,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1850,7 +1859,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
@@ -1865,7 +1874,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1899,9 +1908,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1921,7 +1930,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2018,7 +2027,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
@@ -2032,7 +2041,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2054,9 +2063,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -2065,9 +2074,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2122,10 +2131,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2139,27 +2148,27 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2172,26 +2181,26 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Périphérique %s ajouté à %s"
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, fuzzy, c-format
 msgid "Device %s overridden for %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
@@ -2201,25 +2210,25 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2298,7 +2307,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Display profiles from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2320,11 +2329,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
@@ -2347,7 +2356,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2429,7 +2438,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2447,7 +2456,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2457,16 +2466,16 @@ msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2510,12 +2519,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2525,12 +2534,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2540,7 +2549,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2552,7 +2561,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2589,8 +2598,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2616,7 +2625,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2631,12 +2640,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2829,7 +2838,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2837,7 +2846,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2846,11 +2855,11 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2869,7 +2878,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2894,16 +2903,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2968,7 +2977,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -3021,7 +3030,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3035,7 +3044,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3049,7 +3058,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3099,7 +3108,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3113,11 +3122,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3198,7 +3207,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3250,7 +3259,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3267,7 +3276,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3321,7 +3330,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3329,7 +3338,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3354,11 +3363,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3488,7 +3497,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3497,7 +3506,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3516,9 +3525,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3556,7 +3565,7 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3566,7 +3575,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3578,8 +3587,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3631,7 +3640,7 @@ msgstr "Alias :"
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3752,7 +3761,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 #, fuzzy
 msgid "List instance devices"
 msgstr "Création du conteneur"
@@ -3949,7 +3958,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3963,12 +3972,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4028,7 +4037,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4366,17 +4375,17 @@ msgstr "Profil %s ajouté à %s"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -4435,7 +4444,7 @@ msgstr "Empreinte du certificat : %s"
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4491,9 +4500,9 @@ msgstr "Résumé manquant."
 msgid "Missing listen address"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 #, fuzzy
 msgid "Missing name"
 msgstr "Résumé manquant."
@@ -4554,12 +4563,12 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4569,9 +4578,9 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4580,12 +4589,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4626,8 +4635,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -4668,7 +4677,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4678,11 +4687,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -4705,12 +4714,12 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr "NOM"
 
@@ -4722,11 +4731,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4738,9 +4747,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr "NON"
 
@@ -4762,8 +4771,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4772,7 +4781,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4911,7 +4920,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4920,7 +4929,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -4942,15 +4951,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4960,7 +4969,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4976,20 +4985,20 @@ msgid ""
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 #, fuzzy
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -5004,7 +5013,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -5020,7 +5029,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5051,7 +5060,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -5063,12 +5072,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr "PROFILS"
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5116,7 +5125,7 @@ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5139,16 +5148,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5244,17 +5253,17 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -5271,7 +5280,7 @@ msgstr "Propriétés :"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5285,7 +5294,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5301,7 +5310,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5322,7 +5331,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5331,7 +5340,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5344,7 +5353,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5404,7 +5413,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
@@ -5437,7 +5446,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -5462,7 +5471,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5520,7 +5529,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5562,7 +5571,7 @@ msgstr "Création du conteneur"
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5614,7 +5623,7 @@ msgstr "Ajouter de nouveaux clients de confiance"
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5650,7 +5659,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -5659,17 +5668,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5679,7 +5688,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5708,7 +5717,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5741,12 +5750,12 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5770,7 +5779,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5836,7 +5845,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5845,7 +5854,7 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5904,12 +5913,12 @@ msgstr "Clé de configuration invalide"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5918,7 +5927,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -6048,12 +6057,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6090,12 +6099,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6176,7 +6185,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6190,7 +6199,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6237,7 +6246,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
@@ -6344,7 +6353,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -6363,12 +6372,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -6441,16 +6450,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6561,22 +6570,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6586,7 +6595,7 @@ msgstr "Image copiée avec succès !"
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6609,7 +6618,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6637,18 +6646,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6695,7 +6704,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 #, fuzzy
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
@@ -6740,7 +6749,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
@@ -6800,7 +6809,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6815,12 +6824,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6839,8 +6848,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -6861,11 +6870,11 @@ msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
@@ -6921,7 +6930,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6936,7 +6945,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6944,7 +6953,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7006,7 +7015,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -7016,7 +7025,7 @@ msgstr "Expire : %s"
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -7028,13 +7037,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7068,7 +7077,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7098,7 +7107,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7108,7 +7117,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset all profiles on the target instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7177,7 +7186,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7192,12 +7201,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -7239,7 +7248,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7253,7 +7262,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7275,12 +7284,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7300,12 +7309,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7323,7 +7332,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -7374,7 +7383,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -7412,9 +7421,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr "OUI"
 
@@ -7442,7 +7451,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
@@ -7450,7 +7459,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -7459,10 +7468,10 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7476,7 +7485,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7484,7 +7493,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7816,8 +7825,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7830,7 +7839,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7838,7 +7847,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7854,7 +7863,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7878,7 +7887,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -8078,8 +8087,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -8103,7 +8112,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -8123,7 +8132,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -8353,7 +8362,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8420,7 +8429,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8434,7 +8443,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8446,7 +8455,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8458,7 +8467,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8470,7 +8479,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8478,7 +8487,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8490,7 +8499,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8498,7 +8507,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
@@ -8514,7 +8523,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8522,7 +8531,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8530,7 +8539,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8542,7 +8551,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8554,7 +8563,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8562,7 +8571,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8570,7 +8579,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 #, fuzzy
 msgid "[<remote>:]<profile>"
@@ -8579,7 +8588,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8587,7 +8596,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8619,7 +8628,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8643,8 +8652,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8652,7 +8661,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8660,7 +8669,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8668,7 +8677,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8788,7 +8797,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8816,7 +8825,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8828,7 +8837,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -8897,7 +8906,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -9211,7 +9220,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9219,7 +9228,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9311,7 +9320,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9319,13 +9328,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9389,7 +9398,7 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -592,6 +592,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -606,6 +611,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -736,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -758,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -802,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -861,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -886,12 +895,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -934,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1019,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1036,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1117,7 +1126,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1161,31 +1170,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1213,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1221,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1292,7 +1301,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1300,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1308,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1326,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1358,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1369,17 +1378,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1461,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1501,7 +1510,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1513,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,9 +1555,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1568,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1652,7 +1661,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1664,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1684,9 +1693,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1695,9 +1704,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1752,10 +1761,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1769,27 +1778,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1801,25 +1810,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1829,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1916,7 +1925,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1937,11 +1946,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1963,7 +1972,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2040,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2056,16 +2065,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2108,12 +2117,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2123,12 +2132,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2138,11 +2147,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2170,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2195,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2207,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2401,7 +2410,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2409,7 +2418,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2417,11 +2426,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,7 +2446,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2462,16 +2471,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2535,7 +2544,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2583,7 +2592,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2595,7 +2604,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2607,7 +2616,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2659,11 +2668,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2741,7 +2750,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2791,7 +2800,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2805,7 +2814,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2855,7 +2864,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2863,7 +2872,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2885,11 +2894,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3015,7 +3024,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3023,7 +3032,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3041,9 +3050,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3079,7 +3088,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3089,7 +3098,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,8 +3110,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3151,7 +3160,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3266,7 +3275,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3398,7 +3407,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3410,11 +3419,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3473,7 +3482,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3774,17 +3783,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3838,7 +3847,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3886,9 +3895,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3943,12 +3952,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3957,9 +3966,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3967,11 +3976,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4008,8 +4017,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4046,7 +4055,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4054,11 +4063,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4080,12 +4089,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4097,11 +4106,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4113,9 +4122,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4137,8 +4146,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4146,7 +4155,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4281,7 +4290,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4290,7 +4299,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4310,15 +4319,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4328,7 +4337,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4341,16 +4350,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4362,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4375,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4405,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4417,12 +4426,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4467,7 +4476,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4488,16 +4497,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4587,17 +4596,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4614,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4628,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4665,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4674,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4744,7 +4753,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4773,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4796,7 +4805,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4851,7 +4860,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4887,7 +4896,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4931,7 +4940,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4964,7 +4973,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4972,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4990,7 +4999,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5017,7 +5026,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5032,11 +5041,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5058,7 +5067,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5121,7 +5130,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5129,7 +5138,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5183,11 +5192,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5196,7 +5205,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5317,11 +5326,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5356,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5433,7 +5442,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5445,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5489,7 +5498,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5578,7 +5587,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5594,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5666,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5779,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5801,7 +5810,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5824,7 +5833,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5850,18 +5859,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5907,7 +5916,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5944,7 +5953,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6003,7 +6012,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6018,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6042,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6063,11 +6072,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6118,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6133,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6141,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6200,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6210,7 +6219,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6222,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6261,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6290,7 +6299,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6298,7 +6307,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6354,7 +6363,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6366,11 +6375,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6406,7 +6415,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6418,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,11 +6448,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6462,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6485,7 +6494,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6534,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6567,9 +6576,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6593,19 +6602,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6614,11 +6623,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6777,17 +6786,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6795,7 +6804,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6807,7 +6816,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6882,8 +6891,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6891,7 +6900,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6899,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7021,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7056,37 +7065,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7094,40 +7103,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7143,7 +7152,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7155,20 +7164,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7220,7 +7229,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7232,11 +7241,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7304,7 +7313,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7596,7 +7605,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7604,7 +7613,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7705,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7704,13 +7713,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7773,7 +7782,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -615,7 +615,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -651,7 +651,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -836,6 +836,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -853,6 +858,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Il nome del container è: %s"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -984,7 +993,7 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -1007,7 +1016,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1052,11 +1061,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1111,16 +1120,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1136,12 +1145,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1184,7 +1193,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1270,7 +1279,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1287,12 +1296,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1370,7 +1379,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1414,31 +1423,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1466,7 +1475,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1474,24 +1483,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1546,7 +1555,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1554,7 +1563,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1562,12 +1571,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1580,7 +1589,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1603,12 +1612,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1623,17 +1632,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1723,7 +1732,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1766,7 +1775,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1778,7 +1787,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1812,9 +1821,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1834,7 +1843,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1922,7 +1931,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1935,7 +1944,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1955,9 +1964,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1966,9 +1975,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2023,10 +2032,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2040,27 +2049,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2073,25 +2082,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2101,25 +2110,25 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2196,7 +2205,7 @@ msgstr "Creazione del container in corso"
 msgid "Display profiles from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2217,11 +2226,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
@@ -2244,7 +2253,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2317,7 +2326,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2334,7 +2343,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2343,16 +2352,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2395,12 +2404,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2410,12 +2419,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2425,12 +2434,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2458,8 +2467,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2483,7 +2492,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2497,11 +2506,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2692,7 +2701,7 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2700,7 +2709,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2708,11 +2717,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2729,7 +2738,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2754,16 +2763,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2828,7 +2837,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2879,7 +2888,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2892,7 +2901,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2905,7 +2914,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2949,7 +2958,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2962,11 +2971,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3045,7 +3054,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3095,7 +3104,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3109,7 +3118,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3160,7 +3169,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3168,7 +3177,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3191,11 +3200,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3323,7 +3332,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -3332,7 +3341,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3351,9 +3360,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3390,7 +3399,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3400,7 +3409,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3412,8 +3421,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3465,7 +3474,7 @@ msgstr "Alias:"
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
@@ -3586,7 +3595,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 #, fuzzy
 msgid "List instance devices"
 msgstr "Creazione del container in corso"
@@ -3722,7 +3731,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3735,11 +3744,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3799,7 +3808,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4122,17 +4131,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4188,7 +4197,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4244,9 +4253,9 @@ msgstr "Il nome del container è: %s"
 msgid "Missing listen address"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4305,12 +4314,12 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4319,9 +4328,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -4330,11 +4339,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -4373,8 +4382,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4412,7 +4421,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4420,11 +4429,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4446,12 +4455,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4463,11 +4472,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4479,9 +4488,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4503,8 +4512,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4512,7 +4521,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4647,7 +4656,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4656,7 +4665,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4677,15 +4686,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4695,7 +4704,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4709,16 +4718,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4730,7 +4739,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4773,7 +4782,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4785,12 +4794,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4836,7 +4845,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
@@ -4858,16 +4867,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4959,17 +4968,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4986,7 +4995,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5000,7 +5009,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5016,7 +5025,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5037,7 +5046,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5046,7 +5055,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5059,7 +5068,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5117,7 +5126,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -5148,7 +5157,7 @@ msgstr "Creazione del container in corso"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5171,7 +5180,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5228,7 +5237,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5267,7 +5276,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Creazione del container in corso"
@@ -5314,7 +5323,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5348,7 +5357,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5356,15 +5365,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5374,7 +5383,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5402,7 +5411,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -5419,11 +5428,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -5446,7 +5455,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
@@ -5511,7 +5520,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5519,7 +5528,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5575,11 +5584,11 @@ msgstr "Il nome del container è: %s"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5588,7 +5597,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5712,11 +5721,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5752,11 +5761,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5832,7 +5841,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5845,7 +5854,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5890,7 +5899,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5987,7 +5996,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -6005,11 +6014,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6079,15 +6088,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6194,21 +6203,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6217,7 +6226,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6240,7 +6249,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6266,18 +6275,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -6324,7 +6333,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
@@ -6361,7 +6370,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 #, fuzzy
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
@@ -6421,7 +6430,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6436,12 +6445,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6460,8 +6469,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6482,11 +6491,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
@@ -6538,7 +6547,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6553,7 +6562,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6561,7 +6570,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6621,7 +6630,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6631,7 +6640,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6643,13 +6652,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6683,7 +6692,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6713,7 +6722,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -6723,7 +6732,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset all profiles on the target instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6784,7 +6793,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6797,11 +6806,11 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6840,7 +6849,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6853,7 +6862,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6874,12 +6883,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6899,12 +6908,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6922,7 +6931,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6971,7 +6980,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -7004,9 +7013,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7033,21 +7042,21 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7058,12 +7067,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -7256,19 +7265,19 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7278,7 +7287,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
@@ -7293,7 +7302,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr "Creazione del container in corso"
@@ -7385,8 +7394,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
@@ -7396,7 +7405,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
@@ -7406,7 +7415,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7554,7 +7563,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7597,44 +7606,44 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -7644,48 +7653,48 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7705,7 +7714,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr "Creazione del container in corso"
@@ -7720,23 +7729,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7801,7 +7810,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7816,12 +7825,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7889,7 +7898,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8181,7 +8190,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8189,7 +8198,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8281,7 +8290,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8289,13 +8298,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8359,7 +8368,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -606,7 +606,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -641,7 +641,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -827,6 +827,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -843,6 +848,10 @@ msgstr ""
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
 msgstr "ネットワークゾーンレコードのエントリを追加します"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -992,7 +1001,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1014,7 +1023,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1059,11 +1068,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1122,16 +1131,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1149,12 +1158,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1197,7 +1206,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1283,7 +1292,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1300,14 +1309,14 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
@@ -1386,7 +1395,7 @@ msgstr "クラスターグループ %s は現在 %s に適用されていませ�
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -1430,31 +1439,31 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1486,7 +1495,7 @@ msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない�
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
@@ -1494,24 +1503,24 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1581,7 +1590,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
@@ -1589,7 +1598,7 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1597,12 +1606,12 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1615,7 +1624,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1638,12 +1647,12 @@ msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
@@ -1658,17 +1667,17 @@ msgstr "設定の構文エラー: %s"
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
@@ -1759,7 +1768,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1799,7 +1808,7 @@ msgstr "新たにネットワークを作成します"
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
@@ -1811,7 +1820,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1844,9 +1853,9 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1866,7 +1875,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1953,7 +1962,7 @@ msgstr "ネットワークを削除します"
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
@@ -1965,7 +1974,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1985,9 +1994,9 @@ msgstr "警告を削除します"
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1996,9 +2005,9 @@ msgstr "警告を削除します"
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2053,10 +2062,10 @@ msgstr "警告を削除します"
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2070,27 +2079,27 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2102,25 +2111,25 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr "デバイス %s が %s に追加されました"
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "デバイス %s が %s で上書きされました"
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
@@ -2130,12 +2139,12 @@ msgstr "デバイス %s が %s から削除されました"
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
@@ -2143,7 +2152,7 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは変更できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
@@ -2151,7 +2160,7 @@ msgstr ""
 "プロファイルのデバイスは個々のインスタンスでは削除できません。デバイスを上書"
 "きするかプロファイルを変更してください"
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr "プロファイルのデバイスは個々のインスタンスでは取得できません"
 
@@ -2227,7 +2236,7 @@ msgstr "すべてのプロジェクトのインスタンスを表示します"
 msgid "Display profiles from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -2248,11 +2257,11 @@ msgstr "ドライバ: %v (%v)"
 msgid "ENTRIES"
 msgstr "ENTRIES"
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
@@ -2277,7 +2286,7 @@ msgstr "クラスタグループを編集します"
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -2348,7 +2357,7 @@ msgstr "ネットワークゾーンレコードをYAMLで編集します"
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
@@ -2364,7 +2373,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2373,18 +2382,18 @@ msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 #, fuzzy
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
@@ -2437,12 +2446,12 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2452,12 +2461,12 @@ msgstr "イメージの取得中: %s"
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2467,11 +2476,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2510,8 +2519,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2538,7 +2547,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2550,12 +2559,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2745,7 +2754,7 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
 
@@ -2753,7 +2762,7 @@ msgstr "特定の待避アクションを強制します"
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2761,11 +2770,11 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
@@ -2782,7 +2791,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2822,16 +2831,16 @@ msgstr ""
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2896,7 +2905,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -2950,7 +2959,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2964,7 +2973,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -2977,7 +2986,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr "デバイスの設定値を取得します"
 
@@ -3017,7 +3026,7 @@ msgstr "ネットワークゾーンレコードの設定値を取得します"
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
@@ -3029,11 +3038,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3112,7 +3121,7 @@ msgstr "ID: %s"
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -3165,7 +3174,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3181,7 +3190,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3231,7 +3240,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3242,7 +3251,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3269,11 +3278,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3404,7 +3413,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -3414,7 +3423,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -3434,9 +3443,9 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3472,7 +3481,7 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr "LIMIT"
 
@@ -3482,7 +3491,7 @@ msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3496,8 +3505,8 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -3547,7 +3556,7 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
@@ -3693,7 +3702,7 @@ msgstr ""
 "    u - アップロード日\n"
 "    t - タイプ"
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr "インスタンスのデバイスを一覧表示します"
 
@@ -3924,7 +3933,7 @@ msgstr ""
 "    u - UUID\n"
 "    t - タイプ"
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
@@ -3936,11 +3945,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -4032,7 +4041,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4356,17 +4365,17 @@ msgstr "メンバー %q はすでにロール %q を持っています"
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -4420,7 +4429,7 @@ msgstr "証明書のフィンガープリントがありません"
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4472,9 +4481,9 @@ msgstr "鍵の名前を指定する必要があります"
 msgid "Missing listen address"
 msgstr "リッスンアドレスを指定する必要があります"
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
@@ -4529,12 +4538,12 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4543,9 +4552,9 @@ msgstr "ストレージプール名を指定する必要があります"
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -4553,11 +4562,11 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4597,8 +4606,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -4648,7 +4657,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -4656,11 +4665,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -4684,12 +4693,12 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr "NAME"
 
@@ -4702,11 +4711,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr "NETWORKS"
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -4718,9 +4727,9 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr "NO"
 
@@ -4742,8 +4751,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr "名前"
 
@@ -4751,7 +4760,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4888,7 +4897,7 @@ msgstr "指定するデバイスに適用する新しいキー/値"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4898,7 +4907,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -4920,15 +4929,15 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr "%q に設定する値が指定されていません"
@@ -4938,7 +4947,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4952,17 +4961,17 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 #, fuzzy
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -4974,7 +4983,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -4987,7 +4996,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5017,7 +5026,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -5029,12 +5038,12 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr "PROFILES"
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -5079,7 +5088,7 @@ msgstr "別のサーバアドレスを指定してください（空の場合は
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
@@ -5101,16 +5110,16 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5202,17 +5211,17 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -5229,7 +5238,7 @@ msgstr "プロパティ:"
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5243,7 +5252,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5259,7 +5268,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5280,7 +5289,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5292,7 +5301,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5305,7 +5314,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5365,7 +5374,7 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
@@ -5396,7 +5405,7 @@ msgstr "インスタンスを一覧表示します"
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -5419,7 +5428,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5476,7 +5485,7 @@ msgstr "クラスタグループからメンバを削除します"
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -5513,7 +5522,7 @@ msgstr "ネットワークゾーンレコードからエントリを削除しま
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr "インスタンスのデバイスを削除します"
 
@@ -5558,7 +5567,7 @@ msgstr "信頼済みクライアントを削除します"
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -5593,7 +5602,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -5601,16 +5610,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5620,7 +5629,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
@@ -5650,7 +5659,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -5668,11 +5677,11 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -5695,7 +5704,7 @@ msgstr "イメージの取得中: %s"
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
@@ -5759,7 +5768,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -5767,7 +5776,7 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
@@ -5823,11 +5832,11 @@ msgstr "クラスターメンバーの設定を行います"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr "デバイスの設定項目を設定します"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5840,7 +5849,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5997,11 +6006,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6048,11 +6057,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6139,7 +6148,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6153,7 +6162,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6199,7 +6208,7 @@ msgstr "バックグラウンド操作の詳細を表示します"
 msgid "Show events from all projects"
 msgstr "すべてのプロジェクトのイベントを表示します"
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
@@ -6290,7 +6299,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -6306,11 +6315,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -6379,15 +6388,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6492,21 +6501,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6514,7 +6523,7 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
@@ -6537,7 +6546,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -6563,18 +6572,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6621,7 +6630,7 @@ msgstr "--target-project と --target は同時に指定できません"
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
@@ -6663,7 +6672,7 @@ msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:' を試してみてください。"
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
@@ -6722,7 +6731,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6737,12 +6746,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6763,8 +6772,8 @@ msgstr "サーバには新しい v2 resource API が実装されていません"
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -6787,11 +6796,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
@@ -6860,7 +6869,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6875,7 +6884,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6883,7 +6892,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -6945,7 +6954,7 @@ msgstr ""
 "フィカル出力の場合は 'vga'"
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -6955,7 +6964,7 @@ msgstr "タイプ: %s"
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -6967,13 +6976,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -7006,7 +7015,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -7036,7 +7045,7 @@ msgstr "未知の出力タイプ: %q"
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
@@ -7044,7 +7053,7 @@ msgstr "クラスターメンバーの設定を削除します"
 msgid "Unset all profiles on the target instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
@@ -7100,7 +7109,7 @@ msgstr "ネットワークゾーンレコードの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -7112,11 +7121,11 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -7158,7 +7167,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7172,7 +7181,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7194,11 +7203,11 @@ msgstr "サポートされていないインスタンスタイプです: %s"
 msgid "Up delay"
 msgstr "Up delay"
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7219,12 +7228,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7244,7 +7253,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -7296,7 +7305,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7331,9 +7340,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr "YES"
 
@@ -7360,21 +7369,21 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -7383,11 +7392,11 @@ msgstr "[<remote>:]"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -7552,17 +7561,17 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr "[<remote>:]<instance> <device> <key>"
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 
@@ -7570,7 +7579,7 @@ msgstr "[<remote>:]<instance> <device> <key>=<value>..."
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
@@ -7584,7 +7593,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr "[<remote>:]<instance> <name>..."
 
@@ -7663,8 +7672,8 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
@@ -7672,7 +7681,7 @@ msgstr "[<remote>:]<member>"
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
@@ -7680,7 +7689,7 @@ msgstr "[<remote>:]<member> <key>"
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -7811,7 +7820,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7846,7 +7855,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7854,32 +7863,32 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
@@ -7889,44 +7898,44 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr "[<remote>:]<profile>"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr "[<remote>:]<profile> <device> <key>"
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr "[<remote>:]<profile> <device> <key>=<value>..."
 
@@ -7943,7 +7952,7 @@ msgstr "[<remote>:]<profile> <key>"
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "[<remote>:]<profile> <key><value>..."
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr "[<remote>:]<profile> <name>..."
 
@@ -7955,20 +7964,20 @@ msgstr "[<remote>:]<profile> <new-name>"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -8021,7 +8030,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -8035,11 +8044,11 @@ msgstr "[<remote>:]<warning-uuid>"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr "現在値"
 
@@ -8122,7 +8131,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8567,7 +8576,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 #, fuzzy
 msgid ""
 "lxc project create p1\n"
@@ -8580,7 +8589,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8702,7 +8711,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8715,7 +8724,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8723,7 +8732,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 #, fuzzy
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
@@ -8793,7 +8802,7 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "yes"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -588,6 +588,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -602,6 +607,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -732,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -754,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -857,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -882,12 +891,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -930,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1015,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1032,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1113,7 +1122,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1157,31 +1166,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1209,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1217,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1288,7 +1297,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1296,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1304,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1322,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1354,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1365,17 +1374,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1457,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1506,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1509,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,9 +1551,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1564,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1657,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1660,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1680,9 +1689,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1691,9 +1700,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1748,10 +1757,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1765,27 +1774,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1797,25 +1806,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1825,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1912,7 +1921,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1933,11 +1942,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1959,7 +1968,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2027,7 +2036,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2043,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2052,16 +2061,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2104,12 +2113,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2119,12 +2128,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2134,11 +2143,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2166,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2191,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2203,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2397,7 +2406,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2405,7 +2414,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2413,11 +2422,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2433,7 +2442,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2458,16 +2467,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2531,7 +2540,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2579,7 +2588,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2591,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2603,7 +2612,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2643,7 +2652,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2655,11 +2664,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2737,7 +2746,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2787,7 +2796,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2801,7 +2810,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2851,7 +2860,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2859,7 +2868,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2881,11 +2890,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3011,7 +3020,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3019,7 +3028,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3037,9 +3046,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3075,7 +3084,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3085,7 +3094,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3097,8 +3106,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3147,7 +3156,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3262,7 +3271,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3394,7 +3403,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3406,11 +3415,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3469,7 +3478,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3770,17 +3779,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3834,7 +3843,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3882,9 +3891,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3939,12 +3948,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3953,9 +3962,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3963,11 +3972,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4004,8 +4013,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4042,7 +4051,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4050,11 +4059,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4076,12 +4085,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4093,11 +4102,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4109,9 +4118,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4133,8 +4142,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4142,7 +4151,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4277,7 +4286,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4286,7 +4295,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4306,15 +4315,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4324,7 +4333,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4337,16 +4346,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4358,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4371,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4401,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4413,12 +4422,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4463,7 +4472,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4484,16 +4493,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4583,17 +4592,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4610,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4624,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4661,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4670,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4683,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4740,7 +4749,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4769,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4792,7 +4801,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4847,7 +4856,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4883,7 +4892,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4927,7 +4936,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4960,7 +4969,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4968,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4986,7 +4995,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5013,7 +5022,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5028,11 +5037,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5054,7 +5063,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5117,7 +5126,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5125,7 +5134,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5179,11 +5188,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5192,7 +5201,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5313,11 +5322,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5352,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5429,7 +5438,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5441,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5485,7 +5494,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5574,7 +5583,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5590,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5662,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5775,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5797,7 +5806,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5820,7 +5829,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5846,18 +5855,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5903,7 +5912,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5940,7 +5949,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5999,7 +6008,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6014,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6038,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6059,11 +6068,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6114,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6129,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6137,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6196,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6206,7 +6215,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6218,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6257,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6286,7 +6295,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6294,7 +6303,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6350,7 +6359,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6362,11 +6371,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6402,7 +6411,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6414,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6435,11 +6444,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6458,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6481,7 +6490,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6530,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6563,9 +6572,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6589,19 +6598,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6610,11 +6619,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6773,17 +6782,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6791,7 +6800,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6803,7 +6812,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6878,8 +6887,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6887,7 +6896,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6895,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7017,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7052,37 +7061,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7090,40 +7099,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7139,7 +7148,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7151,20 +7160,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7216,7 +7225,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7228,11 +7237,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7300,7 +7309,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7592,7 +7601,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7600,7 +7609,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7692,7 +7701,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7700,13 +7709,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7769,7 +7778,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-01-28 15:43-0700\n"
+        "POT-Creation-Date: 2025-02-12 10:13-0800\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -358,7 +358,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -378,7 +378,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -557,6 +557,10 @@ msgstr  ""
 msgid   "Action %q isn't supported by this tool"
 msgstr  ""
 
+#: lxc/project.go:106
+msgid   "Add a NIC device to the default profile connected to the specified network"
+msgstr  ""
+
 #: lxc/cluster_group.go:725
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
@@ -571,6 +575,10 @@ msgstr  ""
 
 #: lxc/network_zone.go:1442
 msgid   "Add a network zone record entry"
+msgstr  ""
+
+#: lxc/project.go:105
+msgid   "Add a storage pool to be used as the root device in the default profile"
 msgstr  ""
 
 #: lxc/network_load_balancer.go:859
@@ -694,7 +702,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid   "All projects"
 msgstr  ""
 
@@ -716,7 +724,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -759,11 +767,11 @@ msgid   "Attach new storage volumes to instances\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr  ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid   "Attach new storage volumes to profiles\n"
         "\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
@@ -816,16 +824,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid   "Backups:"
 msgstr  ""
 
@@ -839,12 +847,12 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -887,7 +895,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -972,7 +980,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -989,11 +997,11 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
@@ -1068,7 +1076,7 @@ msgstr  ""
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
@@ -1093,23 +1101,23 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:399 lxc/storage_volume.go:623 lxc/storage_volume.go:728 lxc/storage_volume.go:1024 lxc/storage_volume.go:1250 lxc/storage_volume.go:1379 lxc/storage_volume.go:1867 lxc/storage_volume.go:1965 lxc/storage_volume.go:2104 lxc/storage_volume.go:2264 lxc/storage_volume.go:2380 lxc/storage_volume.go:2441 lxc/storage_volume.go:2568 lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:409 lxc/storage_volume.go:633 lxc/storage_volume.go:738 lxc/storage_volume.go:1040 lxc/storage_volume.go:1266 lxc/storage_volume.go:1395 lxc/storage_volume.go:1886 lxc/storage_volume.go:1984 lxc/storage_volume.go:2123 lxc/storage_volume.go:2283 lxc/storage_volume.go:2399 lxc/storage_volume.go:2460 lxc/storage_volume.go:2587 lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid   "Cluster member name (alternative to passing it as an argument)"
 msgstr  ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid   "Cluster member name was provided as both a flag and as an argument"
 msgstr  ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1136,7 +1144,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
@@ -1144,16 +1152,16 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169 lxc/storage_volume.go:1201
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185 lxc/storage_volume.go:1217
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1201,7 +1209,7 @@ msgid   "Copy instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
@@ -1209,7 +1217,7 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -1217,11 +1225,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:402
+#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:412
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1234,7 +1242,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1257,12 +1265,12 @@ msgstr  ""
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
@@ -1277,17 +1285,17 @@ msgstr  ""
 msgid   "Could not parse identity: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
@@ -1368,7 +1376,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1408,7 +1416,7 @@ msgstr  ""
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid   "Create projects"
 msgstr  ""
 
@@ -1420,7 +1428,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1448,7 +1456,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1751
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1770
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1468,7 +1476,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1552,7 +1560,7 @@ msgstr  ""
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid   "Delete projects"
 msgstr  ""
 
@@ -1564,7 +1572,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1572,16 +1580,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:286 lxc/storage_volume.go:395 lxc/storage_volume.go:616 lxc/storage_volume.go:725 lxc/storage_volume.go:812 lxc/storage_volume.go:914 lxc/storage_volume.go:1015 lxc/storage_volume.go:1236 lxc/storage_volume.go:1367 lxc/storage_volume.go:1526 lxc/storage_volume.go:1610 lxc/storage_volume.go:1863 lxc/storage_volume.go:1962 lxc/storage_volume.go:2089 lxc/storage_volume.go:2247 lxc/storage_volume.go:2368 lxc/storage_volume.go:2430 lxc/storage_volume.go:2566 lxc/storage_volume.go:2649 lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:291 lxc/storage_volume.go:405 lxc/storage_volume.go:626 lxc/storage_volume.go:735 lxc/storage_volume.go:822 lxc/storage_volume.go:927 lxc/storage_volume.go:1031 lxc/storage_volume.go:1252 lxc/storage_volume.go:1383 lxc/storage_volume.go:1545 lxc/storage_volume.go:1629 lxc/storage_volume.go:1882 lxc/storage_volume.go:1981 lxc/storage_volume.go:2108 lxc/storage_volume.go:2266 lxc/storage_volume.go:2387 lxc/storage_volume.go:2449 lxc/storage_volume.go:2585 lxc/storage_volume.go:2668 lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1593,25 +1601,25 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid   "Device %s overridden for %s"
 msgstr  ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -1621,19 +1629,19 @@ msgstr  ""
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566 lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567 lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid   "Device doesn't exist"
 msgstr  ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid   "Device from profile(s) cannot be modified for individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid   "Device from profile(s) cannot be removed from individual instance. Override device or modify profile instead"
 msgstr  ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid   "Device from profile(s) cannot be retrieved for individual instance"
 msgstr  ""
 
@@ -1703,7 +1711,7 @@ msgstr  ""
 msgid   "Display profiles from all projects"
 msgstr  ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1724,11 +1732,11 @@ msgstr  ""
 msgid   "ENTRIES"
 msgstr  ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1748,7 +1756,7 @@ msgstr  ""
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1816,7 +1824,7 @@ msgstr  ""
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
@@ -1832,7 +1840,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1840,16 +1848,16 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1888,7 +1896,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1898,7 +1906,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2174 lxc/storage_volume.go:2212
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2193 lxc/storage_volume.go:2231
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1908,11 +1916,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1938,7 +1946,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527 lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546 lxc/storage_volume.go:1596
 msgid   "Expires at"
 msgstr  ""
 
@@ -1961,7 +1969,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1973,11 +1981,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2165,7 +2173,7 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid   "Force a particular evacuation action"
 msgstr  ""
 
@@ -2173,7 +2181,7 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -2181,11 +2189,11 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid   "Force restoration without user confirmation"
 msgstr  ""
 
@@ -2201,7 +2209,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -2220,7 +2228,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2284,7 +2292,7 @@ msgstr  ""
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2332,7 +2340,7 @@ msgstr  ""
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid   "Get the key as a project property"
 msgstr  ""
 
@@ -2344,7 +2352,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2356,7 +2364,7 @@ msgstr  ""
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid   "Get values for device configuration keys"
 msgstr  ""
 
@@ -2396,7 +2404,7 @@ msgstr  ""
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
@@ -2408,11 +2416,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2490,7 +2498,7 @@ msgstr  ""
 msgid   "IDENTIFIER"
 msgstr  ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid   "IMAGES"
 msgstr  ""
 
@@ -2540,7 +2548,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2552,7 +2560,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2602,7 +2610,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2610,7 +2618,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2630,11 +2638,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2759,7 +2767,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2767,7 +2775,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2785,7 +2793,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300 lxc/storage_volume.go:1424 lxc/storage_volume.go:2010 lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316 lxc/storage_volume.go:1440 lxc/storage_volume.go:2029 lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2821,7 +2829,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid   "LIMIT"
 msgstr  ""
 
@@ -2829,7 +2837,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2841,7 +2849,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124 lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128 lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2890,7 +2898,7 @@ msgstr  ""
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
@@ -3003,7 +3011,7 @@ msgid   "List images\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid   "List instance devices"
 msgstr  ""
 
@@ -3125,7 +3133,7 @@ msgid   "List profiles\n"
         "u - Used By"
 msgstr  ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid   "List projects"
 msgstr  ""
 
@@ -3137,11 +3145,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3198,7 +3206,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3494,17 +3502,17 @@ msgstr  ""
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -3551,7 +3559,7 @@ msgstr  ""
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129 lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82 lxc/cluster_role.go:150
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129 lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82 lxc/cluster_role.go:150
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -3583,7 +3591,7 @@ msgstr  ""
 msgid   "Missing listen address"
 msgstr  ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367 lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682 lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368 lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683 lxc/config_device.go:804
 msgid   "Missing name"
 msgstr  ""
 
@@ -3607,7 +3615,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:211 lxc/storage_volume.go:328 lxc/storage_volume.go:654 lxc/storage_volume.go:761 lxc/storage_volume.go:852 lxc/storage_volume.go:954 lxc/storage_volume.go:1072 lxc/storage_volume.go:1289 lxc/storage_volume.go:1999 lxc/storage_volume.go:2140 lxc/storage_volume.go:2298 lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:211 lxc/storage_volume.go:333 lxc/storage_volume.go:664 lxc/storage_volume.go:771 lxc/storage_volume.go:862 lxc/storage_volume.go:967 lxc/storage_volume.go:1088 lxc/storage_volume.go:1305 lxc/storage_volume.go:2018 lxc/storage_volume.go:2159 lxc/storage_volume.go:2317 lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3615,7 +3623,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318 lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821 lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324 lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827 lxc/project.go:956
 msgid   "Missing project name"
 msgstr  ""
 
@@ -3623,11 +3631,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -3663,7 +3671,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876 lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889 lxc/storage_volume.go:993
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -3695,7 +3703,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3703,11 +3711,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -3728,7 +3736,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid   "NAME"
 msgstr  ""
 
@@ -3740,11 +3748,11 @@ msgstr  ""
 msgid   "NETWORK"
 msgstr  ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -3756,7 +3764,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531 lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551 lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid   "NO"
 msgstr  ""
 
@@ -3778,7 +3786,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525 lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544 lxc/storage_volume.go:1594
 msgid   "Name"
 msgstr  ""
 
@@ -3786,7 +3794,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3920,7 +3928,7 @@ msgstr  ""
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
@@ -3929,7 +3937,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -3949,15 +3957,15 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid   "No value found in %q"
 msgstr  ""
@@ -3967,7 +3975,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3979,15 +3987,15 @@ msgstr  ""
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -3999,7 +4007,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -4012,7 +4020,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4042,7 +4050,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid   "POOL"
 msgstr  ""
 
@@ -4054,11 +4062,11 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4103,7 +4111,7 @@ msgstr  ""
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
@@ -4124,7 +4132,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170 lxc/storage_volume.go:1202
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186 lxc/storage_volume.go:1218
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4214,17 +4222,17 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -4241,7 +4249,7 @@ msgstr  ""
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4252,7 +4260,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4265,7 +4273,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4281,7 +4289,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4289,7 +4297,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4300,7 +4308,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4355,7 +4363,7 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid   "RESOURCE"
 msgstr  ""
 
@@ -4384,7 +4392,7 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -4407,7 +4415,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047 lxc/remote.go:1095
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047 lxc/remote.go:1095
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -4461,7 +4469,7 @@ msgstr  ""
 msgid   "Remove a group from an identity"
 msgstr  ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -4497,7 +4505,7 @@ msgstr  ""
 msgid   "Remove identities from groups"
 msgstr  ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid   "Remove instance devices"
 msgstr  ""
 
@@ -4541,7 +4549,7 @@ msgstr  ""
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -4573,7 +4581,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid   "Rename projects"
 msgstr  ""
 
@@ -4581,15 +4589,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4599,7 +4607,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -4625,7 +4633,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -4639,11 +4647,11 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -4665,7 +4673,7 @@ msgstr  ""
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
@@ -4727,7 +4735,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -4735,7 +4743,7 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
@@ -4789,18 +4797,18 @@ msgstr  ""
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid   "Set device configuration keys"
 msgstr  ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid   "Set device configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4903,11 +4911,11 @@ msgid   "Set profile configuration keys\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4936,11 +4944,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5011,7 +5019,7 @@ msgstr  ""
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid   "Set the key as a project property"
 msgstr  ""
 
@@ -5023,7 +5031,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5067,7 +5075,7 @@ msgstr  ""
 msgid   "Show events from all projects"
 msgstr  ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid   "Show full device configuration"
 msgstr  ""
 
@@ -5152,7 +5160,7 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid   "Show project options"
 msgstr  ""
 
@@ -5168,11 +5176,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5238,15 +5246,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5351,21 +5359,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5373,7 +5381,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -5396,7 +5404,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -5422,15 +5430,15 @@ msgstr  ""
 msgid   "TLS identity %q created with fingerprint %q"
 msgstr  ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid   "Taken at"
 msgstr  ""
 
@@ -5474,7 +5482,7 @@ msgstr  ""
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid   "The device already exists"
 msgstr  ""
 
@@ -5509,7 +5517,7 @@ msgstr  ""
 msgid   "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr  ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
@@ -5568,7 +5576,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
@@ -5583,12 +5591,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -5605,7 +5613,7 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890 lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903 lxc/storage_volume.go:1007
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -5625,11 +5633,11 @@ msgstr  ""
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -5674,7 +5682,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5689,7 +5697,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5697,7 +5705,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -5753,7 +5761,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1474
+#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1490
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5763,7 +5771,7 @@ msgstr  ""
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -5775,11 +5783,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid   "USED BY"
 msgstr  ""
 
@@ -5811,7 +5819,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5840,7 +5848,7 @@ msgstr  ""
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
@@ -5848,7 +5856,7 @@ msgstr  ""
 msgid   "Unset all profiles on the target instance"
 msgstr  ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid   "Unset device configuration keys"
 msgstr  ""
 
@@ -5904,7 +5912,7 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -5916,11 +5924,11 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid   "Unset the key as a cluster property"
 msgstr  ""
 
@@ -5956,7 +5964,7 @@ msgstr  ""
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid   "Unset the key as a project property"
 msgstr  ""
 
@@ -5968,7 +5976,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -5989,11 +5997,11 @@ msgstr  ""
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
@@ -6010,12 +6018,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6032,7 +6040,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -6080,7 +6088,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6109,7 +6117,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533 lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553 lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid   "YES"
 msgstr  ""
 
@@ -6133,15 +6141,15 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6149,11 +6157,11 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -6305,15 +6313,15 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330 lxc/config_device.go:762 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid   "[<remote>:]<instance> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid   "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr  ""
 
@@ -6321,7 +6329,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
@@ -6333,7 +6341,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid   "[<remote>:]<instance> <name>..."
 msgstr  ""
 
@@ -6405,7 +6413,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769 lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773 lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
@@ -6413,7 +6421,7 @@ msgstr  ""
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
@@ -6421,7 +6429,7 @@ msgstr  ""
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -6529,7 +6537,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6561,35 +6569,35 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid   "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -6597,39 +6605,39 @@ msgstr  ""
 msgid   "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356 lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356 lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid   "[<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid   "[<remote>:]<profile> <device> <key>"
 msgstr  ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid   "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr  ""
 
@@ -6645,7 +6653,7 @@ msgstr  ""
 msgid   "[<remote>:]<profile> <key>=<value>..."
 msgstr  ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid   "[<remote>:]<profile> <name>..."
 msgstr  ""
 
@@ -6657,19 +6665,19 @@ msgstr  ""
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787 lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793 lxc/project.go:854 lxc/project.go:921
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -6721,7 +6729,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6733,11 +6741,11 @@ msgstr  ""
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid   "current"
 msgstr  ""
 
@@ -6796,7 +6804,7 @@ msgid   "lxc auth identity-provider-group edit <identity_provider_group> < ident
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -7037,14 +7045,14 @@ msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid   "lxc project create p1\n"
         "\n"
         "lxc project create p1 < config.yaml\n"
         "    Create a project with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -7119,19 +7127,19 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"
@@ -7192,7 +7200,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -598,7 +598,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -633,7 +633,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -815,6 +815,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -829,6 +834,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -959,7 +968,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -981,7 +990,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1025,11 +1034,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1084,16 +1093,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1109,12 +1118,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1157,7 +1166,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1242,7 +1251,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1259,12 +1268,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1340,7 +1349,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1384,31 +1393,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1436,7 +1445,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1444,24 +1453,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1515,7 +1524,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1523,7 +1532,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1531,12 +1540,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1549,7 +1558,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1572,12 +1581,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1592,17 +1601,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1684,7 +1693,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1724,7 +1733,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1736,7 +1745,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1769,9 +1778,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1791,7 +1800,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1875,7 +1884,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1887,7 +1896,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1907,9 +1916,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1918,9 +1927,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1975,10 +1984,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1992,27 +2001,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2024,25 +2033,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2052,24 +2061,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2139,7 +2148,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2160,11 +2169,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2186,7 +2195,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2254,7 +2263,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2270,7 +2279,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2279,16 +2288,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2331,12 +2340,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2346,12 +2355,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2361,11 +2370,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2393,8 +2402,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2418,7 +2427,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2430,11 +2439,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2624,7 +2633,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2632,7 +2641,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2640,11 +2649,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2660,7 +2669,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2685,16 +2694,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2758,7 +2767,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2806,7 +2815,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2818,7 +2827,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2830,7 +2839,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2870,7 +2879,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2882,11 +2891,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2964,7 +2973,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3014,7 +3023,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3028,7 +3037,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3086,7 +3095,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3108,11 +3117,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3238,7 +3247,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3246,7 +3255,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3264,9 +3273,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3302,7 +3311,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3312,7 +3321,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3324,8 +3333,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3374,7 +3383,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3489,7 +3498,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3621,7 +3630,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3633,11 +3642,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3696,7 +3705,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3997,17 +4006,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4061,7 +4070,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4109,9 +4118,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4166,12 +4175,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4180,9 +4189,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -4190,11 +4199,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4231,8 +4240,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4269,7 +4278,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4277,11 +4286,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4303,12 +4312,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4320,11 +4329,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4336,9 +4345,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4360,8 +4369,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4369,7 +4378,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4504,7 +4513,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4513,7 +4522,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4533,15 +4542,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4551,7 +4560,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4564,16 +4573,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4585,7 +4594,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4598,7 +4607,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4628,7 +4637,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4640,12 +4649,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4690,7 +4699,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4711,16 +4720,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4810,17 +4819,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4837,7 +4846,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4851,7 +4860,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4867,7 +4876,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4888,7 +4897,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4897,7 +4906,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4910,7 +4919,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4967,7 +4976,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4996,7 +5005,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5019,7 +5028,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5074,7 +5083,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5110,7 +5119,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -5154,7 +5163,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5187,7 +5196,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5195,15 +5204,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5213,7 +5222,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5240,7 +5249,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5255,11 +5264,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5281,7 +5290,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5344,7 +5353,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5352,7 +5361,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5406,11 +5415,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5419,7 +5428,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5540,11 +5549,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5579,11 +5588,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5656,7 +5665,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5668,7 +5677,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5712,7 +5721,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5801,7 +5810,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5817,11 +5826,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5889,15 +5898,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6002,21 +6011,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6024,7 +6033,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6047,7 +6056,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6073,18 +6082,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6130,7 +6139,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6167,7 +6176,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6226,7 +6235,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6241,12 +6250,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6265,8 +6274,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6286,11 +6295,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6341,7 +6350,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6356,7 +6365,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6364,7 +6373,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6423,7 +6432,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6433,7 +6442,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6445,13 +6454,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6484,7 +6493,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6513,7 +6522,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6521,7 +6530,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6577,7 +6586,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6589,11 +6598,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6629,7 +6638,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6641,7 +6650,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6662,11 +6671,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6685,12 +6694,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6708,7 +6717,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6757,7 +6766,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6790,9 +6799,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6816,19 +6825,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6837,11 +6846,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -7000,17 +7009,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -7018,7 +7027,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7030,7 +7039,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -7105,8 +7114,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7114,7 +7123,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -7122,7 +7131,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7244,7 +7253,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7279,37 +7288,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7317,40 +7326,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7366,7 +7375,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7378,20 +7387,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7443,7 +7452,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7455,11 +7464,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7527,7 +7536,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7819,7 +7828,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7827,7 +7836,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7919,7 +7928,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7927,13 +7936,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7996,7 +8005,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -632,7 +632,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -671,7 +671,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -853,6 +853,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -867,6 +872,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -997,7 +1006,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -1019,7 +1028,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1063,11 +1072,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1122,16 +1131,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1147,12 +1156,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1195,7 +1204,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1280,7 +1289,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1297,12 +1306,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1378,7 +1387,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1422,31 +1431,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1474,7 +1483,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1482,24 +1491,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1553,7 +1562,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1561,7 +1570,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1569,12 +1578,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1587,7 +1596,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1610,12 +1619,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1630,17 +1639,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1722,7 +1731,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1762,7 +1771,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1774,7 +1783,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1807,9 +1816,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1829,7 +1838,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1913,7 +1922,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1925,7 +1934,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1945,9 +1954,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1956,9 +1965,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2013,10 +2022,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2030,27 +2039,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2062,25 +2071,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2090,24 +2099,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2177,7 +2186,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2198,11 +2207,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2224,7 +2233,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2292,7 +2301,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2308,7 +2317,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2317,16 +2326,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2369,12 +2378,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2384,12 +2393,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2399,11 +2408,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2431,8 +2440,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2456,7 +2465,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2468,11 +2477,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2662,7 +2671,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2670,7 +2679,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2678,11 +2687,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2698,7 +2707,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2723,16 +2732,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2796,7 +2805,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2844,7 +2853,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2856,7 +2865,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2868,7 +2877,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2908,7 +2917,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2920,11 +2929,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3002,7 +3011,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3052,7 +3061,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3066,7 +3075,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3116,7 +3125,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3124,7 +3133,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3146,11 +3155,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3276,7 +3285,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3284,7 +3293,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3302,9 +3311,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3340,7 +3349,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3350,7 +3359,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3362,8 +3371,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3412,7 +3421,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3527,7 +3536,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3659,7 +3668,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3671,11 +3680,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3734,7 +3743,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4035,17 +4044,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4099,7 +4108,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4147,9 +4156,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4204,12 +4213,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4218,9 +4227,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -4228,11 +4237,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4269,8 +4278,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4307,7 +4316,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4315,11 +4324,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4341,12 +4350,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4358,11 +4367,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4374,9 +4383,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4398,8 +4407,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4407,7 +4416,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4542,7 +4551,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4551,7 +4560,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4571,15 +4580,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4589,7 +4598,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4602,16 +4611,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4623,7 +4632,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4636,7 +4645,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4666,7 +4675,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4678,12 +4687,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4728,7 +4737,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4749,16 +4758,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4848,17 +4857,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4875,7 +4884,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4889,7 +4898,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4905,7 +4914,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4926,7 +4935,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4935,7 +4944,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4948,7 +4957,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5005,7 +5014,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -5034,7 +5043,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5112,7 +5121,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5148,7 +5157,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -5192,7 +5201,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5225,7 +5234,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5233,15 +5242,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5251,7 +5260,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5278,7 +5287,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5293,11 +5302,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5319,7 +5328,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5382,7 +5391,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5390,7 +5399,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5444,11 +5453,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5457,7 +5466,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5578,11 +5587,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5617,11 +5626,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5694,7 +5703,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5706,7 +5715,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5750,7 +5759,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5839,7 +5848,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5855,11 +5864,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5927,15 +5936,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6040,21 +6049,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6062,7 +6071,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6085,7 +6094,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6111,18 +6120,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6168,7 +6177,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6205,7 +6214,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6264,7 +6273,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6279,12 +6288,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6303,8 +6312,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6324,11 +6333,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6379,7 +6388,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6394,7 +6403,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6402,7 +6411,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6461,7 +6470,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6471,7 +6480,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6483,13 +6492,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6522,7 +6531,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6551,7 +6560,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6559,7 +6568,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6615,7 +6624,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6627,11 +6636,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6667,7 +6676,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6679,7 +6688,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6700,11 +6709,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6723,12 +6732,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6746,7 +6755,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6795,7 +6804,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6828,9 +6837,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6854,19 +6863,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6875,11 +6884,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -7038,17 +7047,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -7056,7 +7065,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7068,7 +7077,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -7143,8 +7152,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7152,7 +7161,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -7160,7 +7169,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7282,7 +7291,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7317,37 +7326,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7355,40 +7364,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7404,7 +7413,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7416,20 +7425,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7481,7 +7490,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7493,11 +7502,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7565,7 +7574,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7857,7 +7866,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7865,7 +7874,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7957,7 +7966,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7965,13 +7974,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8034,7 +8043,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -588,6 +588,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -602,6 +607,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -732,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -754,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -857,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -882,12 +891,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -930,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1015,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1032,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1113,7 +1122,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1157,31 +1166,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1209,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1217,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1288,7 +1297,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1296,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1304,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1322,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1354,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1365,17 +1374,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1457,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1506,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1509,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,9 +1551,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1564,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1657,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1660,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1680,9 +1689,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1691,9 +1700,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1748,10 +1757,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1765,27 +1774,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1797,25 +1806,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1825,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1912,7 +1921,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1933,11 +1942,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1959,7 +1968,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2027,7 +2036,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2043,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2052,16 +2061,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2104,12 +2113,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2119,12 +2128,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2134,11 +2143,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2166,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2191,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2203,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2397,7 +2406,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2405,7 +2414,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2413,11 +2422,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2433,7 +2442,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2458,16 +2467,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2531,7 +2540,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2579,7 +2588,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2591,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2603,7 +2612,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2643,7 +2652,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2655,11 +2664,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2737,7 +2746,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2787,7 +2796,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2801,7 +2810,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2851,7 +2860,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2859,7 +2868,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2881,11 +2890,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3011,7 +3020,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3019,7 +3028,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3037,9 +3046,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3075,7 +3084,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3085,7 +3094,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3097,8 +3106,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3147,7 +3156,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3262,7 +3271,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3394,7 +3403,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3406,11 +3415,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3469,7 +3478,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3770,17 +3779,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3834,7 +3843,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3882,9 +3891,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3939,12 +3948,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3953,9 +3962,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3963,11 +3972,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4004,8 +4013,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4042,7 +4051,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4050,11 +4059,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4076,12 +4085,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4093,11 +4102,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4109,9 +4118,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4133,8 +4142,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4142,7 +4151,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4277,7 +4286,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4286,7 +4295,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4306,15 +4315,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4324,7 +4333,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4337,16 +4346,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4358,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4371,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4401,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4413,12 +4422,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4463,7 +4472,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4484,16 +4493,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4583,17 +4592,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4610,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4624,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4661,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4670,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4683,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4740,7 +4749,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4769,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4792,7 +4801,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4847,7 +4856,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4883,7 +4892,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4927,7 +4936,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4960,7 +4969,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4968,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4986,7 +4995,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5013,7 +5022,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5028,11 +5037,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5054,7 +5063,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5117,7 +5126,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5125,7 +5134,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5179,11 +5188,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5192,7 +5201,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5313,11 +5322,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5352,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5429,7 +5438,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5441,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5485,7 +5494,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5574,7 +5583,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5590,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5662,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5775,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5797,7 +5806,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5820,7 +5829,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5846,18 +5855,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5903,7 +5912,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5940,7 +5949,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5999,7 +6008,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6014,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6038,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6059,11 +6068,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6114,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6129,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6137,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6196,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6206,7 +6215,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6218,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6257,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6286,7 +6295,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6294,7 +6303,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6350,7 +6359,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6362,11 +6371,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6402,7 +6411,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6414,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6435,11 +6444,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6458,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6481,7 +6490,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6530,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6563,9 +6572,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6589,19 +6598,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6610,11 +6619,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6773,17 +6782,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6791,7 +6800,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6803,7 +6812,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6878,8 +6887,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6887,7 +6896,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6895,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7017,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7052,37 +7061,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7090,40 +7099,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7139,7 +7148,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7151,20 +7160,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7216,7 +7225,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7228,11 +7237,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7300,7 +7309,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7592,7 +7601,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7600,7 +7609,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7692,7 +7701,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7700,13 +7709,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7769,7 +7778,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -619,7 +619,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -655,7 +655,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -851,6 +851,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -868,6 +873,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Editar configurações de perfil como YAML"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -1002,7 +1011,7 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1026,7 +1035,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1075,11 +1084,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1136,16 +1145,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1161,12 +1170,12 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1209,7 +1218,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1296,7 +1305,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1313,12 +1322,12 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1396,7 +1405,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1440,31 +1449,31 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1500,7 +1509,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1509,24 +1518,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1582,7 +1591,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1590,7 +1599,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1598,12 +1607,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1617,7 +1626,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1640,12 +1649,12 @@ msgstr "Impossível criar diretório para certificado do servidor"
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1660,17 +1669,17 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1764,7 +1773,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1811,7 +1820,7 @@ msgstr "Criar novas redes"
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr "Criar projetos"
 
@@ -1823,7 +1832,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1857,9 +1866,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1879,7 +1888,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1976,7 +1985,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
@@ -1989,7 +1998,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2009,9 +2018,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -2020,9 +2029,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2077,10 +2086,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2094,27 +2103,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2128,26 +2137,26 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr "Dispositivo %s sobreposto em %s"
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
@@ -2157,25 +2166,25 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Device already exists: %s"
 msgstr "O dispositivo já existe: %s"
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 #, fuzzy
 msgid "Device doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2251,7 +2260,7 @@ msgstr "Criar projetos"
 msgid "Display profiles from all projects"
 msgstr "Criar projetos"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2272,11 +2281,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
@@ -2300,7 +2309,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2382,7 +2391,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2410,16 +2419,16 @@ msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2462,12 +2471,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2477,12 +2486,12 @@ msgstr "Editar propriedades da imagem"
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2492,12 +2501,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2525,8 +2534,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2550,7 +2559,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2562,11 +2571,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2756,7 +2765,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2764,7 +2773,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2772,11 +2781,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2793,7 +2802,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2818,16 +2827,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2892,7 +2901,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2946,7 +2955,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2959,7 +2968,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -2973,7 +2982,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 #, fuzzy
 msgid "Get values for device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3021,7 +3030,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3035,11 +3044,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3117,7 +3126,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3167,7 +3176,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3181,7 +3190,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3233,7 +3242,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3241,7 +3250,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3263,11 +3272,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3393,7 +3402,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -3402,7 +3411,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3420,9 +3429,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3459,7 +3468,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3469,7 +3478,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3481,8 +3490,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3533,7 +3542,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
@@ -3652,7 +3661,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3787,7 +3796,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3799,11 +3808,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3862,7 +3871,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4191,17 +4200,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4258,7 +4267,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4313,9 +4322,9 @@ msgstr "Nome de membro do cluster"
 msgid "Missing listen address"
 msgstr "Nome de membro do cluster"
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4374,12 +4383,12 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4388,9 +4397,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -4398,11 +4407,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -4441,8 +4450,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4480,7 +4489,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4488,11 +4497,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4514,12 +4523,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4531,11 +4540,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4547,9 +4556,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4571,8 +4580,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4580,7 +4589,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4715,7 +4724,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4724,7 +4733,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4744,15 +4753,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4762,7 +4771,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4775,16 +4784,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4796,7 +4805,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4809,7 +4818,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4839,7 +4848,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4851,12 +4860,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4901,7 +4910,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
@@ -4923,16 +4932,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5027,17 +5036,17 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5054,7 +5063,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5068,7 +5077,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5084,7 +5093,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5105,7 +5114,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5114,7 +5123,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5127,7 +5136,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5185,7 +5194,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -5216,7 +5225,7 @@ msgstr "Editar arquivos no container"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5239,7 +5248,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5298,7 +5307,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5339,7 +5348,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -5390,7 +5399,7 @@ msgstr "Adicionar novos clientes confiáveis"
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5424,7 +5433,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5432,15 +5441,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5450,7 +5459,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5478,7 +5487,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -5499,11 +5508,11 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -5526,7 +5535,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
@@ -5591,7 +5600,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5599,7 +5608,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5655,12 +5664,12 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 #, fuzzy
 msgid "Set device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5669,7 +5678,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5798,12 +5807,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5839,11 +5848,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5921,7 +5930,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5934,7 +5943,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -5981,7 +5990,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 #, fuzzy
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
@@ -6084,7 +6093,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -6102,11 +6111,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6178,15 +6187,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6291,21 +6300,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6314,7 +6323,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6337,7 +6346,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6363,18 +6372,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6424,7 +6433,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6461,7 +6470,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6520,7 +6529,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6535,12 +6544,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6559,8 +6568,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6581,11 +6590,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
@@ -6637,7 +6646,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6652,7 +6661,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6660,7 +6669,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6721,7 +6730,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6731,7 +6740,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6743,13 +6752,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6783,7 +6792,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6813,7 +6822,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6823,7 +6832,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Unset all profiles on the target instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 #, fuzzy
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6891,7 +6900,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6905,11 +6914,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6951,7 +6960,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6964,7 +6973,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6985,12 +6994,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7010,12 +7019,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7033,7 +7042,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7082,7 +7091,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -7115,9 +7124,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7141,21 +7150,21 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7165,12 +7174,12 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -7351,17 +7360,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -7369,7 +7378,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -7383,7 +7392,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -7462,8 +7471,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7472,7 +7481,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
@@ -7482,7 +7491,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7617,7 +7626,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7657,39 +7666,39 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr "Criar perfis"
@@ -7699,47 +7708,47 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 #, fuzzy
 msgid "[<remote>:]<profile>"
 msgstr "Criar perfis"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7756,7 +7765,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7768,21 +7777,21 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7842,7 +7851,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -7857,12 +7866,12 @@ msgstr "Criar perfis"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7930,7 +7939,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8222,7 +8231,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8230,7 +8239,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8322,7 +8331,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8330,13 +8339,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8399,7 +8408,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -627,7 +627,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -666,7 +666,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -854,6 +854,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 #, fuzzy
 msgid "Add a cluster member to a cluster group"
@@ -871,6 +876,10 @@ msgstr ""
 #, fuzzy
 msgid "Add a network zone record entry"
 msgstr "Копирование образа: %s"
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
+msgstr ""
 
 #: lxc/network_load_balancer.go:859
 msgid "Add backend to a load balancer"
@@ -1003,7 +1012,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1027,7 +1036,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1073,11 +1082,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1133,16 +1142,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1158,12 +1167,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1206,7 +1215,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1293,7 +1302,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1310,12 +1319,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1396,7 +1405,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1440,31 +1449,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1492,7 +1501,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1500,24 +1509,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1572,7 +1581,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1580,7 +1589,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1589,12 +1598,12 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1608,7 +1617,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1631,12 +1640,12 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
@@ -1651,17 +1660,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1753,7 +1762,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1800,7 +1809,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1814,7 +1823,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1848,9 +1857,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1870,7 +1879,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1975,7 +1984,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -1996,9 +2005,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -2007,9 +2016,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -2064,10 +2073,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2081,27 +2090,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2114,26 +2123,26 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -2143,24 +2152,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2238,7 +2247,7 @@ msgstr "Копирование образа: %s"
 msgid "Display profiles from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2259,11 +2268,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2285,7 +2294,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2361,7 +2370,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2378,7 +2387,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2387,16 +2396,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2439,12 +2448,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2454,12 +2463,12 @@ msgstr "Копирование образа: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2469,7 +2478,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2477,7 +2486,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2505,8 +2514,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2531,7 +2540,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2546,12 +2555,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2741,7 +2750,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2749,7 +2758,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2757,11 +2766,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2778,7 +2787,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2803,16 +2812,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2877,7 +2886,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2930,7 +2939,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2944,7 +2953,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -2958,7 +2967,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -3003,7 +3012,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3016,11 +3025,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3099,7 +3108,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -3149,7 +3158,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3163,7 +3172,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3214,7 +3223,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3222,7 +3231,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3247,11 +3256,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3380,7 +3389,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -3389,7 +3398,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3407,9 +3416,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3446,7 +3455,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3456,7 +3465,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3468,8 +3477,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3521,7 +3530,7 @@ msgstr "Псевдонимы:"
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
@@ -3642,7 +3651,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 #, fuzzy
 msgid "List instance devices"
 msgstr "Копирование образа: %s"
@@ -3779,7 +3788,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3793,12 +3802,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3858,7 +3867,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4188,17 +4197,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -4256,7 +4265,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4312,9 +4321,9 @@ msgstr "Имя контейнера: %s"
 msgid "Missing listen address"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4373,12 +4382,12 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4387,9 +4396,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -4398,12 +4407,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -4442,8 +4451,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4481,7 +4490,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -4490,11 +4499,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -4516,12 +4525,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4533,11 +4542,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4549,9 +4558,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4573,8 +4582,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4582,7 +4591,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4719,7 +4728,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4728,7 +4737,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -4749,15 +4758,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4767,7 +4776,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4781,16 +4790,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4802,7 +4811,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4815,7 +4824,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4845,7 +4854,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4857,12 +4866,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4907,7 +4916,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
@@ -4929,16 +4938,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5028,17 +5037,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -5055,7 +5064,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5069,7 +5078,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5085,7 +5094,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5106,7 +5115,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5115,7 +5124,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5128,7 +5137,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5185,7 +5194,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -5216,7 +5225,7 @@ msgstr "Псевдонимы:"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -5241,7 +5250,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5298,7 +5307,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5337,7 +5346,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 #, fuzzy
 msgid "Remove instance devices"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5384,7 +5393,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5420,7 +5429,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5428,17 +5437,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5448,7 +5457,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5476,7 +5485,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -5493,12 +5502,12 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -5521,7 +5530,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
@@ -5586,7 +5595,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5594,7 +5603,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5650,11 +5659,11 @@ msgstr "Копирование образа: %s"
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5663,7 +5672,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5789,11 +5798,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5829,11 +5838,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5911,7 +5920,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5925,7 +5934,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -5972,7 +5981,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -6071,7 +6080,7 @@ msgstr "Копирование образа: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -6089,11 +6098,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6165,16 +6174,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -6282,21 +6291,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6305,7 +6314,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6328,7 +6337,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6354,18 +6363,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6411,7 +6420,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6448,7 +6457,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6507,7 +6516,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
@@ -6522,12 +6531,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6546,8 +6555,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6568,11 +6577,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6623,7 +6632,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6638,7 +6647,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6646,7 +6655,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6706,7 +6715,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6716,7 +6725,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6728,13 +6737,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6767,7 +6776,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6797,7 +6806,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -6806,7 +6815,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6870,7 +6879,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6883,11 +6892,11 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6929,7 +6938,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6943,7 +6952,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6965,12 +6974,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6990,12 +6999,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7013,7 +7022,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -7062,7 +7071,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -7095,9 +7104,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7121,7 +7130,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
@@ -7129,7 +7138,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 #, fuzzy
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -7138,10 +7147,10 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7158,7 +7167,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7166,7 +7175,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -7461,8 +7470,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
@@ -7471,7 +7480,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
@@ -7479,7 +7488,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 #, fuzzy
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
@@ -7495,7 +7504,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 #, fuzzy
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
@@ -7519,7 +7528,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 #, fuzzy
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
@@ -7666,8 +7675,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7683,7 +7692,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -7699,7 +7708,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -7925,7 +7934,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7992,7 +8001,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8002,7 +8011,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8010,7 +8019,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8018,7 +8027,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8026,7 +8035,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8034,7 +8043,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8042,7 +8051,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8050,7 +8059,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
@@ -8066,7 +8075,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8074,7 +8083,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8082,7 +8091,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8090,7 +8099,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8098,7 +8107,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8106,7 +8115,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8114,7 +8123,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 #, fuzzy
 msgid "[<remote>:]<profile>"
@@ -8123,7 +8132,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
@@ -8131,7 +8140,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 #, fuzzy
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
@@ -8163,7 +8172,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 #, fuzzy
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
@@ -8187,8 +8196,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8196,7 +8205,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8204,7 +8213,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8212,7 +8221,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8316,7 +8325,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8340,7 +8349,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8348,7 +8357,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8416,7 +8425,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8708,7 +8717,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8716,7 +8725,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8808,7 +8817,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8816,13 +8825,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8885,7 +8894,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -592,6 +592,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -606,6 +611,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -736,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -758,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -802,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -861,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -886,12 +895,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -934,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1019,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1036,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1117,7 +1126,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1161,31 +1170,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1213,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1221,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1292,7 +1301,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1300,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1308,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1326,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1358,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1369,17 +1378,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1461,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1501,7 +1510,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1513,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,9 +1555,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1568,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1652,7 +1661,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1664,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1684,9 +1693,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1695,9 +1704,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1752,10 +1761,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1769,27 +1778,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1801,25 +1810,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1829,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1916,7 +1925,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1937,11 +1946,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1963,7 +1972,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2040,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2056,16 +2065,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2108,12 +2117,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2123,12 +2132,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2138,11 +2147,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2170,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2195,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2207,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2401,7 +2410,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2409,7 +2418,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2417,11 +2426,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,7 +2446,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2462,16 +2471,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2535,7 +2544,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2583,7 +2592,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2595,7 +2604,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2607,7 +2616,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2659,11 +2668,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2741,7 +2750,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2791,7 +2800,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2805,7 +2814,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2855,7 +2864,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2863,7 +2872,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2885,11 +2894,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3015,7 +3024,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3023,7 +3032,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3041,9 +3050,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3079,7 +3088,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3089,7 +3098,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,8 +3110,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3151,7 +3160,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3266,7 +3275,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3398,7 +3407,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3410,11 +3419,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3473,7 +3482,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3774,17 +3783,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3838,7 +3847,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3886,9 +3895,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3943,12 +3952,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3957,9 +3966,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3967,11 +3976,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4008,8 +4017,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4046,7 +4055,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4054,11 +4063,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4080,12 +4089,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4097,11 +4106,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4113,9 +4122,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4137,8 +4146,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4146,7 +4155,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4281,7 +4290,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4290,7 +4299,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4310,15 +4319,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4328,7 +4337,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4341,16 +4350,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4362,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4375,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4405,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4417,12 +4426,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4467,7 +4476,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4488,16 +4497,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4587,17 +4596,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4614,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4628,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4665,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4674,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4744,7 +4753,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4773,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4796,7 +4805,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4851,7 +4860,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4887,7 +4896,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4931,7 +4940,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4964,7 +4973,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4972,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4990,7 +4999,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5017,7 +5026,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5032,11 +5041,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5058,7 +5067,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5121,7 +5130,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5129,7 +5138,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5183,11 +5192,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5196,7 +5205,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5317,11 +5326,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5356,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5433,7 +5442,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5445,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5489,7 +5498,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5578,7 +5587,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5594,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5666,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5779,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5801,7 +5810,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5824,7 +5833,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5850,18 +5859,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5907,7 +5916,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5944,7 +5953,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6003,7 +6012,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6018,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6042,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6063,11 +6072,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6118,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6133,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6141,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6200,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6210,7 +6219,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6222,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6261,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6290,7 +6299,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6298,7 +6307,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6354,7 +6363,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6366,11 +6375,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6406,7 +6415,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6418,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,11 +6448,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6462,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6485,7 +6494,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6534,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6567,9 +6576,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6593,19 +6602,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6614,11 +6623,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6777,17 +6786,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6795,7 +6804,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6807,7 +6816,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6882,8 +6891,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6891,7 +6900,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6899,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7021,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7056,37 +7065,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7094,40 +7103,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7143,7 +7152,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7155,20 +7164,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7220,7 +7229,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7232,11 +7241,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7304,7 +7313,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7596,7 +7605,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7604,7 +7613,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7705,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7704,13 +7713,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7773,7 +7782,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -592,6 +592,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -606,6 +611,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -736,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -758,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -802,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -861,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -886,12 +895,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -934,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1019,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1036,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1117,7 +1126,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1161,31 +1170,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1213,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1221,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1292,7 +1301,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1300,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1308,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1326,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1358,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1369,17 +1378,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1461,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1501,7 +1510,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1513,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,9 +1555,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1568,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1652,7 +1661,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1664,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1684,9 +1693,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1695,9 +1704,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1752,10 +1761,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1769,27 +1778,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1801,25 +1810,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1829,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1916,7 +1925,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1937,11 +1946,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1963,7 +1972,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2040,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2056,16 +2065,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2108,12 +2117,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2123,12 +2132,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2138,11 +2147,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2170,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2195,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2207,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2401,7 +2410,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2409,7 +2418,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2417,11 +2426,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,7 +2446,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2462,16 +2471,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2535,7 +2544,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2583,7 +2592,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2595,7 +2604,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2607,7 +2616,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2659,11 +2668,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2741,7 +2750,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2791,7 +2800,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2805,7 +2814,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2855,7 +2864,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2863,7 +2872,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2885,11 +2894,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3015,7 +3024,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3023,7 +3032,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3041,9 +3050,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3079,7 +3088,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3089,7 +3098,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,8 +3110,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3151,7 +3160,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3266,7 +3275,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3398,7 +3407,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3410,11 +3419,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3473,7 +3482,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3774,17 +3783,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3838,7 +3847,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3886,9 +3895,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3943,12 +3952,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3957,9 +3966,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3967,11 +3976,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4008,8 +4017,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4046,7 +4055,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4054,11 +4063,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4080,12 +4089,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4097,11 +4106,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4113,9 +4122,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4137,8 +4146,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4146,7 +4155,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4281,7 +4290,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4290,7 +4299,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4310,15 +4319,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4328,7 +4337,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4341,16 +4350,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4362,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4375,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4405,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4417,12 +4426,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4467,7 +4476,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4488,16 +4497,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4587,17 +4596,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4614,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4628,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4665,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4674,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4744,7 +4753,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4773,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4796,7 +4805,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4851,7 +4860,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4887,7 +4896,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4931,7 +4940,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4964,7 +4973,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4972,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4990,7 +4999,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5017,7 +5026,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5032,11 +5041,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5058,7 +5067,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5121,7 +5130,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5129,7 +5138,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5183,11 +5192,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5196,7 +5205,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5317,11 +5326,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5356,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5433,7 +5442,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5445,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5489,7 +5498,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5578,7 +5587,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5594,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5666,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5779,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5801,7 +5810,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5824,7 +5833,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5850,18 +5859,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5907,7 +5916,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5944,7 +5953,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6003,7 +6012,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6018,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6042,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6063,11 +6072,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6118,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6133,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6141,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6200,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6210,7 +6219,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6222,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6261,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6290,7 +6299,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6298,7 +6307,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6354,7 +6363,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6366,11 +6375,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6406,7 +6415,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6418,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,11 +6448,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6462,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6485,7 +6494,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6534,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6567,9 +6576,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6593,19 +6602,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6614,11 +6623,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6777,17 +6786,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6795,7 +6804,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6807,7 +6816,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6882,8 +6891,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6891,7 +6900,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6899,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7021,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7056,37 +7065,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7094,40 +7103,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7143,7 +7152,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7155,20 +7164,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7220,7 +7229,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7232,11 +7241,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7304,7 +7313,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7596,7 +7605,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7604,7 +7613,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7705,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7704,13 +7713,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7773,7 +7782,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -385,7 +385,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -406,7 +406,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -588,6 +588,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -602,6 +607,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -732,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -754,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,11 +807,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -857,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -882,12 +891,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -930,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1015,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1032,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1113,7 +1122,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1157,31 +1166,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1209,7 +1218,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1217,24 +1226,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1288,7 +1297,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1296,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1304,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1322,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1345,12 +1354,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1365,17 +1374,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1457,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1506,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1509,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1542,9 +1551,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1564,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1657,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1660,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1680,9 +1689,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1691,9 +1700,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1748,10 +1757,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1765,27 +1774,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1797,25 +1806,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1825,24 +1834,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1912,7 +1921,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1933,11 +1942,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1959,7 +1968,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2027,7 +2036,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2043,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2052,16 +2061,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2104,12 +2113,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2119,12 +2128,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2134,11 +2143,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2166,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2191,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2203,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2397,7 +2406,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2405,7 +2414,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2413,11 +2422,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2433,7 +2442,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2458,16 +2467,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2531,7 +2540,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2579,7 +2588,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2591,7 +2600,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2603,7 +2612,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2643,7 +2652,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2655,11 +2664,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2737,7 +2746,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2787,7 +2796,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2801,7 +2810,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2851,7 +2860,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2859,7 +2868,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2881,11 +2890,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3011,7 +3020,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3019,7 +3028,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3037,9 +3046,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3075,7 +3084,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3085,7 +3094,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3097,8 +3106,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3147,7 +3156,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3262,7 +3271,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3394,7 +3403,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3406,11 +3415,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3469,7 +3478,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3770,17 +3779,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3834,7 +3843,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3882,9 +3891,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3939,12 +3948,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3953,9 +3962,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3963,11 +3972,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4004,8 +4013,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4042,7 +4051,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4050,11 +4059,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4076,12 +4085,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4093,11 +4102,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4109,9 +4118,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4133,8 +4142,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4142,7 +4151,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4277,7 +4286,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4286,7 +4295,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4306,15 +4315,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4324,7 +4333,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4337,16 +4346,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4358,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4371,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4401,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4413,12 +4422,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4463,7 +4472,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4484,16 +4493,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4583,17 +4592,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4610,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4624,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4661,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4670,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4683,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4740,7 +4749,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4769,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4792,7 +4801,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4847,7 +4856,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4883,7 +4892,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4927,7 +4936,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4960,7 +4969,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4968,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4986,7 +4995,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5013,7 +5022,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5028,11 +5037,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5054,7 +5063,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5117,7 +5126,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5125,7 +5134,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5179,11 +5188,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5192,7 +5201,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5313,11 +5322,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5352,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5429,7 +5438,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5441,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5485,7 +5494,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5574,7 +5583,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5590,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5662,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5775,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5797,7 +5806,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5820,7 +5829,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5846,18 +5855,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5903,7 +5912,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5940,7 +5949,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -5999,7 +6008,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6014,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6038,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6059,11 +6068,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6114,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6129,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6137,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6196,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6206,7 +6215,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6218,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6257,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6286,7 +6295,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6294,7 +6303,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6350,7 +6359,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6362,11 +6371,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6402,7 +6411,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6414,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6435,11 +6444,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6458,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6481,7 +6490,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6530,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6563,9 +6572,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6589,19 +6598,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6610,11 +6619,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6773,17 +6782,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6791,7 +6800,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6803,7 +6812,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6878,8 +6887,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6887,7 +6896,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6895,7 +6904,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7017,7 +7026,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7052,37 +7061,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7090,40 +7099,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7139,7 +7148,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7151,20 +7160,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7216,7 +7225,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7228,11 +7237,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7300,7 +7309,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7592,7 +7601,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7600,7 +7609,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7692,7 +7701,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7700,13 +7709,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7769,7 +7778,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -389,7 +389,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -410,7 +410,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -592,6 +592,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -606,6 +611,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -736,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -758,7 +767,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -802,11 +811,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -861,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -886,12 +895,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -934,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1019,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1036,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1117,7 +1126,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1161,31 +1170,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1213,7 +1222,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1221,24 +1230,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1292,7 +1301,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1300,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1308,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1326,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1349,12 +1358,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1369,17 +1378,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1461,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1501,7 +1510,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1513,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1546,9 +1555,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1568,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1652,7 +1661,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1664,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1684,9 +1693,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1695,9 +1704,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1752,10 +1761,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1769,27 +1778,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1801,25 +1810,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1829,24 +1838,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1916,7 +1925,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1937,11 +1946,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1963,7 +1972,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2040,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2047,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2056,16 +2065,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2108,12 +2117,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2123,12 +2132,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2138,11 +2147,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2170,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2195,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2207,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2401,7 +2410,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2409,7 +2418,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2417,11 +2426,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,7 +2446,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2462,16 +2471,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2535,7 +2544,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2583,7 +2592,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2595,7 +2604,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2607,7 +2616,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2647,7 +2656,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2659,11 +2668,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2741,7 +2750,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2791,7 +2800,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2805,7 +2814,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2855,7 +2864,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2863,7 +2872,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2885,11 +2894,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3015,7 +3024,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3023,7 +3032,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3041,9 +3050,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3079,7 +3088,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3089,7 +3098,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,8 +3110,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3151,7 +3160,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3266,7 +3275,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3398,7 +3407,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3410,11 +3419,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3473,7 +3482,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3774,17 +3783,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3838,7 +3847,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3886,9 +3895,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3943,12 +3952,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3957,9 +3966,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3967,11 +3976,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4008,8 +4017,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4046,7 +4055,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4054,11 +4063,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4080,12 +4089,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4097,11 +4106,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4113,9 +4122,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4137,8 +4146,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4146,7 +4155,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4281,7 +4290,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4290,7 +4299,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4310,15 +4319,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4328,7 +4337,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4341,16 +4350,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4362,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4375,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4405,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4417,12 +4426,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4467,7 +4476,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4488,16 +4497,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4587,17 +4596,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4614,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4628,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4665,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4674,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4744,7 +4753,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4773,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4796,7 +4805,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4851,7 +4860,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4887,7 +4896,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4931,7 +4940,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4964,7 +4973,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4972,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4990,7 +4999,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5017,7 +5026,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5032,11 +5041,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5058,7 +5067,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5121,7 +5130,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5129,7 +5138,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5183,11 +5192,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5196,7 +5205,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5317,11 +5326,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5356,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5433,7 +5442,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5445,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5489,7 +5498,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5578,7 +5587,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5594,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5666,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5779,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5801,7 +5810,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5824,7 +5833,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5850,18 +5859,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5907,7 +5916,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5944,7 +5953,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6003,7 +6012,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6018,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6042,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6063,11 +6072,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6118,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6133,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6141,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6200,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6210,7 +6219,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6222,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6261,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6290,7 +6299,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6298,7 +6307,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6354,7 +6363,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6366,11 +6375,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6406,7 +6415,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6418,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,11 +6448,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6462,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6485,7 +6494,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6534,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6567,9 +6576,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6593,19 +6602,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6614,11 +6623,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6777,17 +6786,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6795,7 +6804,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6807,7 +6816,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6882,8 +6891,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6891,7 +6900,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6899,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7021,7 +7030,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7056,37 +7065,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7094,40 +7103,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7143,7 +7152,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7155,20 +7164,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7220,7 +7229,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7232,11 +7241,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7304,7 +7313,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7596,7 +7605,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7604,7 +7613,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7696,7 +7705,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7704,13 +7713,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7773,7 +7782,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -531,7 +531,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -570,7 +570,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -752,6 +752,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -766,6 +771,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -896,7 +905,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -918,7 +927,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -962,11 +971,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1021,16 +1030,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -1046,12 +1055,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1094,7 +1103,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1179,7 +1188,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1196,12 +1205,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1277,7 +1286,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1321,31 +1330,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1373,7 +1382,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1381,24 +1390,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1452,7 +1461,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1468,12 +1477,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1486,7 +1495,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1509,12 +1518,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1529,17 +1538,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1621,7 +1630,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1661,7 +1670,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1673,7 +1682,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1706,9 +1715,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1728,7 +1737,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1812,7 +1821,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1824,7 +1833,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1844,9 +1853,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1855,9 +1864,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1912,10 +1921,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1929,27 +1938,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1961,25 +1970,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1989,24 +1998,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -2076,7 +2085,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2097,11 +2106,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2123,7 +2132,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2191,7 +2200,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2207,7 +2216,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2216,16 +2225,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2268,12 +2277,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2283,12 +2292,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2298,11 +2307,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2330,8 +2339,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2355,7 +2364,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2367,11 +2376,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2561,7 +2570,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2569,7 +2578,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2577,11 +2586,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2597,7 +2606,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2622,16 +2631,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2695,7 +2704,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2743,7 +2752,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2755,7 +2764,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2767,7 +2776,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2807,7 +2816,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2819,11 +2828,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2901,7 +2910,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2951,7 +2960,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2965,7 +2974,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3015,7 +3024,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3023,7 +3032,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3045,11 +3054,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3175,7 +3184,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3183,7 +3192,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3201,9 +3210,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3239,7 +3248,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3249,7 +3258,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3261,8 +3270,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3311,7 +3320,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3426,7 +3435,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3558,7 +3567,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3570,11 +3579,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3633,7 +3642,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3934,17 +3943,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3998,7 +4007,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4046,9 +4055,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -4103,12 +4112,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -4117,9 +4126,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -4127,11 +4136,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4168,8 +4177,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4206,7 +4215,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4214,11 +4223,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4240,12 +4249,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4257,11 +4266,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4273,9 +4282,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4297,8 +4306,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4306,7 +4315,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4441,7 +4450,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4450,7 +4459,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4470,15 +4479,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4488,7 +4497,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4501,16 +4510,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4522,7 +4531,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4535,7 +4544,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4565,7 +4574,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4577,12 +4586,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4627,7 +4636,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4648,16 +4657,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4747,17 +4756,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4774,7 +4783,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4788,7 +4797,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4804,7 +4813,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4825,7 +4834,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4834,7 +4843,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4847,7 +4856,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4904,7 +4913,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4933,7 +4942,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4956,7 +4965,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5011,7 +5020,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -5047,7 +5056,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -5091,7 +5100,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -5124,7 +5133,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -5132,15 +5141,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5150,7 +5159,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5177,7 +5186,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5192,11 +5201,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5218,7 +5227,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5281,7 +5290,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5289,7 +5298,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5343,11 +5352,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5356,7 +5365,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5477,11 +5486,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5516,11 +5525,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5593,7 +5602,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5605,7 +5614,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5649,7 +5658,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5738,7 +5747,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5754,11 +5763,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5826,15 +5835,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5939,21 +5948,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5961,7 +5970,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5984,7 +5993,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -6010,18 +6019,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -6067,7 +6076,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -6104,7 +6113,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6163,7 +6172,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6178,12 +6187,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6202,8 +6211,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6223,11 +6232,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6278,7 +6287,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6293,7 +6302,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6301,7 +6310,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6360,7 +6369,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6370,7 +6379,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6382,13 +6391,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6421,7 +6430,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6450,7 +6459,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6458,7 +6467,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6514,7 +6523,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6526,11 +6535,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6566,7 +6575,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6578,7 +6587,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6599,11 +6608,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6622,12 +6631,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6645,7 +6654,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6694,7 +6703,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6727,9 +6736,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6753,19 +6762,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6774,11 +6783,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6937,17 +6946,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6955,7 +6964,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6967,7 +6976,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -7042,8 +7051,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7051,7 +7060,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -7059,7 +7068,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7181,7 +7190,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7216,37 +7225,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7254,40 +7263,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7315,20 +7324,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7380,7 +7389,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7392,11 +7401,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7464,7 +7473,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7756,7 +7765,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7764,7 +7773,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7856,7 +7865,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7864,13 +7873,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7933,7 +7942,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-28 15:43-0700\n"
+"POT-Creation-Date: 2025-02-12 10:13-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1043
+#: lxc/storage_volume.go:1059
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:288
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:791
+#: lxc/cluster.go:795
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -591,6 +591,11 @@ msgstr ""
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 
+#: lxc/project.go:106
+msgid ""
+"Add a NIC device to the default profile connected to the specified network"
+msgstr ""
+
 #: lxc/cluster_group.go:725
 msgid "Add a cluster member to a cluster group"
 msgstr ""
@@ -605,6 +610,10 @@ msgstr ""
 
 #: lxc/network_zone.go:1442
 msgid "Add a network zone record entry"
+msgstr ""
+
+#: lxc/project.go:105
+msgid "Add a storage pool to be used as the root device in the default profile"
 msgstr ""
 
 #: lxc/network_load_balancer.go:859
@@ -735,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1628
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +766,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1372
+#: lxc/cluster.go:1376
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -801,11 +810,11 @@ msgid ""
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:285
+#: lxc/storage_volume.go:290
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:286
+#: lxc/storage_volume.go:291
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -860,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2721
+#: lxc/storage_volume.go:2740
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2798
+#: lxc/export.go:192 lxc/storage_volume.go:2817
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1540
+#: lxc/info.go:666 lxc/storage_volume.go:1559
 msgid "Backups:"
 msgstr ""
 
@@ -885,12 +894,12 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -933,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1752
+#: lxc/storage_volume.go:1771
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1018,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1035,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:497
+#: lxc/storage_volume.go:507
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:451
+#: lxc/storage_volume.go:461
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1116,7 +1125,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1155
+#: lxc/cluster.go:1159
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1160,31 +1169,31 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
-#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
-#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
-#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
-#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
-#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
-#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
-#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
+#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
+#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
+#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
+#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
+#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
+#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
+#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:895
+#: lxc/cluster.go:899
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:927
+#: lxc/cluster.go:931
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:757
+#: lxc/cluster.go:761
 msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1608 lxc/warning.go:93
+#: lxc/storage_volume.go:1627 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1212,7 +1221,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:104
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1220,24 +1229,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
-#: lxc/storage_volume.go:1201
+#: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
+#: lxc/storage_volume.go:1217
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:634
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1480
+#: lxc/storage_volume.go:1496
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1291,7 +1300,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/config_device.go:408 lxc/config_device.go:409
+#: lxc/config_device.go:409 lxc/config_device.go:410
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
@@ -1299,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1307,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:401
+#: lxc/storage_volume.go:411
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:412
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1325,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:529
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1348,12 +1357,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1236
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1240
+#: lxc/cluster.go:1244
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1368,17 +1377,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1245
+#: lxc/cluster.go:1249
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1250
+#: lxc/cluster.go:1254
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1267
+#: lxc/cluster.go:1271
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1460,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1500,7 +1509,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:96 lxc/project.go:97
 msgid "Create projects"
 msgstr ""
 
@@ -1512,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1545,9 +1554,9 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
-#: lxc/profile.go:750 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1751
+#: lxc/storage_volume.go:1770
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1567,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2655
+#: lxc/storage_volume.go:2674
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1651,7 +1660,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:196 lxc/project.go:197
 msgid "Delete projects"
 msgstr ""
 
@@ -1663,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
+#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1683,9 +1692,9 @@ msgstr ""
 #: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
-#: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
-#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
+#: lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681
+#: lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092
+#: lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
@@ -1694,9 +1703,9 @@ msgstr ""
 #: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
 #: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
 #: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
-#: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
-#: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
-#: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
+#: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
+#: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
+#: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:56 lxc/config_metadata.go:189
 #: lxc/config_template.go:28 lxc/config_template.go:68
 #: lxc/config_template.go:119 lxc/config_template.go:173
@@ -1751,10 +1760,10 @@ msgstr ""
 #: lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276
 #: lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634
 #: lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015
-#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97
+#: lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478
+#: lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795
+#: lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -1768,27 +1777,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
-#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
-#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
-#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
-#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
-#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
-#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
-#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
-#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
-#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
+#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1483
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
+#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1800,25 +1809,25 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
+#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
-#: lxc/config_device.go:206
+#: lxc/config_device.go:207
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config_device.go:487
+#: lxc/config_device.go:488
 #, c-format
 msgid "Device %s overridden for %s"
 msgstr ""
 
-#: lxc/config_device.go:608
+#: lxc/config_device.go:609
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -1828,24 +1837,24 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/config_device.go:288 lxc/config_device.go:302 lxc/config_device.go:566
-#: lxc/config_device.go:587 lxc/config_device.go:701 lxc/config_device.go:724
+#: lxc/config_device.go:289 lxc/config_device.go:303 lxc/config_device.go:567
+#: lxc/config_device.go:588 lxc/config_device.go:702 lxc/config_device.go:725
 msgid "Device doesn't exist"
 msgstr ""
 
-#: lxc/config_device.go:727
+#: lxc/config_device.go:728
 msgid ""
 "Device from profile(s) cannot be modified for individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:590
+#: lxc/config_device.go:591
 msgid ""
 "Device from profile(s) cannot be removed from individual instance. Override "
 "device or modify profile instead"
 msgstr ""
 
-#: lxc/config_device.go:305
+#: lxc/config_device.go:306
 msgid "Device from profile(s) cannot be retrieved for individual instance"
 msgstr ""
 
@@ -1915,7 +1924,7 @@ msgstr ""
 msgid "Display profiles from all projects"
 msgstr ""
 
-#: lxc/cluster.go:591
+#: lxc/cluster.go:595
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1936,11 +1945,11 @@ msgstr ""
 msgid "ENTRIES"
 msgstr ""
 
-#: lxc/list.go:874
+#: lxc/list.go:875
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1072 lxc/config_trust.go:516
+#: lxc/cluster.go:1076 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1962,7 +1971,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:770 lxc/cluster.go:771
+#: lxc/cluster.go:774 lxc/cluster.go:775
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2030,7 +2039,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:267 lxc/project.go:268
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2046,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2055,16 +2064,16 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1785 lxc/warning.go:236
+#: lxc/storage_volume.go:1804 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:676
+#: lxc/cluster.go:680
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:677
+#: lxc/cluster.go:681
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2107,12 +2116,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
+#: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2122,12 +2131,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
-#: lxc/profile.go:1076 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
-#: lxc/storage_volume.go:2212
+#: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
+#: lxc/storage_volume.go:2231
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2137,11 +2146,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1299 lxc/cluster.go:1300
+#: lxc/cluster.go:1303 lxc/cluster.go:1304
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1397
+#: lxc/cluster.go:1401
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2169,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
-#: lxc/storage_volume.go:1577
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
+#: lxc/storage_volume.go:1596
 msgid "Expires at"
 msgstr ""
 
@@ -2194,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2206,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2652
+#: lxc/storage_volume.go:2671
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2781
+#: lxc/export.go:152 lxc/storage_volume.go:2800
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2400,7 +2409,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1303
+#: lxc/cluster.go:1307
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2408,7 +2417,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1306
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2416,11 +2425,11 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:590
+#: lxc/cluster.go:594
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1332
+#: lxc/cluster.go:1336
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2436,7 +2445,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:606
+#: lxc/cluster.go:610
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2461,16 +2470,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
-#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
+#: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/storage_volume.go:1646 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2534,7 +2543,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:922 lxc/project.go:923
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2582,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:408
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2594,7 +2603,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1251
+#: lxc/storage_volume.go:1267
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2606,7 +2615,7 @@ msgstr ""
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:228 lxc/config_device.go:229
+#: lxc/config_device.go:229 lxc/config_device.go:230
 msgid "Get values for device configuration keys"
 msgstr ""
 
@@ -2646,7 +2655,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:403 lxc/project.go:404
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2658,11 +2667,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:480
+#: lxc/storage_volume.go:490
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2740,7 +2749,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:574
 msgid "IMAGES"
 msgstr ""
 
@@ -2790,7 +2799,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2804,7 +2813,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2439
+#: lxc/storage_volume.go:2458
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2854,7 +2863,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2834
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2862,7 +2871,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2833
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2884,11 +2893,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2822
+#: lxc/storage_volume.go:2841
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2896
+#: lxc/storage_volume.go:2915
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3014,7 +3023,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2025
+#: lxc/move.go:153 lxc/storage_volume.go:2044
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3022,7 +3031,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2021
+#: lxc/storage_volume.go:2040
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3040,9 +3049,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
-#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
-#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
+#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
+#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
+#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3078,7 +3087,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1000
 msgid "LIMIT"
 msgstr ""
 
@@ -3088,7 +3097,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3100,8 +3109,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
-#: lxc/cluster.go:1232 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1025 lxc/cluster.go:1128
+#: lxc/cluster.go:1236 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3159,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:977 lxc/cluster.go:978
+#: lxc/cluster.go:981 lxc/cluster.go:982
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3265,7 +3274,7 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/config_device.go:325 lxc/config_device.go:326
+#: lxc/config_device.go:326 lxc/config_device.go:327
 msgid "List instance devices"
 msgstr ""
 
@@ -3397,7 +3406,7 @@ msgid ""
 "u - Used By"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:477 lxc/project.go:478
 msgid "List projects"
 msgstr ""
 
@@ -3409,11 +3418,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1605
+#: lxc/storage_volume.go:1624
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1629
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3472,7 +3481,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1483
+#: lxc/info.go:489 lxc/storage_volume.go:1499
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3773,17 +3782,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:958
+#: lxc/cluster.go:962
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:661
+#: lxc/cluster.go:665
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:566
+#: lxc/cluster.go:570
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3837,7 +3846,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
+#: lxc/cluster.go:816 lxc/cluster.go:1372 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3885,9 +3894,9 @@ msgstr ""
 msgid "Missing listen address"
 msgstr ""
 
-#: lxc/config_device.go:140 lxc/config_device.go:273 lxc/config_device.go:367
-#: lxc/config_device.go:441 lxc/config_device.go:553 lxc/config_device.go:682
-#: lxc/config_device.go:803
+#: lxc/config_device.go:141 lxc/config_device.go:274 lxc/config_device.go:368
+#: lxc/config_device.go:442 lxc/config_device.go:554 lxc/config_device.go:683
+#: lxc/config_device.go:804
 msgid "Missing name"
 msgstr ""
 
@@ -3942,12 +3951,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
-#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
-#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
-#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
-#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
-#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
+#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
+#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
+#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
+#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
+#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
+#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
 msgid "Missing pool name"
 msgstr ""
 
@@ -3956,9 +3965,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:409 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:409 lxc/project.go:152 lxc/project.go:234 lxc/project.go:324
+#: lxc/project.go:441 lxc/project.go:630 lxc/project.go:699 lxc/project.go:827
+#: lxc/project.go:956
 msgid "Missing project name"
 msgstr ""
 
@@ -3966,11 +3975,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1413
+#: lxc/storage_volume.go:1429
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4007,8 +4016,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
-#: lxc/storage_volume.go:977
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
+#: lxc/storage_volume.go:993
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4045,7 +4054,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
+#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4053,11 +4062,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1869
+#: lxc/storage_volume.go:1888
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:523
+#: lxc/storage_volume.go:533
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4079,12 +4088,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
-#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:567
+#: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
 msgid "NAME"
 msgstr ""
 
@@ -4096,11 +4105,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:579
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:578
 msgid "NETWORKS"
 msgstr ""
 
@@ -4112,9 +4121,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:531
+#: lxc/project.go:536 lxc/project.go:541 lxc/project.go:546 lxc/project.go:551
+#: lxc/project.go:556 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4136,8 +4145,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
+#: lxc/storage_volume.go:1594
 msgid "Name"
 msgstr ""
 
@@ -4145,7 +4154,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4280,7 +4289,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1162
+#: lxc/cluster.go:1166
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4289,7 +4298,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
+#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4309,15 +4318,15 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
+#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
+#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
 msgid "No storage pool for target volume specified"
 msgstr ""
 
-#: lxc/config_device.go:151 lxc/config_device.go:465
+#: lxc/config_device.go:152 lxc/config_device.go:466
 #, c-format
 msgid "No value found in %q"
 msgstr ""
@@ -4327,7 +4336,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2037
+#: lxc/storage_volume.go:2056
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4340,16 +4349,16 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:348
+#: lxc/storage_volume.go:353
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:2703
+#: lxc/storage_volume.go:2722
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2502
+#: lxc/storage_volume.go:2521
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4361,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1431
+#: lxc/storage_volume.go:1447
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4374,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1579
+#: lxc/info.go:705 lxc/storage_volume.go:1598
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4404,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1769
+#: lxc/storage_volume.go:1788
 msgid "POOL"
 msgstr ""
 
@@ -4416,12 +4425,12 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:575
 msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1775 lxc/warning.go:213
+#: lxc/storage_volume.go:1794 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4466,7 +4475,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:932
+#: lxc/cluster.go:936
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4487,16 +4496,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
-#: lxc/storage_volume.go:1202
+#: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
+#: lxc/storage_volume.go:1218
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4586,17 +4595,17 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:180
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:244
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:645
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -4613,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1369
+#: lxc/storage_volume.go:1385
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4627,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1254
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4643,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2249
+#: lxc/storage_volume.go:2268
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4664,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1017
+#: lxc/storage_volume.go:1033
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4673,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2113
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4686,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2370
+#: lxc/storage_volume.go:2389
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4743,7 +4752,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:999
 msgid "RESOURCE"
 msgstr ""
 
@@ -4772,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:413
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4795,7 +4804,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:890 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4850,7 +4859,7 @@ msgstr ""
 msgid "Remove a group from an identity"
 msgstr ""
 
-#: lxc/cluster.go:585 lxc/cluster.go:586
+#: lxc/cluster.go:589 lxc/cluster.go:590
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4886,7 +4895,7 @@ msgstr ""
 msgid "Remove identities from groups"
 msgstr ""
 
-#: lxc/config_device.go:510 lxc/config_device.go:511
+#: lxc/config_device.go:511 lxc/config_device.go:512
 msgid "Remove instance devices"
 msgstr ""
 
@@ -4930,7 +4939,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:527 lxc/cluster.go:528
+#: lxc/cluster.go:531 lxc/cluster.go:532
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4963,7 +4972,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:597 lxc/project.go:598
 msgid "Rename projects"
 msgstr ""
 
@@ -4971,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:1981
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:1980
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
+#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +4998,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:893 lxc/cluster.go:894
+#: lxc/cluster.go:897 lxc/cluster.go:898
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -5016,7 +5025,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1329 lxc/cluster.go:1330
+#: lxc/cluster.go:1333 lxc/cluster.go:1334
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5031,11 +5040,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1395
+#: lxc/cluster.go:1399
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5057,7 +5066,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1087
+#: lxc/cluster.go:1091
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5120,7 +5129,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:577
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5128,7 +5137,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:576
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5182,11 +5191,11 @@ msgstr ""
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
-#: lxc/config_device.go:624
+#: lxc/config_device.go:625
 msgid "Set device configuration keys"
 msgstr ""
 
-#: lxc/config_device.go:627
+#: lxc/config_device.go:628
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5195,7 +5204,7 @@ msgid ""
 "    lxc config device set [<remote>:]<instance> <device> <key> <value>"
 msgstr ""
 
-#: lxc/config_device.go:634
+#: lxc/config_device.go:635
 msgid ""
 "Set device configuration keys\n"
 "\n"
@@ -5316,11 +5325,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:662
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:663
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5355,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2088
+#: lxc/storage_volume.go:2107
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2108
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5432,7 +5441,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:670
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5444,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2105
+#: lxc/storage_volume.go:2124
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5488,7 +5497,7 @@ msgstr ""
 msgid "Show events from all projects"
 msgstr ""
 
-#: lxc/config_device.go:766 lxc/config_device.go:767
+#: lxc/config_device.go:767 lxc/config_device.go:768
 msgid "Show full device configuration"
 msgstr ""
 
@@ -5577,7 +5586,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:794 lxc/project.go:795
 msgid "Show project options"
 msgstr ""
 
@@ -5593,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5665,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2192
+#: lxc/storage_volume.go:2211
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1504
+#: lxc/info.go:619 lxc/storage_volume.go:1523
 msgid "Snapshots:"
 msgstr ""
 
@@ -5778,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:707
+#: lxc/storage_volume.go:717
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:795
+#: lxc/storage_volume.go:805
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:530
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:524
+#: lxc/storage_volume.go:534
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5800,7 +5809,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1272
+#: lxc/cluster.go:1276
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5823,7 +5832,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:855 lxc/project.go:856
 msgid "Switch the current project"
 msgstr ""
 
@@ -5849,18 +5858,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:515
+#: lxc/cluster.go:1075 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1749 lxc/warning.go:216
+#: lxc/storage_volume.go:1768 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
 msgid "Taken at"
 msgstr ""
 
@@ -5906,7 +5915,7 @@ msgstr ""
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
-#: lxc/config_device.go:172 lxc/config_device.go:189 lxc/config_device.go:453
+#: lxc/config_device.go:173 lxc/config_device.go:190 lxc/config_device.go:454
 msgid "The device already exists"
 msgstr ""
 
@@ -5943,7 +5952,7 @@ msgstr ""
 msgid "The local image '%q' couldn't be found, trying '%q:' instead."
 msgstr ""
 
-#: lxc/config_device.go:458
+#: lxc/config_device.go:459
 msgid "The profile device doesn't exist"
 msgstr ""
 
@@ -6002,7 +6011,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:454
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6017,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1342
+#: lxc/storage_volume.go:1358
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1319
+#: lxc/storage_volume.go:1335
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6041,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
-#: lxc/storage_volume.go:991
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
+#: lxc/storage_volume.go:1007
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6062,11 +6071,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:740
+#: lxc/cluster.go:744
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:730
+#: lxc/cluster.go:734
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6117,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1489
+#: lxc/storage_volume.go:1508
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6132,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1885
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6140,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:408
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6199,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1490
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6209,7 +6218,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:971
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6221,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1754
+#: lxc/project.go:1001 lxc/storage_volume.go:1773
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1753
+#: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
+#: lxc/storage.go:724 lxc/storage_volume.go:1772
 msgid "USED BY"
 msgstr ""
 
@@ -6260,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1791 lxc/warning.go:242
+#: lxc/storage_volume.go:1810 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6289,7 +6298,7 @@ msgstr ""
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
-#: lxc/cluster.go:483
+#: lxc/cluster.go:487
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -6297,7 +6306,7 @@ msgstr ""
 msgid "Unset all profiles on the target instance"
 msgstr ""
 
-#: lxc/config_device.go:851 lxc/config_device.go:852
+#: lxc/config_device.go:852 lxc/config_device.go:853
 msgid "Unset device configuration keys"
 msgstr ""
 
@@ -6353,7 +6362,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:750 lxc/project.go:751
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6365,11 +6374,11 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
-#: lxc/cluster.go:486
+#: lxc/cluster.go:490
 msgid "Unset the key as a cluster property"
 msgstr ""
 
@@ -6405,7 +6414,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:755
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6417,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2381
+#: lxc/storage_volume.go:2400
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6438,11 +6447,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1175
+#: lxc/cluster.go:1179
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1177
+#: lxc/cluster.go:1181
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6461,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1504
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2654
+#: lxc/export.go:42 lxc/storage_volume.go:2673
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6484,7 +6493,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:625 lxc/delete.go:53
+#: lxc/cluster.go:629 lxc/delete.go:53
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6533,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1578
+#: lxc/storage_volume.go:1597
 msgid "Volume Only"
 msgstr ""
 
@@ -6566,9 +6575,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:533
+#: lxc/project.go:538 lxc/project.go:543 lxc/project.go:548 lxc/project.go:553
+#: lxc/project.go:558 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6592,19 +6601,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:912
+#: lxc/storage_volume.go:925
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:284
+#: lxc/storage_volume.go:289
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
-#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -6613,11 +6622,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1173
+#: lxc/cluster.go:1177
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:675 lxc/config_trust.go:578
+#: lxc/cluster.go:679 lxc/config_trust.go:578
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6776,17 +6785,17 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
-#: lxc/config_device.go:761 lxc/config_metadata.go:54
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
-#: lxc/config_device.go:223 lxc/config_device.go:846
+#: lxc/config_device.go:224 lxc/config_device.go:847
 msgid "[<remote>:]<instance> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:626
+#: lxc/config_device.go:627
 msgid "[<remote>:]<instance> <device> <key>=<value>..."
 msgstr ""
 
@@ -6794,7 +6803,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/config_device.go:407
+#: lxc/config_device.go:408
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
@@ -6806,7 +6815,7 @@ msgstr ""
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:504
+#: lxc/config_device.go:505
 msgid "[<remote>:]<instance> <name>..."
 msgstr ""
 
@@ -6881,8 +6890,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
-#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:587 lxc/cluster.go:773
+#: lxc/cluster.go:1090 lxc/cluster.go:1302 lxc/cluster.go:1332
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6890,7 +6899,7 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:329 lxc/cluster.go:482
+#: lxc/cluster.go:329 lxc/cluster.go:486
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
@@ -6898,7 +6907,7 @@ msgstr ""
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:525
+#: lxc/cluster.go:529
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -7020,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2832
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7055,37 +7064,37 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1979
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2583
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2666
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2447
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:624
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:722
+#: lxc/storage_volume.go:732
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:810
+#: lxc/storage_volume.go:820
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7093,40 +7102,40 @@ msgstr ""
 msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2385
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2106
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2264
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1250
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1860
+#: lxc/storage_volume.go:1879
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:392
+#: lxc/storage_volume.go:402
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/config_device.go:331 lxc/config_device.go:763 lxc/profile.go:356
+#: lxc/config_device.go:332 lxc/config_device.go:764 lxc/profile.go:356
 #: lxc/profile.go:437 lxc/profile.go:496 lxc/profile.go:1102
 msgid "[<remote>:]<profile>"
 msgstr ""
 
-#: lxc/config_device.go:225 lxc/config_device.go:848
+#: lxc/config_device.go:226 lxc/config_device.go:849
 msgid "[<remote>:]<profile> <device> <key>"
 msgstr ""
 
-#: lxc/config_device.go:633
+#: lxc/config_device.go:634
 msgid "[<remote>:]<profile> <device> <key>=<value>..."
 msgstr ""
 
@@ -7142,7 +7151,7 @@ msgstr ""
 msgid "[<remote>:]<profile> <key>=<value>..."
 msgstr ""
 
-#: lxc/config_device.go:506
+#: lxc/config_device.go:507
 msgid "[<remote>:]<profile> <name>..."
 msgstr ""
 
@@ -7154,20 +7163,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:95 lxc/project.go:194 lxc/project.go:266 lxc/project.go:793
+#: lxc/project.go:854 lxc/project.go:921
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:402 lxc/project.go:749
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:661
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:595
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7219,7 +7228,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1622
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7231,11 +7240,11 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:892
+#: lxc/cluster.go:896
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:563 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7303,7 +7312,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:773
+#: lxc/cluster.go:777
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7595,7 +7604,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:99
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7603,7 +7612,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:270
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7695,7 +7704,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:618
+#: lxc/storage_volume.go:628
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7703,13 +7712,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2817
+#: lxc/storage_volume.go:2836
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2432
+#: lxc/storage_volume.go:2451
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7772,7 +7781,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""

--- a/shared/api/project.go
+++ b/shared/api/project.go
@@ -14,6 +14,14 @@ type ProjectsPost struct {
 	// The name of the new project
 	// Example: foo
 	Name string `json:"name" yaml:"name"`
+
+	// Add a root disk device using the specified storage pool to the default profile
+	// Example: default
+	StoragePool string `json:"storage" yaml:"storage"`
+
+	// Add a network device connected to the specified network to the default profile
+	// Example: lxdbr0
+	Network string `json:"network" yaml:"network"`
 }
 
 // ProjectPost represents the fields required to rename a LXD project

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -438,6 +438,7 @@ var APIExtensions = []string{
 	"storage_driver_pure",
 	"cloud_init_ssh_keys",
 	"oidc_scopes",
+	"project_default_network_and_storage",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/init_dump.sh
+++ b/test/suites/init_dump.sh
@@ -97,6 +97,8 @@ projects:
     features.storage.volumes: "true"
   description: Default LXD project
   name: default
+  storage: ""
+  network: ""
 
 EOF
 

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -383,6 +383,19 @@ test_projects_profiles_default() {
   lxc delete c1
   lxc image delete "${fingerprint}"
   lxc project delete foo
+
+  # Create another project using --storage and --network flags
+  lxc project create bar --storage default --network lxdbr0
+
+  # Ensure default profile properly set up
+  lxc profile show default --project bar | grep -E -q "network: lxdbr0"
+  lxc profile show default --project bar | grep -E -q "pool: default"
+
+  # Delete project
+  lxc project delete bar
+
+  # Ensure failure when --network and features.networks=true used together
+  ! lxc project create bar --network lxdbr0 -c features.networks=true || false
 }
 
 # Use private images in a project.


### PR DESCRIPTION
This PR adds a `--storage` and `--network` flags to project create, which ensures the default profile in the new project is set up with a root device and a network. This allows for a more smooth project -> workload workflow, as users will be able to immediately use projects to launch instances.