### PR TITLE
lxd: Factor out delete endpoint logic

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1702,11 +1702,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1863,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1967,7 +1967,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2250,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2310,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2354,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2670,7 +2670,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2695,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2765,12 +2765,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2825,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2907,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3211,7 +3211,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3821,7 +3821,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3951,7 +3951,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3993,7 +3993,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4055,7 +4055,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4698,16 +4698,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4859,7 +4859,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5074,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5155,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5441,7 +5441,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5486,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5841,11 +5841,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6278,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6577,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6681,7 +6681,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6709,27 +6709,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6749,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6837,7 +6837,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7358,7 +7358,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7371,7 +7371,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7720,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -243,7 +243,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -679,12 +679,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -783,7 +783,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -867,7 +867,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1318,7 +1318,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1735,7 +1735,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1931,7 +1931,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2024,9 +2024,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2050,11 +2050,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2221,7 +2221,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2336,7 +2336,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2626,12 +2626,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2646,12 +2646,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2681,7 +2681,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2706,12 +2706,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2750,7 +2750,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2765,7 +2765,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2853,7 +2853,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2911,7 +2911,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2933,7 +2933,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -3091,7 +3091,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3117,22 +3117,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3189,12 +3189,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3250,11 +3250,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -3264,7 +3264,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3335,12 +3335,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3358,7 +3358,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3411,7 +3411,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3477,7 +3477,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3657,7 +3657,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -4049,7 +4049,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4063,7 +4063,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4336,7 +4336,7 @@ msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4347,12 +4347,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4482,7 +4482,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4593,7 +4593,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -5009,11 +5009,11 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5141,7 +5141,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -5255,17 +5255,17 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5274,7 +5274,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5305,7 +5305,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5427,7 +5427,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5497,7 +5497,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -5665,12 +5665,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5750,7 +5750,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5777,7 +5777,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5961,7 +5961,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
@@ -5970,7 +5970,7 @@ msgstr "Setzt die gid der Datei beim Übertragen"
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
@@ -5979,7 +5979,7 @@ msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -6047,7 +6047,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6059,7 +6059,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6108,7 +6108,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6491,12 +6491,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6895,7 +6895,7 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6911,7 +6911,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6946,7 +6946,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -7290,7 +7290,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7484,7 +7484,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7498,7 +7498,7 @@ msgstr ""
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7533,7 +7533,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7541,7 +7541,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7550,7 +7550,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7558,7 +7558,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7567,7 +7567,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7576,7 +7576,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7616,7 +7616,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7798,7 +7798,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8603,7 +8603,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8689,7 +8689,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8702,7 +8702,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9055,16 +9055,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1424,7 +1424,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1436,7 +1436,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1603,7 +1603,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1691,9 +1691,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1717,11 +1717,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1987,7 +1987,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2256,12 +2256,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2276,12 +2276,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2311,7 +2311,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2326,7 +2326,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2336,12 +2336,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2395,7 +2395,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2479,7 +2479,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2537,7 +2537,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2557,7 +2557,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2709,7 +2709,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2734,22 +2734,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2804,12 +2804,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2848,7 +2848,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2864,11 +2864,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2878,7 +2878,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2946,11 +2946,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2968,7 +2968,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3020,7 +3020,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3083,7 +3083,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3252,7 +3252,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3610,7 +3610,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
@@ -3623,7 +3623,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3880,7 +3880,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
@@ -3891,12 +3891,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -4017,7 +4017,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4121,7 +4121,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4529,11 +4529,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4655,7 +4655,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4767,16 +4767,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4785,7 +4785,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4814,7 +4814,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4822,7 +4822,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4831,7 +4831,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4931,7 +4931,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4994,7 +4994,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5149,12 +5149,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5231,7 +5231,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5257,7 +5257,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5435,7 +5435,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5443,7 +5443,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5451,7 +5451,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5517,7 +5517,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5529,7 +5529,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5576,7 +5576,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5940,11 +5940,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6331,7 +6331,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6347,7 +6347,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6379,7 +6379,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6694,7 +6694,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6798,7 +6798,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6807,7 +6807,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6826,27 +6826,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6866,7 +6866,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6954,7 +6954,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7389,7 +7389,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7475,7 +7475,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7488,7 +7488,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7837,16 +7837,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -247,7 +247,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -667,12 +667,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -766,7 +766,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -843,7 +843,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1276,7 +1276,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1683,7 +1683,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1697,7 +1697,7 @@ msgstr "Creando el contenedor"
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1955,9 +1955,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1981,11 +1981,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2144,7 +2144,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2253,7 +2253,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
@@ -2526,12 +2526,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2546,12 +2546,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2581,7 +2581,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2596,7 +2596,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2606,12 +2606,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2650,7 +2650,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2665,7 +2665,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2750,7 +2750,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2808,7 +2808,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2829,7 +2829,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2981,7 +2981,7 @@ msgstr "Perfil %s creado"
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -3007,22 +3007,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3079,12 +3079,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
@@ -3123,7 +3123,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3139,11 +3139,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3153,7 +3153,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3223,11 +3223,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3247,7 +3247,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3299,7 +3299,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3364,7 +3364,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3540,7 +3540,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3904,7 +3904,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
@@ -3917,7 +3917,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4175,7 +4175,7 @@ msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
@@ -4186,12 +4186,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4318,7 +4318,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4362,7 +4362,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4425,7 +4425,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4831,11 +4831,11 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4961,7 +4961,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -5073,16 +5073,16 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5091,7 +5091,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5122,7 +5122,7 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5130,7 +5130,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -5139,7 +5139,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5241,7 +5241,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5304,7 +5304,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5465,12 +5465,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5548,7 +5548,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5574,7 +5574,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5752,7 +5752,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5768,7 +5768,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5834,7 +5834,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5846,7 +5846,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5893,7 +5893,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6259,11 +6259,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6655,7 +6655,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6671,7 +6671,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6704,7 +6704,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -7022,7 +7022,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7147,7 +7147,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7157,7 +7157,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7180,32 +7180,32 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7230,7 +7230,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7338,7 +7338,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7860,7 +7860,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7946,7 +7946,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7959,7 +7959,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8308,16 +8308,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -245,7 +245,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -676,12 +676,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -775,7 +775,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -863,7 +863,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1314,7 +1314,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1672,7 +1672,7 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1739,7 +1739,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1753,7 +1753,7 @@ msgstr "Créer tous répertoires nécessaires"
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1954,7 +1954,7 @@ msgstr "Création du conteneur"
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2050,9 +2050,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2076,11 +2076,11 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2241,7 +2241,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2357,7 +2357,7 @@ msgstr "Création du conteneur"
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
@@ -2659,12 +2659,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2679,12 +2679,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2714,7 +2714,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2729,7 +2729,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2739,12 +2739,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2784,7 +2784,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2799,7 +2799,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2888,7 +2888,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2967,7 +2967,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -3127,7 +3127,7 @@ msgstr "Profil %s créé"
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3154,22 +3154,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3227,12 +3227,12 @@ msgstr "DATE D'ÉMISSION"
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
@@ -3275,7 +3275,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3292,11 +3292,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -3306,7 +3306,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3380,12 +3380,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3405,7 +3405,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3457,7 +3457,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3523,7 +3523,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3700,7 +3700,7 @@ msgstr ""
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -4133,7 +4133,7 @@ msgstr "Création du conteneur"
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
@@ -4147,7 +4147,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4422,7 +4422,7 @@ msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4433,12 +4433,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4569,7 +4569,7 @@ msgstr "Copie de l'image : %s"
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4616,7 +4616,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4683,7 +4683,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -5114,11 +5114,11 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5246,7 +5246,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -5360,17 +5360,17 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5379,7 +5379,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5411,7 +5411,7 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -5421,7 +5421,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5431,7 +5431,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5536,7 +5536,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
@@ -5607,7 +5607,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -5791,12 +5791,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5879,7 +5879,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5906,7 +5906,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -6092,7 +6092,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
@@ -6101,7 +6101,7 @@ msgstr "Définir le gid du fichier lors de l'envoi"
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
@@ -6110,7 +6110,7 @@ msgstr "Définir les permissions du fichier lors de l'envoi"
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -6178,7 +6178,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6190,7 +6190,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6239,7 +6239,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6632,11 +6632,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -7041,7 +7041,7 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -7057,7 +7057,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7092,7 +7092,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -7437,7 +7437,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7643,7 +7643,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7660,7 +7660,7 @@ msgstr ""
 "(configuration, instantanés, …)."
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7695,7 +7695,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7703,7 +7703,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7715,7 +7715,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7723,7 +7723,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7735,7 +7735,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7747,7 +7747,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7787,7 +7787,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7999,7 +7999,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8868,7 +8868,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8954,7 +8954,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8967,7 +8967,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9339,16 +9339,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1680,9 +1680,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1706,11 +1706,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2234,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2254,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2314,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2358,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2457,7 +2457,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2515,7 +2515,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2535,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2674,7 +2674,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2699,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,12 +2769,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2911,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2933,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2985,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3215,7 +3215,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3584,7 +3584,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3825,7 +3825,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3834,11 +3834,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3955,7 +3955,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4590,7 +4590,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4702,16 +4702,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4720,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4766,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4863,7 +4863,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4924,7 +4924,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5078,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5159,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5185,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5357,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5373,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5845,11 +5845,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6282,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6581,7 +6581,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6685,7 +6685,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6694,7 +6694,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6713,27 +6713,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6753,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6841,7 +6841,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7362,7 +7362,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7375,7 +7375,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7724,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -254,7 +254,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -672,12 +672,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -768,7 +768,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -845,7 +845,7 @@ msgstr "Il nome del container è: %s"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1679,7 +1679,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1692,7 +1692,7 @@ msgstr "Creazione del container in corso"
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1863,7 +1863,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1951,9 +1951,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1977,11 +1977,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2140,7 +2140,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2252,7 +2252,7 @@ msgstr "Creazione del container in corso"
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2523,12 +2523,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2543,12 +2543,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2578,7 +2578,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2593,7 +2593,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2603,12 +2603,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2647,7 +2647,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2662,7 +2662,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2748,7 +2748,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2806,7 +2806,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2827,7 +2827,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2976,7 +2976,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3002,22 +3002,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3072,12 +3072,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
@@ -3117,7 +3117,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3133,11 +3133,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3147,7 +3147,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3217,11 +3217,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3240,7 +3240,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3292,7 +3292,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3358,7 +3358,7 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3534,7 +3534,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3902,7 +3902,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
@@ -3916,7 +3916,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4175,7 +4175,7 @@ msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
@@ -4186,12 +4186,12 @@ msgstr "Il nome del container è: %s"
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4318,7 +4318,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4361,7 +4361,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4424,7 +4424,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4833,11 +4833,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4961,7 +4961,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -5073,17 +5073,17 @@ msgstr "Creazione del container in corso"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5092,7 +5092,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5123,7 +5123,7 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5131,7 +5131,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -5140,7 +5140,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5242,7 +5242,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5306,7 +5306,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5467,12 +5467,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5550,7 +5550,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5576,7 +5576,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5752,7 +5752,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5760,7 +5760,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5768,7 +5768,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5832,7 +5832,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5844,7 +5844,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5891,7 +5891,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6261,11 +6261,11 @@ msgstr ""
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6656,7 +6656,7 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6672,7 +6672,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6706,7 +6706,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -7022,7 +7022,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7147,7 +7147,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7157,7 +7157,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7180,32 +7180,32 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7230,7 +7230,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -7338,7 +7338,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7860,7 +7860,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7946,7 +7946,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7959,7 +7959,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8309,16 +8309,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -233,7 +233,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -664,12 +664,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -758,7 +758,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -836,7 +836,7 @@ msgstr "クラスタグループからメンバを削除します"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1648,7 +1648,7 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
@@ -1712,7 +1712,7 @@ msgstr "警告を削除します"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1726,7 +1726,7 @@ msgstr "必要なディレクトリをすべて作成します"
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1896,7 +1896,7 @@ msgstr "インスタンス内のファイルを削除します"
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1981,9 +1981,9 @@ msgstr "警告を削除します"
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2007,11 +2007,11 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2174,7 +2174,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2285,7 +2285,7 @@ msgstr "インスタンス内のファイルを編集します"
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
@@ -2577,12 +2577,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2597,12 +2597,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2632,7 +2632,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2647,7 +2647,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2657,12 +2657,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2701,7 +2701,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2716,7 +2716,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2816,7 +2816,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2874,7 +2874,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2895,7 +2895,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3043,7 +3043,7 @@ msgstr "プロファイル %s を作成しました"
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3069,22 +3069,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3139,12 +3139,12 @@ msgstr "ISSUE DATE"
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
@@ -3188,7 +3188,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3204,11 +3204,11 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
@@ -3218,7 +3218,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3294,11 +3294,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3317,7 +3317,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3370,7 +3370,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3440,7 +3440,7 @@ msgstr "不正なスナップショット名"
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3612,7 +3612,7 @@ msgstr "プロファイルを一覧表示します"
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -4111,7 +4111,7 @@ msgstr "デバイスを管理します"
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
@@ -4126,7 +4126,7 @@ msgstr "信頼済みのクライアントを管理します"
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4387,7 +4387,7 @@ msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
@@ -4398,12 +4398,12 @@ msgstr "クラスターグループ名がありません"
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4521,7 +4521,7 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4568,7 +4568,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4643,7 +4643,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -5057,11 +5057,11 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5185,7 +5185,7 @@ msgstr "リモートで使用するプロジェクト"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5303,16 +5303,16 @@ msgstr "インスタンスの出力中: %s"
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5321,7 +5321,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5352,7 +5352,7 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -5360,7 +5360,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5369,7 +5369,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5468,7 +5468,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
@@ -5532,7 +5532,7 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -5696,12 +5696,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5779,7 +5779,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5813,7 +5813,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -6035,7 +6035,7 @@ msgstr "リモートの URL を設定します"
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
@@ -6044,7 +6044,7 @@ msgstr "プッシュ時にファイルのgidを設定します"
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
@@ -6053,7 +6053,7 @@ msgstr "プッシュ時にファイルのパーミションを設定します"
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -6122,7 +6122,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -6135,7 +6135,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6181,7 +6181,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6538,11 +6538,11 @@ msgstr "TYPE"
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6960,7 +6960,7 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
@@ -6976,7 +6976,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -7008,7 +7008,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7330,7 +7330,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7434,7 +7434,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7443,7 +7443,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
@@ -7464,30 +7464,30 @@ msgstr "[<remote>:]<group> <new-name>"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7508,7 +7508,7 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -7600,7 +7600,7 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -8071,7 +8071,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
@@ -8196,7 +8196,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8215,7 +8215,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8722,16 +8722,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1702,11 +1702,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1863,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1967,7 +1967,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2250,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2310,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2354,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2670,7 +2670,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2695,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2765,12 +2765,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2825,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2907,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3211,7 +3211,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3821,7 +3821,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3951,7 +3951,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3993,7 +3993,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4055,7 +4055,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4698,16 +4698,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4859,7 +4859,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5074,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5155,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5441,7 +5441,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5486,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5841,11 +5841,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6278,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6577,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6681,7 +6681,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6709,27 +6709,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6749,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6837,7 +6837,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7358,7 +7358,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7371,7 +7371,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7720,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-01-10 14:44-0600\n"
+        "POT-Creation-Date: 2025-01-24 09:30-0800\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -163,7 +163,7 @@ msgid   "### This is a YAML representation of the group.\n"
         "### - operations\n"
 msgstr  ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -398,12 +398,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -491,7 +491,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -565,7 +565,7 @@ msgstr  ""
 msgid   "Add a group to an identity"
 msgstr  ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
