### PR TITLE
shared/util: set the path variable provided to the editor

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -927,6 +927,8 @@ func TextEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
+		path = f.Name()
+
 		revert.Success()
 		revert.Add(func() { _ = os.Remove(path) })
 	} else {


### PR DESCRIPTION
Fixes 4add3b838521325af557e4827914c6654e298a34.