### PR TITLE
Projects: Peform uplink quota validation in a single transaction

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4056,7 +4056,7 @@ This number of IPs can be consumed by networks, forwards and load balancers in t
 ```
 
 ```{config:option} limits.networks.uplink_ips.ipv6.NETWORK_NAME project-limits
-:shortdesc: "Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project"
+:shortdesc: "Quota of IPv6 addresses from a specified uplink network that can be used by entities in this project"
 :type: "string"
 Maximum number of IPv6 addresses that this project can consume from the specified uplink network.
 This number of IPs can be consumed by networks, forwards and load balancers in this project.

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -312,7 +312,7 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the configuration.
-	err = projectValidateConfig(s, project.Config, project.Name)
+	err = projectValidateConfig(s, project.Config)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -712,7 +712,7 @@ func projectChange(s *state.State, project *api.Project, req api.ProjectPut) res
 	}
 
 	// Validate the configuration.
-	err := projectValidateConfig(s, req.Config, project.Name)
+	err := projectValidateConfig(s, req.Config)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -1105,7 +1105,7 @@ func isEitherAllowOrBlockOrManaged(value string) error {
 // projectValidateConfig validates whether project config keys follow the expected format.
 // Any value checks that rely on the state of the database should be performed on AllowProjectUpdate,
 // so that we are performing these checks and updating the project in a single transaction.
-func projectValidateConfig(s *state.State, config map[string]string, projectName string) error {
+func projectValidateConfig(s *state.State, config map[string]string) error {
 	// Validate the project configuration.
 	projectConfigKeys := map[string]func(value string) error{
 		// lxdmeta:generate(entities=project; group=specific; key=backups.compression_algorithm)

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -980,54 +979,6 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	return response.SyncResponse(true, &state)
-}
-
-// uplinkIPLimitValidator returns a validator function for uplink IP limits.
-// The protocol argument specifies whether we should validate ipv4 or ipv6.
-func uplinkIPLimitValidator(s *state.State, projectName string, networkName string, protocol string) func(string) error {
-	return func(value string) error {
-		// Perform cheaper checks on the value first.
-		providedIPQuota, err := strconv.Atoi(value)
-		if err != nil {
-			return err
-		}
-
-		if providedIPQuota < 0 {
-			return fmt.Errorf("Value must be non-negative")
-		}
-
-		// The results for the quota we are not interested in will be ignored in the end, so
-		// here -1 is used to prevent the quota that is not relevant from stopping UplinkAddressQuotasExceeded
-		// from returning early.
-		IPV4AddressQuota := -1
-		IPV6AddressQuota := -1
-
-		if protocol == "ipv6" {
-			IPV6AddressQuota = providedIPQuota
-		}
-
-		if protocol == "ipv4" {
-			IPV4AddressQuota = providedIPQuota
-		}
-
-		// Check if the provided value is equal or lower to the number of uplink addresses currently in use
-		// on the provided project and in the specified network.
-		// We are only interested on the result for the desired protocol, the other will always come out as true.
-		err = s.DB.Cluster.Transaction(s.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
-			invalidIPV4Quota, invalidIPV6Quota, err := limits.UplinkAddressQuotasExceeded(ctx, tx, projectName, networkName, IPV4AddressQuota, IPV6AddressQuota)
-			if err != nil {
-				return err
-			}
-
-			if protocol == "ipv4" && invalidIPV4Quota || protocol == "ipv6" && invalidIPV6Quota {
-				return fmt.Errorf("Uplink %s limit %q is below current number of used uplink addresses", protocol, value)
-			}
-
-			return nil
-		})
-
-		return err
-	}
 }
 
 // Check if a project is empty.

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1512,7 +1512,7 @@ func projectValidateConfig(s *state.State, config map[string]string, projectName
 			// ---
 			//  type: string
 			//  shortdesc: Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project
-			projectConfigKeys["limits.networks.uplink_ips.ipv4."+networkName] = validate.Optional(uplinkIPLimitValidator(s, projectName, networkName, "ipv4"))
+			projectConfigKeys["limits.networks.uplink_ips.ipv4."+networkName] = validate.Optional(validate.IsUint32)
 
 			// lxdmeta:generate(entities=project; group=limits; key=limits.networks.uplink_ips.ipv6.NETWORK_NAME)
 			// Maximum number of IPv6 addresses that this project can consume from the specified uplink network.
@@ -1521,7 +1521,7 @@ func projectValidateConfig(s *state.State, config map[string]string, projectName
 			// ---
 			//  type: string
 			//  shortdesc: Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project
-			projectConfigKeys["limits.networks.uplink_ips.ipv6."+networkName] = validate.Optional(uplinkIPLimitValidator(s, projectName, networkName, "ipv6"))
+			projectConfigKeys["limits.networks.uplink_ips.ipv6."+networkName] = validate.Optional(validate.IsUint32)
 		}
 	}
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1471,7 +1471,7 @@ func projectValidateConfig(s *state.State, config map[string]string) error {
 			//
 			// ---
 			//  type: string
-			//  shortdesc: Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project
+			//  shortdesc: Quota of IPv6 addresses from a specified uplink network that can be used by entities in this project
 			projectConfigKeys["limits.networks.uplink_ips.ipv6."+networkName] = validate.Optional(validate.IsUint32)
 		}
 	}

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1102,6 +1102,9 @@ func isEitherAllowOrBlockOrManaged(value string) error {
 	return validate.Optional(validate.IsOneOf("block", "allow", "managed"))(value)
 }
 
+// projectValidateConfig validates whether project config keys follow the expected format.
+// Any value checks that rely on the state of the database should be performed on AllowProjectUpdate,
+// so that we are performing these checks and updating the project in a single transaction.
 func projectValidateConfig(s *state.State, config map[string]string, projectName string) error {
 	// Validate the project configuration.
 	projectConfigKeys := map[string]func(value string) error{

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -4613,7 +4613,7 @@
 					{
 						"limits.networks.uplink_ips.ipv6.NETWORK_NAME": {
 							"longdesc": "Maximum number of IPv6 addresses that this project can consume from the specified uplink network.\nThis number of IPs can be consumed by networks, forwards and load balancers in this project.\n",
-							"shortdesc": "Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project",
+							"shortdesc": "Quota of IPv6 addresses from a specified uplink network that can be used by entities in this project",
 							"type": "string"
 						}
 					},

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -843,7 +843,7 @@ func (n *common) projectUplinkIPQuotaAvailable(ctx context.Context, tx *db.Clust
 	var ipv6QuotaMet bool
 
 	// If limit-1 is exceeded, than that means we have no quota available.
-	ipv4QuotaMet, ipv6QuotaMet, err = limits.UplinkAddressQuotasExceeded(ctx, tx, p.Name, uplinkName, ipv4AddressLimit-1, ipv6AddressLimit-1)
+	ipv4QuotaMet, ipv6QuotaMet, err = limits.UplinkAddressQuotasExceeded(ctx, tx, p.Name, uplinkName, ipv4AddressLimit-1, ipv6AddressLimit-1, nil)
 	if err != nil {
 		return false, false, err
 	}


### PR DESCRIPTION
Moving the checks for uplink quotas to `AllowProjectUpdate` enables us to:
1- Be more aligned with our code standards;
2- Perform the check and update the quota values in a single transaction;
3- Be more efficient if setting many uplink quotas at once;