@@ -976,7 +976,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1267,7 +1267,7 @@ msgstr  ""
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid   "Could not parse group: %s"
 msgstr  ""
@@ -1329,7 +1329,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1341,7 +1341,7 @@ msgstr  ""
 msgid   "Create groups"
 msgstr  ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid   "Create identity provider groups"
 msgstr  ""
 
@@ -1496,7 +1496,7 @@ msgstr  ""
 msgid   "Delete groups"
 msgstr  ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid   "Delete identity provider groups"
 msgstr  ""
 
@@ -1572,7 +1572,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779 lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058 lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702 lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603 lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:286 lxc/storage_volume.go:395 lxc/storage_volume.go:616 lxc/storage_volume.go:725 lxc/storage_volume.go:812 lxc/storage_volume.go:914 lxc/storage_volume.go:1015 lxc/storage_volume.go:1236 lxc/storage_volume.go:1367 lxc/storage_volume.go:1526 lxc/storage_volume.go:1610 lxc/storage_volume.go:1863 lxc/storage_volume.go:1962 lxc/storage_volume.go:2089 lxc/storage_volume.go:2247 lxc/storage_volume.go:2368 lxc/storage_volume.go:2430 lxc/storage_volume.go:2566 lxc/storage_volume.go:2649 lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:286 lxc/storage_volume.go:395 lxc/storage_volume.go:616 lxc/storage_volume.go:725 lxc/storage_volume.go:812 lxc/storage_volume.go:914 lxc/storage_volume.go:1015 lxc/storage_volume.go:1236 lxc/storage_volume.go:1367 lxc/storage_volume.go:1526 lxc/storage_volume.go:1610 lxc/storage_volume.go:1863 lxc/storage_volume.go:1962 lxc/storage_volume.go:2089 lxc/storage_volume.go:2247 lxc/storage_volume.go:2368 lxc/storage_volume.go:2430 lxc/storage_volume.go:2566 lxc/storage_volume.go:2649 lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1654,7 +1654,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1756,7 +1756,7 @@ msgstr  ""
 msgid   "Edit groups as YAML"
 msgstr  ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
