### PR TITLE
Add missing `swtpm` command for container_devices_tpm test

### DIFF
--- a/.github/actions/install-lxd-runtimedeps/action.yml
+++ b/.github/actions/install-lxd-runtimedeps/action.yml
@@ -37,6 +37,7 @@ runs:
           socat \
           sqlite3 \
           squashfs-tools \
+          swtpm \
           tar \
           tcl \
           thin-provisioning-tools \

--- a/test/main.sh
+++ b/test/main.sh
@@ -45,7 +45,7 @@ import_subdir_files() {
 import_subdir_files includes
 
 echo "==> Checking for dependencies"
-check_dependencies lxd lxc curl dnsmasq jq git sqlite3 msgmerge msgfmt shuf setfacl socat dig
+check_dependencies lxd lxc curl dnsmasq jq git sqlite3 msgmerge msgfmt shuf setfacl socat swtpm dig
 
 if [ "${USER:-'root'}" != "root" ]; then
   echo "The testsuite must be run as root." >&2

--- a/test/suites/container_devices_tpm.sh
+++ b/test/suites/container_devices_tpm.sh
@@ -28,5 +28,5 @@ test_container_devices_tpm() {
   ! lxc exec "${ctName}" -- stat /dev/tpmrm0
 
   # Clean up
-  lxc rm -f "${ctName}"
+  lxc delete -f "${ctName}"
 }

--- a/test/suites/container_devices_tpm.sh
+++ b/test/suites/container_devices_tpm.sh
@@ -4,6 +4,11 @@ test_container_devices_tpm() {
     return
   fi
 
+  if ! modprobe tpm_vtpm_proxy; then
+    echo "==> SKIP: Required tpm_vtpm_proxy.ko is missing"
+    return
+  fi
+
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
   ctName="ct$$"


### PR DESCRIPTION
ATM, GHA runners don't have the needed kconfig:

```
$ grep TPM_PROXY /boot/config-*
/boot/config-6.8.0-1020-azure:# CONFIG_TCG_VTPM_PROXY is not set
```
but those running the test suite locally should have no problem when using a non-Azure kernel (like `linux-image-virtual`).