### PR TITLE
lxc: Ensure unset expiry date is nil for instance snapshots

### DIFF
--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -123,7 +122,7 @@ func (c *cmdSnapshot) run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.flagNoExpiry {
-		req.ExpiresAt = &time.Time{}
+		req.ExpiresAt = nil
 	}
 
 	op, err := d.CreateInstanceSnapshot(name, req)


### PR DESCRIPTION
To make the response for instance snapshots consistent with storage pool snapshots, the expiry date should be set to nil if no expiry is desired, instead of the default time value.

Closes https://github.com/canonical/lxd/issues/14538.