@@ -1999,12 +1999,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2019,12 +2019,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2054,7 +2054,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2069,7 +2069,7 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2079,12 +2079,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2123,7 +2123,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2138,7 +2138,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2216,7 +2216,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1627 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2264,7 +2264,7 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid   "GROUPS"
 msgstr  ""
 
@@ -2284,7 +2284,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2423,7 +2423,7 @@ msgstr  ""
 msgid   "Group %s deleted"
 msgstr  ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid   "Group %s renamed to %s"
 msgstr  ""
@@ -2448,22 +2448,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2518,12 +2518,12 @@ msgstr  ""
 msgid   "Identity creation only supported for TLS identities"
 msgstr  ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid   "Identity provider group %s created"
 msgstr  ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid   "Identity provider group %s deleted"
 msgstr  ""
@@ -2560,7 +2560,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2576,11 +2576,11 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
@@ -2590,7 +2590,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2656,11 +2656,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2678,7 +2678,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2730,7 +2730,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2790,7 +2790,7 @@ msgstr  ""
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2954,7 +2954,7 @@ msgstr  ""
 msgid   "List identities"
 msgstr  ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid   "List identity provider groups"
 msgstr  ""
 
@@ -3296,7 +3296,7 @@ msgstr  ""
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid   "Manage groups"
 msgstr  ""
 
