### PR TITLE
Storage: Use zero for unbound volumes' total size on the API

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2516,13 +2516,13 @@ definitions:
     InstanceStateDisk:
         properties:
             total:
-                description: Total size in bytes. Uses -1 to convey that the instance has access to the entire pool's storage.
+                description: Total size in bytes. Uses 0 to convey that the instance has access to the entire pool's storage.
                 example: 502239232
                 format: int64
                 type: integer
                 x-go-name: Total
             usage:
-                description: Disk usage in bytes. Uses -1 to indicate that the storage driver for the instance's pool does not support retrieving the disk usage.
+                description: Disk usage in bytes. Uses 0 to indicate that the storage driver for the pool does not support retrieving disk usage.
                 example: 502239232
                 format: int64
                 type: integer
@@ -6703,13 +6703,13 @@ definitions:
         description: StorageVolumeStateUsage represents the disk usage of a volume
         properties:
             total:
-                description: Storage volume size in bytes
+                description: Storage volume size in bytes. Uses 0 to convey that the volume has access to the entire pool's storage.
                 example: 5189222192
                 format: int64
                 type: integer
                 x-go-name: Total
             used:
-                description: Used space in bytes
+                description: Used space in bytes. Uses 0 to indicate that the storage driver for the pool does not support retrieving volume usage.
                 example: 1693552640
                 format: uint64
                 type: integer

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1484,7 +1484,10 @@ func (c *cmdStorageVolumeInfo) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if volState != nil && volState.Usage != nil {
-		fmt.Printf(i18n.G("Usage: %s")+"\n", units.GetByteSizeStringIEC(int64(volState.Usage.Used), 2))
+		if volState.Usage.Used > 0 {
+			fmt.Printf(i18n.G("Usage: %s")+"\n", units.GetByteSizeStringIEC(int64(volState.Usage.Used), 2))
+		}
+
 		if volState.Usage.Total > 0 {
 			fmt.Printf(i18n.G("Total: %s")+"\n", units.GetByteSizeStringIEC(int64(volState.Usage.Total), 2))
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3290,14 +3290,6 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 		}
 	}
 
-	// If the instance volume is neither block based/typed nor bound by the device's size config key,
-	// this means it is only bound by the pool limits and has access to the entire pool storage.
-	// So instead of showing the entire pool size for each instance disk, we return -1 to signify the root disk
-	// is unbounded below the pool level.
-	if val.Total == 0 {
-		val.Total = -1
-	}
-
 	return &val, nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6248,12 +6248,15 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	// Get the usage.
-	size, err := b.driver.GetVolumeUsage(vol)
-	if err != nil {
+	usedBytes, err := b.driver.GetVolumeUsage(vol)
+	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, err
 	}
 
-	val.Used = size
+	// If retrieving usage is unsupported, Used should be 0.
+	if usedBytes > 0 {
+		val.Used = usedBytes
+	}
 
 	// Get the total size.
 	sizeStr, ok := vol.Config()["size"]

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3264,13 +3264,15 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 
 	// Get the usage
 	// If storage driver does not support getting the volume usage, proceed getting the total.
-	size, err := b.driver.GetVolumeUsage(vol)
+	usedBytes, err := b.driver.GetVolumeUsage(vol)
 	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, err
 	}
 
-	// If driver does not support getting volume usage, this value would be -1.
-	val.Used = size
+	// If driver does not support getting volume usage, this value should be 0.
+	if usedBytes > 0 {
+		val.Used = usedBytes
+	}
 
 	// Get the total size.
 	_, rootDiskConf, err := instancetype.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())

--- a/shared/api/instance_state.go
+++ b/shared/api/instance_state.go
@@ -64,11 +64,11 @@ type InstanceState struct {
 //
 // API extension: instances.
 type InstanceStateDisk struct {
-	// Disk usage in bytes. Uses -1 to indicate that the storage driver for the instance's pool does not support retrieving the disk usage.
+	// Disk usage in bytes. Uses 0 to indicate that the storage driver for the pool does not support retrieving disk usage.
 	// Example: 502239232
 	Usage int64 `json:"usage" yaml:"usage"`
 
-	// Total size in bytes. Uses -1 to convey that the instance has access to the entire pool's storage.
+	// Total size in bytes. Uses 0 to convey that the instance has access to the entire pool's storage.
 	// Example: 502239232
 	//
 	// API extension: instances_state_total

--- a/shared/api/storage_pool_volume_state.go
+++ b/shared/api/storage_pool_volume_state.go
@@ -18,7 +18,7 @@ type StorageVolumeState struct {
 type StorageVolumeStateUsage struct {
 	// Used space in bytes. Uses 0 to indicate that the storage driver for the pool does not support retrieving volume usage.
 	// Example: 1693552640
-	Used uint64 `json:"used,omitempty" yaml:"used,omitempty"`
+	Used uint64 `json:"used" yaml:"used"`
 
 	// Storage volume size in bytes. Uses 0 to convey that the volume has access to the entire pool's storage.
 	// Example: 5189222192

--- a/shared/api/storage_pool_volume_state.go
+++ b/shared/api/storage_pool_volume_state.go
@@ -16,11 +16,11 @@ type StorageVolumeState struct {
 //
 // API extension: storage_volume_state.
 type StorageVolumeStateUsage struct {
-	// Used space in bytes
+	// Used space in bytes. Uses 0 to indicate that the storage driver for the pool does not support retrieving volume usage.
 	// Example: 1693552640
 	Used uint64 `json:"used,omitempty" yaml:"used,omitempty"`
 
-	// Storage volume size in bytes
+	// Storage volume size in bytes. Uses 0 to convey that the volume has access to the entire pool's storage.
 	// Example: 5189222192
 	//
 	// API extension: storage_volume_state_total


### PR DESCRIPTION
As per discussed on https://github.com/canonical/lxd/pull/14595#issuecomment-2589868308, this implements the standard of showing the size of unbound volumes as 0.

To keep the API consistent, also updates getting custom volume state so that total is shown even when usage is not supported and shows 0 to represent unsupporte usage of both custom and instance volumes.