### PR TITLE
lxd: Entitlement enrichment for remaining API entities

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1106,6 +1106,15 @@ definitions:
     ImageAliasesEntry:
         description: ImageAliasesEntry represents a LXD image alias
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             description:
                 description: Alias description
                 example: Our preferred Ubuntu image
@@ -1156,6 +1165,15 @@ definitions:
     ImageAliasesPost:
         description: ImageAliasesPost represents a new LXD image alias
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             description:
                 description: Alias description
                 example: Our preferred Ubuntu image
@@ -1795,6 +1813,15 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     InstanceBackup:
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             container_only:
                 description: Whether to ignore snapshots (deprecated, use instance_only)
                 example: false
@@ -2264,6 +2291,15 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     InstanceSnapshot:
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             architecture:
                 description: Architecture name
                 example: x86_64
@@ -5856,6 +5892,15 @@ definitions:
     Server:
         description: Server represents a LXD server
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             api_extensions:
                 description: List of supported API extensions
                 example:
@@ -6432,6 +6477,15 @@ definitions:
     StoragePoolVolumeBackup:
         description: StoragePoolVolumeBackup represents a LXD volume backup
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             created_at:
                 description: When the backup was created
                 example: "2021-03-23T16:38:37.753398689-04:00"
@@ -6687,6 +6741,15 @@ definitions:
     StorageVolumeSnapshot:
         description: StorageVolumeSnapshot represents a LXD storage volume snapshot
         properties:
+            access_entitlements:
+                description: AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
+                example:
+                    - can_view
+                    - can_edit
+                items:
+                    type: string
+                type: array
+                x-go-name: AccessEntitlements
             config:
                 additionalProperties:
                     type: string

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -149,7 +149,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	if recursion {
-		var certResponses []api.Certificate
+		var certResponses []*api.Certificate
 		var baseCerts []dbCluster.Certificate
 		urlToCertificate := make(map[*api.URL]auth.EntitlementReporter)
 		var err error
@@ -159,7 +159,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
-			certResponses = make([]api.Certificate, 0, len(baseCerts))
+			certResponses = make([]*api.Certificate, 0, len(baseCerts))
 			for _, baseCert := range baseCerts {
 				if !userHasPermission(entity.CertificateURL(baseCert.Fingerprint)) {
 					continue
@@ -170,7 +170,7 @@ func certificatesGet(d *Daemon, r *http.Request) response.Response {
 					return err
 				}
 
-				certResponses = append(certResponses, *apiCert)
+				certResponses = append(certResponses, apiCert)
 				urlToCertificate[entity.CertificateURL(apiCert.Fingerprint)] = apiCert
 			}
 

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -894,7 +894,7 @@ func getIdentities(authenticationMethod string) func(d *Daemon, r *http.Request)
 				}
 			}
 
-			apiIdentities := make([]api.Identity, 0, len(identities))
+			apiIdentities := make([]*api.Identity, 0, len(identities))
 			urlToIdentity := make(map[*api.URL]auth.EntitlementReporter, len(identities))
 			for _, id := range identities {
 				var certificate string
@@ -907,7 +907,7 @@ func getIdentities(authenticationMethod string) func(d *Daemon, r *http.Request)
 					certificate = metadata.Certificate
 				}
 
-				identity := api.Identity{
+				identity := &api.Identity{
 					AuthenticationMethod: string(id.AuthMethod),
 					Type:                 string(id.Type),
 					Identifier:           id.Identifier,
@@ -917,7 +917,7 @@ func getIdentities(authenticationMethod string) func(d *Daemon, r *http.Request)
 				}
 
 				apiIdentities = append(apiIdentities, identity)
-				urlToIdentity[entity.IdentityURL(string(id.AuthMethod), id.Identifier)] = &identity
+				urlToIdentity[entity.IdentityURL(string(id.AuthMethod), id.Identifier)] = identity
 			}
 
 			if len(withEntitlements) > 0 {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -3628,9 +3628,14 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 
 	s := d.State()
 
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeImageAlias, true)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	projectName := request.ProjectParam(r)
 	var effectiveProjectName string
-	err := s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
 		return err
@@ -3646,7 +3651,8 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	var responseStr []string
-	var responseMap []api.ImageAliasesEntry
+	var responseMap []*api.ImageAliasesEntry
+	urlToImageAlias := make(map[*api.URL]auth.EntitlementReporter)
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		names, err := tx.GetImageAliases(ctx, projectName)
 		if err != nil {
@@ -3654,7 +3660,7 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if recursion {
-			responseMap = make([]api.ImageAliasesEntry, 0, len(names))
+			responseMap = make([]*api.ImageAliasesEntry, 0, len(names))
 		} else {
 			responseStr = make([]string, 0, len(names))
 		}
@@ -3672,7 +3678,8 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 					continue
 				}
 
