### PR TITLE
cloud-init: Address `cloud-init` misconceptions

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -74,8 +74,11 @@ See {ref}`cloud-init:merging_user_data` for instructions.
 
 To configure `cloud-init` for an instance, add the corresponding configuration options to a {ref}`profile <profiles>` that the instance uses or directly to the {ref}`instance configuration <instances-configure>`.
 
-When configuring `cloud-init` directly for an instance, keep in mind that `cloud-init` runs only on the first start of the instance.
-That means that you must configure `cloud-init` before you start the instance.
+When configuring `cloud-init` directly for an instance, keep in mind that `cloud-init` runs only on instance start.
+That means any changes to `cloud-init` configuration will only take effect after the next instance start.
+Some configuration options only take effect on the first boot of an instance. If `cloud-init` notices that an
+instance's `instance-id` has changed, it behaves as it this was the instance's first boot. For more information, see
+the [cloud-init docs](https://docs.cloud-init.io/en/latest/explanation/first_boot.html#first-boot-determination)
 If you are using the CLI client, create the instance with [`lxc init`](lxc_init.md) instead of [`lxc launch`](lxc_launch.md), and then start it after completing the configuration.
 
 To add your configuration:

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -134,7 +134,7 @@ Then click {guilabel}`Edit instance` and override the configuration for one or m
 The `cloud-init` options require YAML's [literal style format](https://yaml.org/spec/1.2.2/#812-literal-style).
 You use a pipe symbol (`|`) to indicate that all indented text after the pipe should be passed to `cloud-init` as a single string, with new lines and indentation preserved.
 
-The `vendor-data` and `user-data` options usually start with `#cloud-config`.
+The `vendor-data` and `user-data` options usually start with `#cloud-config`. But `cloud-init` has an array of [configuration formats](https://docs.cloud-init.io/en/latest/explanation/format.html#configuration-types) available.
 
 For example:
 
@@ -146,6 +146,13 @@ config:
     packages:
       - package1
       - package2
+```
+
+```yaml
+config:
+  cloud-init.user-data: |
+    #!/usr/bin/bash
+    echo hello | tee -a /tmp/example.txt
 ```
 
 ```{tip}

--- a/doc/dev-lxd.md
+++ b/doc/dev-lxd.md
@@ -229,6 +229,5 @@ Return value:
 
 Return value:
 
-    #cloud-config
     instance-id: af6a01c7-f847-4688-a2a4-37fddd744625
     local-hostname: abc

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -134,7 +134,7 @@ func devlxdMetadataGetHandler(d *Daemon, inst instance.Instance, w http.Response
 
 	value := inst.ExpandedConfig()["user.meta-data"]
 
-	return response.DevLxdResponse(http.StatusOK, fmt.Sprintf("#cloud-config\ninstance-id: %s\nlocal-hostname: %s\n%s", inst.CloudInitID(), inst.Name(), value), "raw", inst.Type() == instancetype.VM)
+	return response.DevLxdResponse(http.StatusOK, fmt.Sprintf("instance-id: %s\nlocal-hostname: %s\n%s", inst.CloudInitID(), inst.Name(), value), "raw", inst.Type() == instancetype.VM)
 }
 
 var devlxdEventsGet = devLxdHandler{


### PR DESCRIPTION
Some misconceptions/observations regarding some `cloud-init` concepts were pointed out throughout the discussions on https://github.com/canonical/lxd/issues/13853 and are addressed here. 