@@ -3308,7 +3308,7 @@ msgstr  ""
 msgid   "Manage identities"
 msgstr  ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid   "Manage identity provider group mappings"
 msgstr  ""
 
@@ -3536,7 +3536,7 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420 lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420 lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid   "Missing group name"
 msgstr  ""
 
@@ -3544,11 +3544,11 @@ msgstr  ""
 msgid   "Missing identity argument"
 msgstr  ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid   "Missing identity provider group name"
 msgstr  ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
@@ -3612,7 +3612,7 @@ msgstr  ""
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3652,7 +3652,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3709,7 +3709,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid   "NAME"
 msgstr  ""
 
@@ -4101,11 +4101,11 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170 lxc/storage_volume.go:1202
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170 lxc/storage_volume.go:1202
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4218,7 +4218,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid   "Property not found"
 msgstr  ""
 
@@ -4314,16 +4314,16 @@ msgstr  ""
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4332,7 +4332,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4361,7 +4361,7 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -4369,7 +4369,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4378,7 +4378,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4474,7 +4474,7 @@ msgstr  ""
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid   "Remove identities from groups"
 msgstr  ""
 
@@ -4534,7 +4534,7 @@ msgstr  ""
 msgid   "Rename groups"
 msgstr  ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid   "Rename identity provider groups"
 msgstr  ""
 
@@ -4686,12 +4686,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4766,7 +4766,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4788,7 +4788,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4936,7 +4936,7 @@ msgstr  ""
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid   "Set the file's gid on push"
 msgstr  ""
 
@@ -4944,7 +4944,7 @@ msgstr  ""
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid   "Set the file's perms on push"
 msgstr  ""
 
@@ -4952,7 +4952,7 @@ msgstr  ""
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -5012,7 +5012,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -5024,7 +5024,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid   "Show an identity provider group"
 msgstr  ""
 
@@ -5065,7 +5065,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5415,11 +5415,11 @@ msgstr  ""
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5787,7 +5787,7 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
@@ -5802,7 +5802,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5833,7 +5833,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -6122,7 +6122,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6218,7 +6218,7 @@ msgstr  ""
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr  ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr  ""
 