-				responseMap = append(responseMap, alias)
+				responseMap = append(responseMap, &alias)
+				urlToImageAlias[entity.ImageAliasURL(projectName, name)] = &alias
 			}
 		}
 
@@ -3684,6 +3691,13 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 
 	if !recursion {
 		return response.SyncResponse(true, responseStr)
+	}
+
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeImageAlias, withEntitlements, urlToImageAlias)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.SyncResponse(true, responseMap)
@@ -3779,6 +3793,12 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	s := d.State()
+
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeImageAlias, false)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	var effectiveProjectName string
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		effectiveProjectName, err = projectutils.ImageProject(ctx, tx.Tx(), projectName)
@@ -3810,7 +3830,14 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 		return response.NotFound(nil)
 	}
 
-	return response.SyncResponseETag(true, alias, alias)
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeImageAlias, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.ImageAliasURL(projectName, name): &alias})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	return response.SyncResponseETag(true, &alias, alias)
 }
 
 // swagger:operation DELETE /1.0/images/aliases/{name} images image_alias_delete

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -157,9 +157,15 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeInstanceSnapshot, true)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	recursion := util.IsRecursionRequest(r)
 	resultString := []string{}
 	resultMap := []*api.InstanceSnapshot{}
+	urlToSnaps := make(map[*api.URL]auth.EntitlementReporter)
 
 	if !recursion {
 		var snaps []string
@@ -213,12 +219,25 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 				continue
 			}
 
-			resultMap = append(resultMap, render.(*api.InstanceSnapshot))
+			renderedSnap, ok := render.(*api.InstanceSnapshot)
+			if !ok {
+				return response.InternalError(fmt.Errorf("Render didn't return a snapshot"))
+			}
+
+			resultMap = append(resultMap, renderedSnap)
+			urlToSnaps[entity.InstanceSnapshotURL(projectName, cname, snapName)] = renderedSnap
 		}
 	}
 
 	if !recursion {
 		return response.SyncResponse(true, resultString)
+	}
+
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeInstanceSnapshot, withEntitlements, urlToSnaps)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.SyncResponse(true, resultMap)
@@ -407,7 +426,7 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 
 	switch r.Method {
 	case "GET":
-		return snapshotGet(s, snapInst)
+		return snapshotGet(s, r, snapInst)
 	case "POST":
 		return snapshotPost(s, r, snapInst)
 	case "DELETE":
@@ -609,14 +628,31 @@ func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance) re
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func snapshotGet(s *state.State, snapInst instance.Instance) response.Response {
+func snapshotGet(s *state.State, r *http.Request, snapInst instance.Instance) response.Response {
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeInstanceSnapshot, false)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	render, _, err := snapInst.Render(storagePools.RenderSnapshotUsage(s, snapInst))
 	if err != nil {
 		return response.SmartError(err)
 	}
 
+	renderedSnap, ok := render.(*api.InstanceSnapshot)
+	if !ok {
+		return response.InternalError(fmt.Errorf("Render didn't return a snapshot"))
+	}
+
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeInstanceSnapshot, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.InstanceSnapshotURL(snapInst.Project().Name, snapInst.Name(), renderedSnap.Name): renderedSnap})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	etag := []any{snapInst.ExpiryDate()}
-	return response.SyncResponseETag(true, render.(*api.InstanceSnapshot), etag)
+	return response.SyncResponseETag(true, renderedSnap, etag)
 }
 
 // swagger:operation POST /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_post

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -311,7 +311,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	resultString := []string{}
-	resultMap := []api.Network{}
+	resultMap := []*api.Network{}
 	urlToNetwork := make(map[*api.URL]auth.EntitlementReporter)
 	for kind, networkNames := range networks {
 		for _, networkName := range networkNames {
@@ -328,7 +328,7 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 					continue
 				}
 
-				resultMap = append(resultMap, net)
+				resultMap = append(resultMap, &net)
 				urlToNetwork[entity.NetworkURL(requestProjectName, networkName)] = &net
 			}
 		}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -185,7 +185,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	resultString := []string{}
