### PR TITLE
Storage: PowerFlex fixes and improvements

### DIFF
--- a/lxd/storage/block/utils.go
+++ b/lxd/storage/block/utils.go
@@ -2,14 +2,59 @@ package block
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
 
+	"github.com/canonical/lxd/lxd/resources"
 	"github.com/canonical/lxd/shared"
 )
+
+// devicePathFilterFunc is a function that accepts device path and returns true
+// if the path matches the required criteria.
+type devicePathFilterFunc func(devPath string) bool
+
+// findDiskDevivePath iterates over device names in /dev/disk/by-id directory and
+// returns the path to the disk device that matches the given prefix and suffix.
+// Disk partitions are skipped, and an error is returned if the device is not found.
+func findDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+	var diskPaths []string
+
+	// If there are no other disks on the system by id, the directory might not
+	// even be there. Returns ENOENT in case the by-id/ directory does not exist.
+	diskPaths, err := resources.GetDisksByID(diskNamePrefix)
+	if err != nil {
+		return "", err
+	}
+
+	for _, diskPath := range diskPaths {
+		// Skip the disk if it is only a partition of the actual volume.
+		if strings.Contains(diskPath, "-part") {
+			continue
+		}
+
+		// Use custom disk path filter, if one is provided.
+		if diskPathFilter != nil && !diskPathFilter(diskPath) {
+			continue
+		}
+
+		// The actual device might not already be created.
+		// Returns ENOENT in case the device does not exist.
+		devPath, err := filepath.EvalSymlinks(diskPath)
+		if err != nil {
+			return "", err
+		}
+
+		return devPath, nil
+	}
+
+	return "", nil
+}
 
 // DiskSizeBytes returns the size of a block disk (path can be either block device or raw file).
 func DiskSizeBytes(blockDiskPath string) (int64, error) {
@@ -87,4 +132,87 @@ func WaitDiskDeviceResize(ctx context.Context, diskPath string, newSizeBytes int
 
 		time.Sleep(500 * time.Millisecond)
 	}
+}
+
+// WaitDiskDeviceGone waits for the disk device to disappear from /dev/disk/by-id.
+// It periodically checks for the device to disappear and returns once the device
+// is gone. If the device does not disappear within the timeout, an error is returned.
+func WaitDiskDeviceGone(ctx context.Context, diskPath string) bool {
+	_, ok := ctx.Deadline()
+	if !ok {
+		// Set a default timeout of 30 seconds for the context
+		// if no deadline is already configured.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+
+	for {
+		if !shared.PathExists(diskPath) {
+			return true
+		}
+
+		if ctx.Err() != nil {
+			return false
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+// WaitDiskDevicePath waits for the disk device to appear in /dev/disk/by-id.
+// It periodically checks for the device to appear and returns the device path
+// once it is found. If the device does not appear within the timeout, an error
+// is returned.
+func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+	var err error
+	var diskPath string
+
+	_, ok := ctx.Deadline()
+	if !ok {
+		// Set a default timeout of 30 seconds for the context
+		// if no deadline is already configured.
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+	}
+
+	for {
+		// Check if the device is already present.
+		diskPath, err = findDiskDevicePath(diskNamePrefix, diskPathFilter)
+		if err != nil && !errors.Is(err, unix.ENOENT) {
+			return "", err
+		}
+
+		// If the device is found, return the device path.
+		if diskPath != "" {
+			break
+		}
+
+		// Check if context is cancelled.
+		err := ctx.Err()
+		if err != nil {
+			return "", err
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return diskPath, nil
+}
+
+// GetDiskDevicePath checks whether the disk device with a given prefix and suffix
+// exists in /dev/disk/by-id directory. A device path is returned if the device is
+// found, otherwise an error is returned.
+func GetDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+	devPath, err := findDiskDevicePath(diskNamePrefix, diskPathFilter)
+	if err != nil {
+		return "", err
+	}
+
+	if devPath == "" {
+		return "", fmt.Errorf("Device not found")
+	}
+
+	return devPath, nil
 }

--- a/lxd/storage/connectors/utils.go
+++ b/lxd/storage/connectors/utils.go
@@ -2,145 +2,14 @@ package connectors
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/canonical/lxd/lxd/locking"
-	"github.com/canonical/lxd/lxd/resources"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/revert"
 )
-
-// devicePathFilterFunc is a function that accepts device path and returns true
-// if the path matches the required criteria.
-type devicePathFilterFunc func(devPath string) bool
-
-// GetDiskDevicePath checks whether the disk device with a given prefix and suffix
-// exists in /dev/disk/by-id directory. A device path is returned if the device is
-// found, otherwise an error is returned.
-func GetDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
-	devPath, err := findDiskDevicePath(diskNamePrefix, diskPathFilter)
-	if err != nil {
-		return "", err
-	}
-
-	if devPath == "" {
-		return "", fmt.Errorf("Device not found")
-	}
-
-	return devPath, nil
-}
-
-// WaitDiskDevicePath waits for the disk device to appear in /dev/disk/by-id.
-// It periodically checks for the device to appear and returns the device path
-// once it is found. If the device does not appear within the timeout, an error
-// is returned.
-func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
-	var err error
-	var diskPath string
-
-	_, ok := ctx.Deadline()
-	if !ok {
-		// Set a default timeout of 30 seconds for the context
-		// if no deadline is already configured.
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-	}
-
-	for {
-		// Check if the device is already present.
-		diskPath, err = findDiskDevicePath(diskNamePrefix, diskPathFilter)
-		if err != nil && !errors.Is(err, unix.ENOENT) {
-			return "", err
-		}
-
-		// If the device is found, return the device path.
-		if diskPath != "" {
-			break
-		}
-
-		// Check if context is cancelled.
-		err := ctx.Err()
-		if err != nil {
-			return "", err
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	return diskPath, nil
-}
-
-// findDiskDevivePath iterates over device names in /dev/disk/by-id directory and
-// returns the path to the disk device that matches the given prefix and suffix.
-// Disk partitions are skipped, and an error is returned if the device is not found.
-func findDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
-	var diskPaths []string
-
-	// If there are no other disks on the system by id, the directory might not
-	// even be there. Returns ENOENT in case the by-id/ directory does not exist.
-	diskPaths, err := resources.GetDisksByID(diskNamePrefix)
-	if err != nil {
-		return "", err
-	}
-
-	for _, diskPath := range diskPaths {
-		// Skip the disk if it is only a partition of the actual volume.
-		if strings.Contains(diskPath, "-part") {
-			continue
-		}
-
-		// Use custom disk path filter, if one is provided.
-		if diskPathFilter != nil && !diskPathFilter(diskPath) {
-			continue
-		}
-
-		// The actual device might not already be created.
-		// Returns ENOENT in case the device does not exist.
-		devPath, err := filepath.EvalSymlinks(diskPath)
-		if err != nil {
-			return "", err
-		}
-
-		return devPath, nil
-	}
-
-	return "", nil
-}
-
-// WaitDiskDeviceGone waits for the disk device to disappear from /dev/disk/by-id.
-// It periodically checks for the device to disappear and returns once the device
-// is gone. If the device does not disappear within the timeout, an error is returned.
-func WaitDiskDeviceGone(ctx context.Context, diskPath string) bool {
-	_, ok := ctx.Deadline()
-	if !ok {
-		// Set a default timeout of 30 seconds for the context
-		// if no deadline is already configured.
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-	}
-
-	for {
-		if !shared.PathExists(diskPath) {
-			return true
-		}
-
-		if ctx.Err() != nil {
-			return false
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-}
 
 // connectFunc is invoked by "connect" for each provided address.
 // It receives a session and a target address. A non-nil session indicates

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dell/goscaleio"
 	"github.com/google/uuid"
 
+	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/connectors"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -997,10 +998,10 @@ func (d *powerflex) getMappedDevPath(vol Volume, mapVolume bool) (string, revert
 	var devicePath string
 	if mapVolume {
 		// Wait for the device path to appear as the volume has been just mapped to the host.
-		devicePath, err = connectors.WaitDiskDevicePath(d.state.ShutdownCtx, prefix, devicePathFilter)
+		devicePath, err = block.WaitDiskDevicePath(d.state.ShutdownCtx, prefix, devicePathFilter)
 	} else {
 		// Get the the device path without waiting.
-		devicePath, err = connectors.GetDiskDevicePath(prefix, devicePathFilter)
+		devicePath, err = block.GetDiskDevicePath(prefix, devicePathFilter)
 	}
 
 	if err != nil {
@@ -1071,7 +1072,7 @@ func (d *powerflex) unmapVolume(vol Volume) error {
 	defer cancel()
 
 	volumePath, _, _ := d.getMappedDevPath(vol, false)
-	if volumePath != "" && !connectors.WaitDiskDeviceGone(ctx, volumePath) {
+	if volumePath != "" && !block.WaitDiskDeviceGone(ctx, volumePath) {
 		return fmt.Errorf("Timeout whilst waiting for PowerFlex volume to disappear: %q", vol.name)
 	}
 

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -148,7 +148,9 @@ type powerFlexVolume struct {
 	VolumeType       string `json:"volumeType"`
 	VTreeID          string `json:"vtreeId"`
 	AncestorVolumeID string `json:"ancestorVolumeId"`
-	MappedSDCInfo    []struct {
+	// PowerFlex reports the value in KB but it's actually KiB.
+	SizeInKiB     int64 `json:"sizeInKb"`
+	MappedSDCInfo []struct {
 		SDCID    string `json:"sdcId"`
 		SDCName  string `json:"sdcName"`
 		NQN      string `json:"nqn"`

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/dell/goscaleio"
@@ -161,8 +162,9 @@ type powerFlexVolume struct {
 
 // powerFlexClient holds the PowerFlex HTTP client and an access token factory.
 type powerFlexClient struct {
-	driver *powerflex
-	token  string
+	driver    *powerflex
+	token     string
+	tokenLock sync.RWMutex
 }
 
 // newPowerFlexClient creates a new instance of the HTTP PowerFlex client.
@@ -185,7 +187,7 @@ func (p *powerFlexClient) createBodyReader(contents map[string]any) (io.Reader, 
 }
 
 // request issues a HTTP request against the PowerFlex gateway.
-func (p *powerFlexClient) request(method string, path string, body io.Reader, response any) error {
+func (p *powerFlexClient) request(method string, path string, token string, body io.Reader, response any) error {
 	url := p.driver.config["powerflex.gateway"] + path
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
@@ -197,7 +199,7 @@ func (p *powerFlexClient) request(method string, path string, body io.Reader, re
 		req.Header.Add("Content-Type", "application/json")
 	}
 
-	if p.token != "" {
+	if token != "" {
 		req.Header.Add("Authorization", "Bearer "+p.token)
 	}
 
@@ -250,17 +252,28 @@ func (p *powerFlexClient) request(method string, path string, body io.Reader, re
 func (p *powerFlexClient) requestAuthenticated(method string, path string, body io.Reader, response any) error {
 	retries := 0
 	for {
-		err := p.login()
+		// Returns a copy of the client's token.
+		// This allows issuing multiple requests in parallel.
+		// Otherwise the lock on the token can only be released after
+		// the actual request has been finished as the token might be expired.
+		token, err := p.login()
 		if err != nil {
 			return err
 		}
 
-		err = p.request(method, path, body, response)
+		err = p.request(method, path, token, body, response)
 		if err != nil {
 			if api.StatusErrorCheck(err, http.StatusUnauthorized) && retries == 0 {
 				// Access token seems to be expired.
 				// Reset the token and try one more time.
+				// If two requests (from different callers) fail at the exact same time this might result in
+				// two subsequent login attempts.
+				// The first one resets the token and tries to login again.
+				// It will use this new token for its own request (as returned by the login func)
+				// but the second caller will again reset the token and perform another login.
+				p.tokenLock.Lock()
 				p.token = ""
+				p.tokenLock.Unlock()
 				retries++
 				continue
 			}
@@ -274,30 +287,36 @@ func (p *powerFlexClient) requestAuthenticated(method string, path string, body 
 }
 
 // login creates a new access token and authenticates the client.
-func (p *powerFlexClient) login() error {
-	if p.token != "" {
-		return nil
+// If the token already exists it returns a copy of it.
+// To prevent parallel logins the function obtains a lock.
+func (p *powerFlexClient) login() (string, error) {
+	p.tokenLock.Lock()
+	defer p.tokenLock.Unlock()
+
+	// Create a new token.
+	if p.token == "" {
+		body, err := p.createBodyReader(map[string]any{
+			"username": p.driver.config["powerflex.user.name"],
+			"password": p.driver.config["powerflex.user.password"],
+		})
+		if err != nil {
+			return "", err
+		}
+
+		var actualResponse struct {
+			AccessToken string `json:"access_token"`
+		}
+
+		err = p.request(http.MethodPost, "/rest/auth/login", "", body, &actualResponse)
+		if err != nil {
+			return "", fmt.Errorf("Failed to login: %w", err)
+		}
+
+		// Save the new token for later use.
+		p.token = actualResponse.AccessToken
 	}
 
-	body, err := p.createBodyReader(map[string]any{
-		"username": p.driver.config["powerflex.user.name"],
-		"password": p.driver.config["powerflex.user.password"],
-	})
-	if err != nil {
-		return err
-	}
-
-	var actualResponse struct {
-		AccessToken string `json:"access_token"`
-	}
-
-	err = p.request(http.MethodPost, "/rest/auth/login", body, &actualResponse)
-	if err != nil {
-		return fmt.Errorf("Failed to login: %w", err)
-	}
-
-	p.token = actualResponse.AccessToken
-	return nil
+	return p.token, nil
 }
 
 // getStoragePool returns the storage pool behind poolID.

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -221,7 +221,7 @@ func (p *powerFlexClient) request(method string, path string, token string, body
 	// Exit right away if not authorized.
 	// We cannot parse the returned body since it's not in JSON format.
 	if resp.StatusCode == http.StatusUnauthorized && resp.Header.Get("Content-Type") != "application/json" {
-		return api.StatusErrorf(http.StatusUnauthorized, "Unauthorized request")
+		return api.NewStatusError(http.StatusUnauthorized, "Unauthorized request")
 	}
 
 	// Overwrite the response data type if an error is detected.

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -98,6 +98,7 @@ type powerFlexStoragePool struct {
 	ID                 string `json:"id"`
 	Name               string `json:"name"`
 	ProtectionDomainID string `json:"protectionDomainId"`
+	ZeroPaddingEnabled bool   `json:"zeroPaddingEnabled"`
 }
 
 // powerFlexStoragePoolStatistics represents the statistics of a storage pool in PowerFlex.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -44,6 +45,12 @@ func (d *powerflex) CreateVolume(vol Volume, filler *VolumeFiller, op *operation
 	pool, err := d.resolvePool()
 	if err != nil {
 		return err
+	}
+
+	// The pool isn't configured to use zero-padding which might yield non pristine data when reading from the volume.
+	// Don't allow the creation of new volumes.
+	if !pool.ZeroPaddingEnabled {
+		return errors.New("The pool doesn't have zero-padding enabled")
 	}
 
 	volName, err := d.getVolumeName(vol)

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -14,7 +14,6 @@ import (
 	"github.com/canonical/lxd/lxd/instancewriter"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
-	"github.com/canonical/lxd/lxd/storage/block"
 	"github.com/canonical/lxd/lxd/storage/filesystem"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -549,17 +548,27 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 		return nil
 	}
 
-	devPath, cleanup, err := d.getMappedDevPath(vol, true)
+	volName, err := d.getVolumeName(vol)
 	if err != nil {
 		return err
 	}
 
-	defer cleanup()
-
-	oldSizeBytes, err := block.DiskSizeBytes(devPath)
+	client := d.client()
+	volumeID, err := client.getVolumeID(volName)
 	if err != nil {
-		return fmt.Errorf("Error getting current size: %w", err)
+		return err
 	}
+
+	volume, err := d.client().getVolume(volumeID)
+	if err != nil {
+		return err
+	}
+
+	// Try to fetch the current size of the volume from the PowerFlex API.
+	// If the volume is not yet mapped to the system this speeds up the
+	// process as the volume doesn't have to be mapped to get its size
+	// from the actual block device.
+	oldSizeBytes := volume.SizeInKiB * 1024
 
 	// Do nothing if volume is already specified size (+/- 512 bytes).
 	if oldSizeBytes+512 > sizeBytes && oldSizeBytes-512 < sizeBytes {
@@ -578,17 +587,6 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 		return ErrNotSupported
 	}
 
-	volName, err := d.getVolumeName(vol)
-	if err != nil {
-		return err
-	}
-
-	client := d.client()
-	volumeID, err := client.getVolumeID(volName)
-	if err != nil {
-		return err
-	}
-
 	// Resize filesystem if needed.
 	if vol.contentType == ContentTypeFS {
 		fsType := vol.ConfigBlockFilesystem()
@@ -599,6 +597,13 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 			if err != nil {
 				return err
 			}
+
+			devPath, cleanup, err := d.getMappedDevPath(vol, true)
+			if err != nil {
+				return err
+			}
+
+			defer cleanup()
 
 			// Grow the filesystem to fill block device.
 			err = growFileSystem(fsType, devPath, vol)
@@ -621,6 +626,13 @@ func (d *powerflex) SetVolumeQuota(vol Volume, size string, allowUnsafeResize bo
 		if err != nil {
 			return err
 		}
+
+		devPath, cleanup, err := d.getMappedDevPath(vol, true)
+		if err != nil {
+			return err
+		}
+
+		defer cleanup()
 
 		// Move the VM GPT alt header to end of disk if needed (not needed in unsafe resize mode as it is
 		// expected the caller will do all necessary post resize actions themselves).


### PR DESCRIPTION
This has to land after https://github.com/canonical/lxd/pull/14710 got merged as it was tested together. 

### Summary of changes

1. Don't map the volume before actually performing the resize in `SetVolumeQuota`. As we can get the current volume's size directly from PowerFlex it does not need to be mapped beforehand. This also allows reducing errors in `dmesg` caused by the resize in case the vol is already mapped to the system.
2. Prevent volume creation in case the PowerFlex pool isn't using zero-padding. This is to prevent leaking data from a previous volume in case the storage pool on PowerFlex wasn't setup appropriately.
3. Lock the PowerFlex client's API token to not cause concurrent logins and to save time in case of parallel access.
4. Always copy the PowerFlex client's request body for retries. Before, if the to be retried request contained a request body, it was already read in the first request which leads any follow up request to not anymore have a request body.
5. Small improvement to use `NewStatusError`
6. Always allow the filler to resize as PowerFlex doesn't use optimized image storage. This caused issues when trying to launch images from an image that were bigger than the volume size. There is now a test for this in `lxd-ci/tests/storage-vm`.
7. Move common disk discovery functions into the `block` package.