@@ -6226,7 +6226,7 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
@@ -6242,27 +6242,27 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new_name>"
 msgstr  ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid   "[<remote>:]<identity_provider_group>"
 msgstr  ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid   "[<remote>:]<identity_provider_group> <group>"
 msgstr  ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6282,7 +6282,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -6366,7 +6366,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6772,7 +6772,7 @@ msgid   "lxc auth identity edit <authentication_method>/<name_or_identifier> < i
         "   Update an identity using the content of identity.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid   "lxc auth identity-provider-group edit <identity_provider_group> < identity-provider-group.yaml\n"
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
@@ -6840,7 +6840,7 @@ msgid   "lxc file create foo/bar\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
@@ -6850,7 +6850,7 @@ msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -7144,16 +7144,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -246,7 +246,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -654,12 +654,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1246,7 +1246,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1656,7 +1656,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1903,9 +1903,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1929,11 +1929,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2090,7 +2090,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2194,7 +2194,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2457,12 +2457,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2477,12 +2477,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2512,7 +2512,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2527,7 +2527,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2537,12 +2537,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2581,7 +2581,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2596,7 +2596,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2680,7 +2680,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2738,7 +2738,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2758,7 +2758,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2897,7 +2897,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2922,22 +2922,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2992,12 +2992,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3052,11 +3052,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3066,7 +3066,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3134,11 +3134,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3156,7 +3156,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3208,7 +3208,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3271,7 +3271,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3438,7 +3438,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3795,7 +3795,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3807,7 +3807,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4048,7 +4048,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -4057,11 +4057,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4178,7 +4178,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4220,7 +4220,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4282,7 +4282,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4687,11 +4687,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4813,7 +4813,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4925,16 +4925,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4943,7 +4943,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4972,7 +4972,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4980,7 +4980,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4989,7 +4989,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5086,7 +5086,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5147,7 +5147,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5301,12 +5301,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5408,7 +5408,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5580,7 +5580,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5588,7 +5588,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5596,7 +5596,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5656,7 +5656,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5668,7 +5668,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5713,7 +5713,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6068,11 +6068,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6458,7 +6458,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6474,7 +6474,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6505,7 +6505,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6804,7 +6804,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6908,7 +6908,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6917,7 +6917,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6936,27 +6936,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6976,7 +6976,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7064,7 +7064,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7499,7 +7499,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7585,7 +7585,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7598,7 +7598,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7947,16 +7947,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -252,7 +252,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -692,12 +692,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -786,7 +786,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1284,7 +1284,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1620,7 +1620,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1694,7 +1694,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1857,7 +1857,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1941,9 +1941,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1967,11 +1967,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2128,7 +2128,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2232,7 +2232,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2495,12 +2495,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2515,12 +2515,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2550,7 +2550,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2565,7 +2565,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2575,12 +2575,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2619,7 +2619,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2634,7 +2634,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2718,7 +2718,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2776,7 +2776,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2796,7 +2796,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2935,7 +2935,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2960,22 +2960,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3030,12 +3030,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3074,7 +3074,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3090,11 +3090,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3104,7 +3104,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3172,11 +3172,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3194,7 +3194,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3246,7 +3246,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3309,7 +3309,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3476,7 +3476,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3833,7 +3833,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3845,7 +3845,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4086,7 +4086,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -4095,11 +4095,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4216,7 +4216,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4258,7 +4258,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4320,7 +4320,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4725,11 +4725,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4851,7 +4851,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4963,16 +4963,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4981,7 +4981,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5010,7 +5010,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5018,7 +5018,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -5027,7 +5027,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5124,7 +5124,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5185,7 +5185,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5339,12 +5339,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5420,7 +5420,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5446,7 +5446,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5618,7 +5618,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5626,7 +5626,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5634,7 +5634,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5694,7 +5694,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5751,7 +5751,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6106,11 +6106,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6496,7 +6496,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6512,7 +6512,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6543,7 +6543,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6842,7 +6842,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6946,7 +6946,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6955,7 +6955,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6974,27 +6974,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -7014,7 +7014,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7102,7 +7102,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7537,7 +7537,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7623,7 +7623,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7636,7 +7636,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7985,16 +7985,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1702,11 +1702,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1863,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1967,7 +1967,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2250,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2310,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2354,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2670,7 +2670,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2695,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2765,12 +2765,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2825,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2907,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3211,7 +3211,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3821,7 +3821,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3951,7 +3951,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3993,7 +3993,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4055,7 +4055,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4698,16 +4698,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4859,7 +4859,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5074,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5155,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5441,7 +5441,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5486,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5841,11 +5841,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6278,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6577,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6681,7 +6681,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6709,27 +6709,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6749,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6837,7 +6837,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7358,7 +7358,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7371,7 +7371,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7720,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -249,7 +249,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -678,12 +678,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -860,7 +860,7 @@ msgstr "Nome de membro do cluster"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1650,7 +1650,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1715,7 +1715,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1729,7 +1729,7 @@ msgstr "Editar arquivos no container"
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1912,7 +1912,7 @@ msgstr "Editar arquivos no container"
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2005,9 +2005,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2031,11 +2031,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2196,7 +2196,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2310,7 +2310,7 @@ msgstr "Editar arquivos no container"
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2588,12 +2588,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2608,12 +2608,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2643,7 +2643,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2658,7 +2658,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2668,12 +2668,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2712,7 +2712,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2727,7 +2727,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2891,7 +2891,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3049,7 +3049,7 @@ msgstr "Clustering ativado"
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3074,22 +3074,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3144,12 +3144,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
@@ -3189,7 +3189,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3205,11 +3205,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
@@ -3219,7 +3219,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3288,11 +3288,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3310,7 +3310,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3362,7 +3362,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3427,7 +3427,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3600,7 +3600,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3965,7 +3965,7 @@ msgstr "Editar arquivos no container"
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
@@ -3979,7 +3979,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4245,7 +4245,7 @@ msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
@@ -4256,12 +4256,12 @@ msgstr "Nome de membro do cluster"
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4386,7 +4386,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4429,7 +4429,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4492,7 +4492,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4898,11 +4898,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5029,7 +5029,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -5141,17 +5141,17 @@ msgstr "Editar arquivos no container"
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5160,7 +5160,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5191,7 +5191,7 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5199,7 +5199,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -5208,7 +5208,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5313,7 +5313,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5382,7 +5382,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5547,12 +5547,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5630,7 +5630,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5657,7 +5657,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5839,7 +5839,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5847,7 +5847,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5855,7 +5855,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5922,7 +5922,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5934,7 +5934,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5983,7 +5983,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6357,12 +6357,12 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6756,7 +6756,7 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6772,7 +6772,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6807,7 +6807,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -7130,7 +7130,7 @@ msgstr "Criar perfis"
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7247,7 +7247,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7257,7 +7257,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7280,31 +7280,31 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7326,7 +7326,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7419,7 +7419,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7901,7 +7901,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7987,7 +7987,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8000,7 +8000,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8349,16 +8349,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -253,7 +253,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -687,12 +687,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -863,7 +863,7 @@ msgstr "Копирование образа: %s"
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1297,7 +1297,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1641,7 +1641,7 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1706,7 +1706,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1720,7 +1720,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1900,7 +1900,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1992,9 +1992,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2018,11 +2018,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2181,7 +2181,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2292,7 +2292,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
@@ -2573,12 +2573,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2593,12 +2593,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2628,7 +2628,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2643,7 +2643,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2653,12 +2653,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2697,7 +2697,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2797,7 +2797,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -3030,7 +3030,7 @@ msgstr " Использование сети:"
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3056,22 +3056,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3126,12 +3126,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
@@ -3171,7 +3171,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -3187,11 +3187,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3201,7 +3201,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3273,11 +3273,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3297,7 +3297,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3349,7 +3349,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3414,7 +3414,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3590,7 +3590,7 @@ msgstr ""
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3961,7 +3961,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
@@ -3975,7 +3975,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4243,7 +4243,7 @@ msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
@@ -4254,12 +4254,12 @@ msgstr "Копирование образа: %s"
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4387,7 +4387,7 @@ msgstr "Копирование образа: %s"
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4430,7 +4430,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4494,7 +4494,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4904,11 +4904,11 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5030,7 +5030,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -5142,16 +5142,16 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5160,7 +5160,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5191,7 +5191,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -5200,7 +5200,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5210,7 +5210,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5312,7 +5312,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5377,7 +5377,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5542,12 +5542,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5625,7 +5625,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5651,7 +5651,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5829,7 +5829,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5837,7 +5837,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5845,7 +5845,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5913,7 +5913,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5925,7 +5925,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5973,7 +5973,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6348,11 +6348,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6740,7 +6740,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6756,7 +6756,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6789,7 +6789,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -7116,7 +7116,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -7304,7 +7304,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7317,7 +7317,7 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7352,7 +7352,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7360,7 +7360,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7368,7 +7368,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -7376,7 +7376,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7384,7 +7384,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7392,7 +7392,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7432,7 +7432,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7604,7 +7604,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8387,7 +8387,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -8473,7 +8473,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8486,7 +8486,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8835,16 +8835,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1680,9 +1680,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1706,11 +1706,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2234,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2254,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2314,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2358,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2457,7 +2457,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2515,7 +2515,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2535,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2674,7 +2674,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2699,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,12 +2769,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2911,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2933,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2985,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3215,7 +3215,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3584,7 +3584,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3825,7 +3825,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3834,11 +3834,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3955,7 +3955,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4590,7 +4590,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4702,16 +4702,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4720,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4766,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4863,7 +4863,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4924,7 +4924,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5078,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5159,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5185,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5357,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5373,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5845,11 +5845,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6282,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6581,7 +6581,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6685,7 +6685,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6694,7 +6694,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6713,27 +6713,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6753,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6841,7 +6841,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7362,7 +7362,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7375,7 +7375,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7724,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1680,9 +1680,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1706,11 +1706,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2234,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2254,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2314,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2358,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2457,7 +2457,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2515,7 +2515,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2535,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2674,7 +2674,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2699,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,12 +2769,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2911,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2933,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2985,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3215,7 +3215,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3584,7 +3584,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3825,7 +3825,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3834,11 +3834,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3955,7 +3955,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4590,7 +4590,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4702,16 +4702,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4720,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4766,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4863,7 +4863,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4924,7 +4924,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5078,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5159,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5185,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5357,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5373,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5845,11 +5845,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6282,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6581,7 +6581,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6685,7 +6685,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6694,7 +6694,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6713,27 +6713,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6753,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6841,7 +6841,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7362,7 +7362,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7375,7 +7375,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7724,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -175,7 +175,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1355,7 +1355,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1417,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1429,7 +1429,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1592,7 +1592,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1702,11 +1702,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1863,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1967,7 +1967,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2230,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2250,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2285,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2300,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2310,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2354,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2369,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2670,7 +2670,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2695,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2765,12 +2765,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2809,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2825,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2907,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2929,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3044,7 +3044,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3211,7 +3211,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3568,7 +3568,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3580,7 +3580,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3821,7 +3821,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3830,11 +3830,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3951,7 +3951,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3993,7 +3993,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4055,7 +4055,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4460,11 +4460,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4586,7 +4586,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4698,16 +4698,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4716,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4745,7 +4745,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4762,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4859,7 +4859,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4920,7 +4920,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5074,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5155,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5181,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5353,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5361,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5369,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5429,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5441,7 +5441,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5486,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5841,11 +5841,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6278,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6577,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6681,7 +6681,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6690,7 +6690,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6709,27 +6709,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6749,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6837,7 +6837,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7272,7 +7272,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7358,7 +7358,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7371,7 +7371,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7720,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -179,7 +179,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -600,7 +600,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1023,7 +1023,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1421,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1433,7 +1433,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1680,9 +1680,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1706,11 +1706,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2234,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2254,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2289,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2304,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2314,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2358,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2373,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2457,7 +2457,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2515,7 +2515,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2535,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2674,7 +2674,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2699,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,12 +2769,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2813,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2829,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2843,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2911,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2933,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2985,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3048,7 +3048,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3215,7 +3215,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3572,7 +3572,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3584,7 +3584,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3825,7 +3825,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3834,11 +3834,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3955,7 +3955,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3997,7 +3997,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4464,11 +4464,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4590,7 +4590,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4702,16 +4702,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4720,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4749,7 +4749,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4757,7 +4757,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4766,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4863,7 +4863,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4924,7 +4924,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5078,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5159,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5185,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5357,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5365,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5373,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5433,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5445,7 +5445,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5490,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5845,11 +5845,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6282,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6581,7 +6581,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6685,7 +6685,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6694,7 +6694,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6713,27 +6713,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6753,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6841,7 +6841,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7276,7 +7276,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7362,7 +7362,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7375,7 +7375,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7724,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -252,7 +252,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -591,12 +591,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1183,7 +1183,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1519,7 +1519,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1581,7 +1581,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1593,7 +1593,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1840,9 +1840,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1866,11 +1866,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2027,7 +2027,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2131,7 +2131,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2394,12 +2394,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2414,12 +2414,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2449,7 +2449,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2464,7 +2464,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2474,12 +2474,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2518,7 +2518,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2533,7 +2533,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2617,7 +2617,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2695,7 +2695,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2834,7 +2834,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2859,22 +2859,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2929,12 +2929,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2973,7 +2973,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2989,11 +2989,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3003,7 +3003,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3071,11 +3071,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3093,7 +3093,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3145,7 +3145,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3208,7 +3208,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3375,7 +3375,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3732,7 +3732,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3744,7 +3744,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3985,7 +3985,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3994,11 +3994,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4115,7 +4115,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -4157,7 +4157,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4219,7 +4219,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4624,11 +4624,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4750,7 +4750,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4862,16 +4862,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4880,7 +4880,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4909,7 +4909,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4917,7 +4917,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4926,7 +4926,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5023,7 +5023,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5084,7 +5084,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5238,12 +5238,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5319,7 +5319,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5345,7 +5345,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5517,7 +5517,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5525,7 +5525,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5533,7 +5533,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5593,7 +5593,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5605,7 +5605,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5650,7 +5650,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -6005,11 +6005,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6395,7 +6395,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6411,7 +6411,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6442,7 +6442,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6741,7 +6741,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6845,7 +6845,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6854,7 +6854,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6873,27 +6873,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6913,7 +6913,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7001,7 +7001,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7436,7 +7436,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7522,7 +7522,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7535,7 +7535,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7884,16 +7884,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-10 14:44-0600\n"
+"POT-Creation-Date: 2025-01-24 09:30-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -178,7 +178,7 @@ msgid ""
 "### - operations\n"
 msgstr ""
 