-	resultMap := []api.StoragePool{}
+	resultMap := []*api.StoragePool{}
 	urlToPool := make(map[*api.URL]auth.EntitlementReporter)
 	for _, poolName := range poolNames {
 		// Hide storage pools with a 0 project limit.
@@ -225,7 +225,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 				poolAPI.Status = pool.LocalStatus()
 			}
 
-			resultMap = append(resultMap, poolAPI)
+			resultMap = append(resultMap, &poolAPI)
 			urlToPool[entity.StoragePoolURL(poolName)] = &poolAPI
 		}
 	}

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -174,6 +174,11 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 		return response.SmartError(err)
 	}
 
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeStorageVolumeBackup, true)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Check that the storage volume type is valid.
 	if details.volumeType != cluster.StoragePoolVolumeTypeCustom {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", details.volumeTypeName))
@@ -205,6 +210,7 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 
 	resultString := []string{}
 	resultMap := []*api.StoragePoolVolumeBackup{}
+	urlToBackup := make(map[*api.URL]auth.EntitlementReporter)
 
 	canView, err := s.Authorizer.GetPermissionChecker(r.Context(), auth.EntitlementCanView, entity.TypeStorageVolumeBackup)
 	if err != nil {
@@ -228,11 +234,19 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 		} else {
 			render := backup.Render()
 			resultMap = append(resultMap, render)
+			urlToBackup[entity.StorageVolumeBackupURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, backupName)] = render
 		}
 	}
 
 	if !recursion {
 		return response.SyncResponse(true, resultString)
+	}
+
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeStorageVolumeBackup, withEntitlements, urlToBackup)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.SyncResponse(true, resultMap)
@@ -478,6 +492,11 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 		return response.SmartError(err)
 	}
 
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeStorageVolumeBackup, false)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Get backup name.
 	backupName, err := url.PathUnescape(mux.Vars(r)["backupName"])
 	if err != nil {
@@ -511,7 +530,15 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 		return response.SmartError(err)
 	}
 
-	return response.SyncResponse(true, backup.Render())
+	renderedBackup := backup.Render()
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeStorageVolumeBackup, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.StorageVolumeBackupURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, backupName): renderedBackup})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	return response.SyncResponse(true, renderedBackup)
 }
 
 // swagger:operation POST /1.0/storage-pools/{poolName}/volumes/{type}/{volumeName}/backups/{backupName} storage storage_pool_volumes_type_backup_post

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -356,6 +356,11 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 		return response.SmartError(err)
 	}
 
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeStorageVolumeSnapshot, true)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	recursion := util.IsRecursionRequest(r)
 
 	// Check that the storage volume type is valid.
@@ -393,6 +398,7 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 	// Prepare the response.
 	resultString := []string{}
 	resultMap := []*api.StorageVolumeSnapshot{}
+	urlToSnapshot := make(map[*api.URL]auth.EntitlementReporter)
 	for _, volume := range volumes {
 		_, snapshotName, _ := api.GetParentAndSnapshotName(volume.Name)
 
@@ -431,11 +437,19 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 			}
 
 			resultMap = append(resultMap, tmp)
+			urlToSnapshot[entity.StorageVolumeSnapshotURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, snapshotName)] = tmp
 		}
 	}
 
 	if !recursion {
 		return response.SyncResponse(true, resultString)
+	}
+
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeStorageVolumeSnapshot, withEntitlements, urlToSnapshot)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	return response.SyncResponse(true, resultMap)
@@ -608,6 +622,11 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 		return response.SmartError(err)
 	}
 
+	withEntitlements, err := extractEntitlementsFromQuery(r, entity.TypeStorageVolumeSnapshot, false)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Get the name of the storage volume.
 	snapshotName, err := url.PathUnescape(mux.Vars(r)["snapshotName"])
 	if err != nil {
@@ -652,7 +671,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 		return response.SmartError(err)
 	}
 
-	snapshot := api.StorageVolumeSnapshot{}
+	snapshot := &api.StorageVolumeSnapshot{}
 	snapshot.Config = dbVolume.Config
 	snapshot.Description = dbVolume.Description
 	snapshot.Name = snapshotName
@@ -660,8 +679,15 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	snapshot.ContentType = dbVolume.ContentType
 	snapshot.CreatedAt = dbVolume.CreatedAt
 
