### PR TITLE
Documentation: Add missing `swtpm` package to installing from source section

### DIFF
--- a/doc/installing.md
+++ b/doc/installing.md
@@ -227,7 +227,7 @@ sudo apt install btrfs-progs
 To run the test suite, you'll also need:
 
 ```bash
-sudo apt install busybox-static curl gettext jq sqlite3 socat bind9-dnsutils
+sudo apt install busybox-static curl gettext jq sqlite3 socat swtpm bind9-dnsutils
 ```
 
 ### From source: Build the latest version


### PR DESCRIPTION
Follow up to https://github.com/canonical/lxd/pull/14844/commits/0c0e89fd218e0241daf3b0e214dcad30fb63f89a.