-#: lxc/auth.go:1791
+#: lxc/auth.go:1793
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1177
+#: lxc/file.go:1175
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1067
+#: lxc/file.go:1065
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:700
+#: lxc/file.go:699
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2080 lxc/auth.go:2081
+#: lxc/auth.go:2082 lxc/auth.go:2083
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:790
+#: lxc/file.go:789
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:304 lxc/auth.go:1866
+#: lxc/auth.go:304 lxc/auth.go:1868
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
@@ -1420,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:708
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1432,7 +1432,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1677 lxc/auth.go:1678
+#: lxc/auth.go:1679 lxc/auth.go:1680
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1595,7 +1595,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1730
+#: lxc/auth.go:1731 lxc/auth.go:1732
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1679,9 +1679,9 @@ msgstr ""
 #: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
 #: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
 #: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
-#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
-#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
-#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
+#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
+#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1705,11 +1705,11 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
-#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
+#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
-#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
+#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1236
+#: lxc/file.go:1234
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1970,7 +1970,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1778 lxc/auth.go:1779
+#: lxc/auth.go:1780 lxc/auth.go:1781
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2233,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1491
+#: lxc/file.go:1489
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1514
+#: lxc/file.go:1512
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2253,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1541
+#: lxc/file.go:1539
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1326
+#: lxc/file.go:1324
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2288,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1447
+#: lxc/file.go:1445
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2303,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1452
+#: lxc/file.go:1450
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2313,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1350
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1479
+#: lxc/file.go:1477
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2357,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1464
+#: lxc/file.go:1462
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2372,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1062
+#: lxc/file.go:1060
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2456,7 +2456,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
@@ -2514,7 +2514,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:968 lxc/auth.go:1942
+#: lxc/auth.go:968 lxc/auth.go:1944
 msgid "GROUPS"
 msgstr ""
 