+	if len(withEntitlements) > 0 {
+		err = reportEntitlements(r.Context(), s.Authorizer, s.IdentityCache, entity.TypeStorageVolumeSnapshot, withEntitlements, map[*api.URL]auth.EntitlementReporter{entity.StorageVolumeSnapshotURL(request.ProjectParam(r), details.location, details.pool.Name(), details.volumeTypeName, details.volumeName, snapshotName): snapshot})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
 	etag := []any{snapshot.Description, expiry}
-	return response.SyncResponseETag(true, &snapshot, etag)
+	return response.SyncResponseETag(true, snapshot, etag)
 }
 
 // swagger:operation PUT /1.0/storage-pools/{poolName}/volumes/{type}/{volumeName}/snapshots/{snapshotName} storage storage_pool_volumes_type_snapshot_put

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -43,7 +43,7 @@ const (
 type WithEntitlements struct {
 	// AccessEntitlements represents the entitlements that are granted to the requesting user on the attached entity.
 	// Example: ["can_view", "can_edit"]
-	AccessEntitlements []string `json:"access_entitlements" yaml:"access_entitlements"`
+	AccessEntitlements []string `json:"access_entitlements,omitempty" yaml:"access_entitlements,omitempty"`
 }
 
 // ReportEntitlements adds entitlements to the identity.

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -309,6 +309,8 @@ type ImageAliasesEntryPut struct {
 //
 // swagger:model
 type ImageAliasesEntry struct {
+	WithEntitlements `yaml:",inline"`
+
 	// Alias name
 	// Example: ubuntu-24.04
 	Name string `json:"name" yaml:"name"`

--- a/shared/api/instance_backup.go
+++ b/shared/api/instance_backup.go
@@ -43,6 +43,8 @@ type InstanceBackupsPost struct {
 //
 // API extension: instances.
 type InstanceBackup struct {
+	WithEntitlements `yaml:",inline"`
+
 	// Backup name
 	// Example: backup0
 	Name string `json:"name" yaml:"name"`

--- a/shared/api/instance_snapshot.go
+++ b/shared/api/instance_snapshot.go
@@ -64,6 +64,8 @@ type InstanceSnapshotPut struct {
 //
 // API extension: instances.
 type InstanceSnapshot struct {
+	WithEntitlements `yaml:",inline"`
+
 	// Architecture name
 	// Example: x86_64
 	Architecture string `json:"architecture" yaml:"architecture"`

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -202,8 +202,9 @@ type ServerUntrusted struct {
 //
 // swagger:model
 type Server struct {
-	ServerPut       `yaml:",inline"`
-	ServerUntrusted `yaml:",inline"`
+	WithEntitlements `yaml:",inline"`
+	ServerPut        `yaml:",inline"`
+	ServerUntrusted  `yaml:",inline"`
 
 	// The current user username as seen by LXD
 	// Read only: true

--- a/shared/api/storage_pool_volume_backup.go
+++ b/shared/api/storage_pool_volume_backup.go
@@ -10,6 +10,8 @@ import (
 //
 // API extension: custom_volume_backup.
 type StoragePoolVolumeBackup struct {
+	WithEntitlements `yaml:",inline"`
+
 	// Backup name
 	// Example: backup0
 	Name string `json:"name" yaml:"name"`

--- a/shared/api/storage_pool_volume_snapshot.go
+++ b/shared/api/storage_pool_volume_snapshot.go
@@ -53,6 +53,8 @@ type StorageVolumeSnapshotPost struct {
 //
 // API extension: storage_api_volume_snapshots.
 type StorageVolumeSnapshot struct {
+	WithEntitlements `yaml:",inline"`
+
 	// Snapshot name
 	// Example: snap0
 	Name string `json:"name" yaml:"name"`

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -138,8 +138,7 @@ test_authorization() {
   lxc auth identity list --format csv | grep -Fq "tls,Client certificate,test-user,${tls_identity_fingerprint},test-group"
 
   # Test `lxc auth identity info`
-  expectedOIDCInfo='access_entitlements: []
-authentication_method: oidc
+  expectedOIDCInfo='authentication_method: oidc
 type: OIDC client
 id: test-user@example.com
 name: '"'"' '"'"'
@@ -153,8 +152,7 @@ fine_grained: true'
 
   [ "$(lxc auth identity info oidc:)" = "${expectedOIDCInfo}" ]
 
-  expectedTLSInfo="access_entitlements: []
-authentication_method: tls
+  expectedTLSInfo="authentication_method: tls
 type: Client certificate
 id: ${tls_identity_fingerprint}
 name: test-user


### PR DESCRIPTION
This should fix the issues discussed here: https://chat.canonical.com/canonical/pl/c3bjkis1g3nmbytao6q5gcaxuc

This also add entitlement enrichment for API entities that weren't added as part as https://github.com/canonical/lxd/pull/14748