@@ -2534,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1602 lxc/image.go:1603
+#: lxc/image.go:1607 lxc/image.go:1608
 msgid "Get image properties"
 msgstr ""
 
@@ -2673,7 +2673,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:430 lxc/auth.go:1992
+#: lxc/auth.go:430 lxc/auth.go:1994
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2698,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1564
+#: lxc/file.go:1562
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1553
+#: lxc/file.go:1551
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1376
+#: lxc/file.go:1374
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1386
+#: lxc/file.go:1384
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2768,12 +2768,12 @@ msgstr ""
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1714
+#: lxc/auth.go:1716
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1764
+#: lxc/auth.go:1766
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2812,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1518
+#: lxc/image.go:1523
 msgid "Image already up to date."
 msgstr ""
 
@@ -2828,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1473
+#: lxc/image.go:364 lxc/image.go:1478
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1699
+#: lxc/image.go:444 lxc/image.go:1704
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2842,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1516
+#: lxc/image.go:1521
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2910,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1378
+#: lxc/file.go:1376
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1555
+#: lxc/file.go:1553
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2932,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1298
+#: lxc/file.go:1296
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2984,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1293
+#: lxc/file.go:1291
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3047,7 +3047,7 @@ msgstr ""
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:739
+#: lxc/file.go:185 lxc/file.go:738
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3214,7 +3214,7 @@ msgstr ""
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1897 lxc/auth.go:1898
+#: lxc/auth.go:1899 lxc/auth.go:1900
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3571,7 +3571,7 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
 msgid "Manage groups"
 msgstr ""
 
@@ -3583,7 +3583,7 @@ msgstr ""
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2057 lxc/auth.go:2058
+#: lxc/auth.go:2059 lxc/auth.go:2060
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3824,7 +3824,7 @@ msgid "Missing cluster member name"
 msgstr ""
 
 #: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
-#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2033
 msgid "Missing group name"
 msgstr ""
 
@@ -3833,11 +3833,11 @@ msgstr ""
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
+#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2105 lxc/auth.go:2158
+#: lxc/auth.go:2107 lxc/auth.go:2160
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -3954,7 +3954,7 @@ msgstr ""
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:842
+#: lxc/file.go:841
 msgid "Missing target directory"
 msgstr ""
 
@@ -3996,7 +3996,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1227 lxc/file.go:1228
+#: lxc/file.go:1225 lxc/file.go:1226
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4058,7 +4058,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
@@ -4463,11 +4463,11 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1356
+#: lxc/file.go:1354
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4589,7 +4589,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1650
+#: lxc/image.go:1655
 msgid "Property not found"
 msgstr ""
 
@@ -4701,16 +4701,16 @@ msgstr ""
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:651 lxc/file.go:1009
+#: lxc/file.go:651 lxc/file.go:1008
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:701 lxc/file.go:702
+#: lxc/file.go:700 lxc/file.go:701
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:943 lxc/file.go:1109
+#: lxc/file.go:942 lxc/file.go:1107
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4748,7 +4748,7 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:475 lxc/file.go:708
+#: lxc/file.go:475 lxc/file.go:707
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -4756,7 +4756,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1445 lxc/image.go:1446
+#: lxc/image.go:1450 lxc/image.go:1451
 msgid "Refresh images"
 msgstr ""
 
@@ -4765,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1482
+#: lxc/image.go:1487
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4862,7 +4862,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2133 lxc/auth.go:2134
+#: lxc/auth.go:2135 lxc/auth.go:2136
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4923,7 @@ msgstr ""
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1957 lxc/auth.go:1958
+#: lxc/auth.go:1959 lxc/auth.go:1960
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5077,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1484
+#: lxc/file.go:1482
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1485
+#: lxc/file.go:1483
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5158,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1237
+#: lxc/file.go:1235
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5184,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1666 lxc/image.go:1667
+#: lxc/image.go:1671 lxc/image.go:1672
 msgid "Set image properties"
 msgstr ""
 
@@ -5356,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:711
+#: lxc/file.go:710
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5364,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:712
+#: lxc/file.go:711
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5372,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:710
+#: lxc/file.go:709
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5432,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1235
+#: lxc/file.go:1233
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5444,7 +5444,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2006 lxc/auth.go:2007
+#: lxc/auth.go:2008 lxc/auth.go:2009
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5489,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1536 lxc/image.go:1537
+#: lxc/image.go:1541 lxc/image.go:1542
 msgid "Show image properties"
 msgstr ""
 
@@ -5844,11 +5844,11 @@ msgstr ""
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1286
+#: lxc/file.go:1284
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1280
+#: lxc/file.go:1278
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1507
+#: lxc/file.go:1505
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1049
+#: lxc/file.go:1047
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6281,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1729 lxc/image.go:1730
+#: lxc/image.go:1734 lxc/image.go:1735
 msgid "Unset image properties"
 msgstr ""
 
@@ -6580,7 +6580,7 @@ msgstr ""
 msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84
@@ -6684,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2134
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6693,7 +6693,7 @@ msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
 #: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
-#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
+#: lxc/auth.go:1105 lxc/auth.go:1678 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
@@ -6712,27 +6712,27 @@ msgstr ""
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
+#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2079
+#: lxc/auth.go:2081
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1955
+#: lxc/auth.go:1957
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1728
+#: lxc/image.go:1606 lxc/image.go:1733
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1665
+#: lxc/image.go:1670
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1444
+#: lxc/image.go:334 lxc/image.go:1449
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6840,7 +6840,7 @@ msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1226
+#: lxc/file.go:1224
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7275,7 +7275,7 @@ msgid ""
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1781
+#: lxc/auth.go:1783
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"
@@ -7361,7 +7361,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1230
+#: lxc/file.go:1228
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -7374,7 +7374,7 @@ msgid ""
 "directory."
 msgstr ""
 
-#: lxc/file.go:704
+#: lxc/file.go:703
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7723,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1396
+#: lxc/file.go:1394
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1355
+#: lxc/file.go:1353
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1308
+#: lxc/file.go:1306
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 


### PR DESCRIPTION
The logic for the delete endpoints for images, instances, networks, network zones, network ACLs, profiles, and storage pool volumes has been factored out such that it can be invoked without going through the lxd client API.