### PR TITLE
Storage: Newtype for Database Volume/Content types

### DIFF
--- a/lxd/db/cluster/storage_volume_type.go
+++ b/lxd/db/cluster/storage_volume_type.go
@@ -1,9 +1,21 @@
 package cluster
 
+import (
+	"errors"
+)
+
+// StoragePoolVolumeType records a volume's type in the database.
+//
+// # Type Safety
+// Funtions using this type should assume that a StoragePoolVolumeType is always
+// a valid value; i.e. that it is type safe. Use the parsing methods below when
+// converting to StoragePoolVolumeType.
+type StoragePoolVolumeType int
+
 // XXX: this was extracted from lxd/storage_volume_utils.go, we find a way to
 // factor it independently from both the db and main packages.
 const (
-	StoragePoolVolumeTypeContainer = iota
+	StoragePoolVolumeTypeContainer StoragePoolVolumeType = iota
 	StoragePoolVolumeTypeImage
 	StoragePoolVolumeTypeCustom
 	StoragePoolVolumeTypeVM
@@ -19,12 +31,50 @@ const (
 	StoragePoolVolumeTypeNameCustom    string = "custom"
 )
 
-// StoragePoolVolumeTypeNames represents a map of storage volume types and their names.
-var StoragePoolVolumeTypeNames = map[int]string{
-	StoragePoolVolumeTypeContainer: "container",
-	StoragePoolVolumeTypeImage:     "image",
-	StoragePoolVolumeTypeCustom:    "custom",
-	StoragePoolVolumeTypeVM:        "virtual-machine",
+// StoragePoolVolumeTypeFromInt is a checked conversion to StoragePoolVolumeType.
+func StoragePoolVolumeTypeFromInt(volType int) (StoragePoolVolumeType, error) {
+	switch StoragePoolVolumeType(volType) {
+	case StoragePoolVolumeTypeContainer, StoragePoolVolumeTypeVM, StoragePoolVolumeTypeCustom, StoragePoolVolumeTypeImage:
+		return StoragePoolVolumeType(volType), nil
+	default:
+		return StoragePoolVolumeType(volType), errors.New("Invalid storage volume type")
+	}
+}
+
+// StoragePoolVolumeTypeFromName is a checked conversion to StoragePoolVolumeType.
+func StoragePoolVolumeTypeFromName(volTypeName string) (StoragePoolVolumeType, error) {
+	switch volTypeName {
+	case StoragePoolVolumeTypeNameContainer:
+		return StoragePoolVolumeTypeContainer, nil
+	case StoragePoolVolumeTypeNameVM:
+		return StoragePoolVolumeTypeVM, nil
+	case StoragePoolVolumeTypeNameImage:
+		return StoragePoolVolumeTypeImage, nil
+	case StoragePoolVolumeTypeNameCustom:
+		return StoragePoolVolumeTypeCustom, nil
+	}
+
+	return StoragePoolVolumeTypeCustom, errors.New("Invalid storage volume type")
+}
+
+// Name gives the name of a StoragePoolVolumeType.
+//
+// # Safety
+// This function assumes that `t` is one of the StoragePoolVolumeType enums
+// defined above.
+func (t StoragePoolVolumeType) Name() string {
+	switch t {
+	case StoragePoolVolumeTypeContainer:
+		return StoragePoolVolumeTypeNameContainer
+	case StoragePoolVolumeTypeVM:
+		return StoragePoolVolumeTypeNameVM
+	case StoragePoolVolumeTypeImage:
+		return StoragePoolVolumeTypeNameImage
+	case StoragePoolVolumeTypeCustom:
+		return StoragePoolVolumeTypeNameCustom
+	}
+
+	return StoragePoolVolumeTypeNameCustom
 }
 
 // Content types.

--- a/lxd/db/cluster/storage_volume_type.go
+++ b/lxd/db/cluster/storage_volume_type.go
@@ -77,9 +77,17 @@ func (t StoragePoolVolumeType) Name() string {
 	return StoragePoolVolumeTypeNameCustom
 }
 
+// StoragePoolVolumeContentType records a volume's content-type in the database.
+//
+// # Type Safety
+// Funtions using this type should assume that a StoragePoolVolumeContentType
+// is always a valid value; i.e. that it is type safe. Use the parsing methods
+// below when converting to StoragePoolVolumeContentType.
+type StoragePoolVolumeContentType int
+
 // Content types.
 const (
-	StoragePoolVolumeContentTypeFS = iota
+	StoragePoolVolumeContentTypeFS StoragePoolVolumeContentType = iota
 	StoragePoolVolumeContentTypeBlock
 	StoragePoolVolumeContentTypeISO
 )
@@ -90,3 +98,45 @@ const (
 	StoragePoolVolumeContentTypeNameBlock string = "block"
 	StoragePoolVolumeContentTypeNameISO   string = "iso"
 )
+
+// StoragePoolVolumeContentTypeFromInt is a checked conversion to StoragePoolVolumeContentType.
+func StoragePoolVolumeContentTypeFromInt(contentType int) (StoragePoolVolumeContentType, error) {
+	switch StoragePoolVolumeContentType(contentType) {
+	case StoragePoolVolumeContentTypeFS, StoragePoolVolumeContentTypeBlock, StoragePoolVolumeContentTypeISO:
+		return StoragePoolVolumeContentType(contentType), nil
+	default:
+		return StoragePoolVolumeContentType(contentType), errors.New("Invalid storage volume content type ID")
+	}
+}
+
+// StoragePoolVolumeContentTypeFromName is a checked conversion to StoragePoolVolumeContentType.
+func StoragePoolVolumeContentTypeFromName(contentTypeName string) (StoragePoolVolumeContentType, error) {
+	switch contentTypeName {
+	case StoragePoolVolumeContentTypeNameFS:
+		return StoragePoolVolumeContentTypeFS, nil
+	case StoragePoolVolumeContentTypeNameBlock:
+		return StoragePoolVolumeContentTypeBlock, nil
+	case StoragePoolVolumeContentTypeNameISO:
+		return StoragePoolVolumeContentTypeISO, nil
+	}
+
+	return StoragePoolVolumeContentTypeFS, errors.New("Invalid volume content type name")
+}
+
+// Name gives the name of a StoragePoolVolumeContentType.
+//
+// # Safety
+// This function assumes that `t` is one of the StoragePoolVolumeContentType
+// enums defined above.
+func (t StoragePoolVolumeContentType) Name() string {
+	switch t {
+	case StoragePoolVolumeContentTypeFS:
+		return StoragePoolVolumeContentTypeNameFS
+	case StoragePoolVolumeContentTypeBlock:
+		return StoragePoolVolumeContentTypeNameBlock
+	case StoragePoolVolumeContentTypeISO:
+		return StoragePoolVolumeContentTypeNameISO
+	}
+
+	return StoragePoolVolumeContentTypeNameFS
+}

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -666,7 +666,7 @@ func (c *ClusterTx) InstancesToInstanceArgs(ctx context.Context, fillProfiles bo
 
 // UpdateInstanceNode changes the name of an instance and the cluster member hosting it.
 // It's meant to be used when moving a non-running instance backed by ceph from one cluster node to another.
-func (c *ClusterTx) UpdateInstanceNode(ctx context.Context, project string, oldName string, newName string, newMemberName string, poolID int64, volumeType int) error {
+func (c *ClusterTx) UpdateInstanceNode(ctx context.Context, project string, oldName string, newName string, newMemberName string, poolID int64, volumeType cluster.StoragePoolVolumeType) error {
 	// Update the name of the instance and its snapshots, and the member ID they are associated with.
 	instanceID, err := cluster.GetInstanceID(ctx, c.tx, project, oldName)
 	if err != nil {

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -198,7 +198,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	getStoragePoolVolume := func(volumeProjectName string, volumeName string, volumeType int, poolID int64) (*db.StorageVolume, error) {
+	getStoragePoolVolume := func(volumeProjectName string, volumeName string, volumeType cluster.StoragePoolVolumeType, poolID int64) (*db.StorageVolume, error) {
 		var dbVolume *db.StorageVolume
 		err = clusterDB.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			dbVolume, err = tx.GetStoragePoolVolume(context.Background(), poolID, volumeProjectName, volumeType, volumeName, true)

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -92,6 +92,7 @@ func (c *ClusterTx) UpdateStorageVolumeSnapshot(ctx context.Context, projectName
 // GetStorageVolumeSnapshotWithID returns the volume snapshot with the given ID.
 func (c *ClusterTx) GetStorageVolumeSnapshotWithID(ctx context.Context, snapshotID int) (StorageVolumeArgs, error) {
 	args := StorageVolumeArgs{}
+	rawVolumeType := int(-1)
 	q := `
 SELECT
 	volumes.id,
@@ -106,7 +107,7 @@ JOIN storage_pools ON storage_pools.id=volumes.storage_pool_id
 WHERE volumes.id=?
 `
 	arg1 := []any{snapshotID}
-	outfmt := []any{&args.ID, &args.Name, &args.CreationDate, &args.PoolName, &args.Type, &args.ProjectName}
+	outfmt := []any{&args.ID, &args.Name, &args.CreationDate, &args.PoolName, &rawVolumeType, &args.ProjectName}
 
 	err := dbQueryRowScan(ctx, c, q, arg1, outfmt)
 	if err != nil {
@@ -121,7 +122,12 @@ WHERE volumes.id=?
 		return args, fmt.Errorf("Volume is not a snapshot")
 	}
 
-	args.TypeName = cluster.StoragePoolVolumeTypeNames[args.Type]
+	args.Type, err = cluster.StoragePoolVolumeTypeFromInt(rawVolumeType)
+	if err != nil {
+		return StorageVolumeArgs{}, err
+	}
+
+	args.TypeName = args.Type.Name()
 
 	return args, nil
 }

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -18,7 +18,7 @@ import (
 
 // CreateStorageVolumeSnapshot creates a new storage volume snapshot attached to a given
 // storage pool.
-func (c *ClusterTx) CreateStorageVolumeSnapshot(ctx context.Context, projectName string, volumeName string, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string, creationDate time.Time, expiryDate time.Time) (int64, error) {
+func (c *ClusterTx) CreateStorageVolumeSnapshot(ctx context.Context, projectName string, volumeName string, volumeDescription string, volumeType cluster.StoragePoolVolumeType, poolID int64, volumeConfig map[string]string, creationDate time.Time, expiryDate time.Time) (int64, error) {
 	var volumeID int64
 
 	volumeName, snapshotName, _ := strings.Cut(volumeName, shared.SnapshotDelimiter)
@@ -54,7 +54,7 @@ func (c *ClusterTx) CreateStorageVolumeSnapshot(ctx context.Context, projectName
 }
 
 // UpdateStorageVolumeSnapshot updates the storage volume snapshot attached to a given storage pool.
-func (c *ClusterTx) UpdateStorageVolumeSnapshot(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string, expiryDate time.Time) error {
+func (c *ClusterTx) UpdateStorageVolumeSnapshot(ctx context.Context, projectName string, volumeName string, volumeType cluster.StoragePoolVolumeType, poolID int64, volumeDescription string, volumeConfig map[string]string, expiryDate time.Time) error {
 	var err error
 
 	if !strings.Contains(volumeName, shared.SnapshotDelimiter) {

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -459,7 +459,7 @@ func (c *ClusterTx) RenameStoragePoolVolume(ctx context.Context, projectName str
 }
 
 // CreateStoragePoolVolume creates a new storage volume attached to a given storage pool.
-func (c *ClusterTx) CreateStoragePoolVolume(ctx context.Context, projectName string, volumeName string, volumeDescription string, volumeType cluster.StoragePoolVolumeType, poolID int64, volumeConfig map[string]string, contentType int, creationDate time.Time) (int64, error) {
+func (c *ClusterTx) CreateStoragePoolVolume(ctx context.Context, projectName string, volumeName string, volumeDescription string, volumeType cluster.StoragePoolVolumeType, poolID int64, volumeConfig map[string]string, contentType cluster.StoragePoolVolumeContentType, creationDate time.Time) (int64, error) {
 	var volumeID int64
 
 	if shared.IsSnapshot(volumeName) {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -165,10 +165,7 @@ func (d *disk) sourceVolumeFields() (volumeName string, volumeType storageDriver
 		return volumeName, volumeType, dbVolumeType, volumeTypeName, err
 	}
 
-	volumeType, err = storagePools.VolumeDBTypeToType(dbVolumeType)
-	if err != nil {
-		return volumeName, volumeType, dbVolumeType, volumeTypeName, err
-	}
+	volumeType = storagePools.VolumeDBTypeToType(dbVolumeType)
 
 	return volumeName, volumeType, dbVolumeType, volumeTypeName, nil
 }
@@ -1199,10 +1196,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						clusterName = storageDrivers.CephDefaultUser
 					}
 
-					contentType, err := storagePools.VolumeDBContentTypeToContentType(dbContentType)
-					if err != nil {
-						return nil, err
-					}
+					contentType := storagePools.VolumeDBContentTypeToContentType(dbContentType)
 
 					projectStorageVolumeName := project.StorageVolume(d.inst.Project().Name, volumeName)
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1174,7 +1174,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					return nil, fmt.Errorf("Failed loading custom volume: %w", err)
 				}
 
-				dbContentType, err := storagePools.VolumeContentTypeNameToContentType(dbVolume.ContentType)
+				dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(dbVolume.ContentType)
 				if err != nil {
 					return nil, err
 				}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -148,7 +148,7 @@ func (d *disk) sourceIsLocalPath(source string) bool {
 	return true
 }
 
-func (d *disk) sourceVolumeFields() (volumeName string, volumeType storageDrivers.VolumeType, dbVolumeType int, volumeTypeName string, err error) {
+func (d *disk) sourceVolumeFields() (volumeName string, volumeType storageDrivers.VolumeType, dbVolumeType cluster.StoragePoolVolumeType, volumeTypeName string, err error) {
 	volumeName = d.config["source"]
 
 	if d.config["source.snapshot"] != "" {
@@ -160,7 +160,7 @@ func (d *disk) sourceVolumeFields() (volumeName string, volumeType storageDriver
 		volumeTypeName = d.config["source.type"]
 	}
 
-	dbVolumeType, err = storagePools.VolumeTypeNameToDBType(volumeTypeName)
+	dbVolumeType, err = cluster.StoragePoolVolumeTypeFromName(volumeTypeName)
 	if err != nil {
 		return volumeName, volumeType, dbVolumeType, volumeTypeName, err
 	}
@@ -1945,7 +1945,7 @@ func (d *disk) localSourceOpen(srcPath string) (*os.File, error) {
 	return f, nil
 }
 
-func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName string, volumeType int, remapPath string) error {
+func (d *disk) storagePoolVolumeAttachShift(projectName, poolName, volumeName string, volumeType cluster.StoragePoolVolumeType, remapPath string) error {
 	var err error
 	var dbVolume *db.StorageVolume
 	err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5356,7 +5356,7 @@ func allowRemoveSecurityProtectionStart(state *state.State, poolName string, vol
 		return err
 	})
 	if err != nil {
-		volumeTypeName := dbCluster.StoragePoolVolumeTypeNames[volumeType]
+		volumeTypeName := volumeType.Name()
 		return fmt.Errorf(`Failed loading "%s/%s" from project %q: %w`, volumeTypeName, volumeName, volumeProject, err)
 	}
 

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -182,7 +182,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	suite.Req.Nil(err)
 
 	err = state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		_, err = tx.CreateStoragePoolVolume(ctx, c.Project().Name, c.Name(), "", cluster.StoragePoolVolumeContentTypeFS, pool.ID(), nil, cluster.StoragePoolVolumeContentTypeFS, time.Now())
+		_, err = tx.CreateStoragePoolVolume(ctx, c.Project().Name, c.Name(), "", cluster.StoragePoolVolumeTypeContainer, pool.ID(), nil, cluster.StoragePoolVolumeContentTypeFS, time.Now())
 
 		return err
 	})

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -10,6 +10,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/migration"
 	"github.com/canonical/lxd/lxd/operations"
 	"github.com/canonical/lxd/lxd/state"
@@ -282,7 +283,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		return err
 	}
 
-	dbContentType, err := storagePools.VolumeContentTypeNameToContentType(req.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(req.ContentType)
 	if err != nil {
 		return err
 	}

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -288,10 +288,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 		return err
 	}
 
-	contentType, err := storagePools.VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := storagePools.VolumeDBContentTypeToContentType(dbContentType)
 
 	// The source/sender will never set Refresh. However, to determine the correct migration type
 	// Refresh needs to be set.

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -198,7 +199,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 
 	if !msg.GetSuccess() {
 		logger.Errorf("Failed to send storage volume")
-		return fmt.Errorf(msg.GetMessage())
+		return errors.New(msg.GetMessage())
 	}
 
 	logger.Debugf("Migration source finished transferring storage volume")
@@ -478,7 +479,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			if !msg.GetSuccess() {
 				c.disconnect()
 
-				return fmt.Errorf(msg.GetMessage())
+				return errors.New(msg.GetMessage())
 			}
 
 			// The source can only tell us it failed (e.g. if

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1008,7 +1008,7 @@ func patchStorageZfsUnsetInvalidBlockSettingsV2(_ string, d *Daemon) error {
 		return err
 	}
 
-	var volType int
+	var volType dbCluster.StoragePoolVolumeType
 
 	for pool, volumes := range poolVolumes {
 		for _, vol := range volumes {

--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -110,7 +110,7 @@ func StorageVolumeParts(projectStorageVolumeName string) (projectName string, st
 // For custom volume type, if the project specified has the "features.storage.volumes" flag enabled then the
 // project name is returned, otherwise the default project name is returned.
 // For all other volume types the supplied project name is returned.
-func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (string, error) {
+func StorageVolumeProject(c *db.Cluster, projectName string, volumeType cluster.StoragePoolVolumeType) (string, error) {
 	// Image volumes are effectively a cache and so are always linked to default project.
 	// Optimisation to avoid loading project record.
 	if volumeType == cluster.StoragePoolVolumeTypeImage {
@@ -140,7 +140,7 @@ func StorageVolumeProject(c *db.Cluster, projectName string, volumeType int) (st
 // For custom volume type, if the project supplied has the "features.storage.volumes" flag enabled then the
 // project name is returned, otherwise the default project name is returned.
 // For all other volume types the supplied project's name is returned.
-func StorageVolumeProjectFromRecord(p *api.Project, volumeType int) string {
+func StorageVolumeProjectFromRecord(p *api.Project, volumeType cluster.StoragePoolVolumeType) string {
 	// Image volumes are effectively a cache and so are always linked to default project.
 	if volumeType == cluster.StoragePoolVolumeTypeImage {
 		return api.ProjectDefaultName

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1300,10 +1300,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	}
 
 	// Get the source volume's content type.
-	contentType, err := VolumeDBContentTypeToContentType(contentDBType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(contentDBType)
 
 	if contentType != drivers.ContentTypeFS && contentType != drivers.ContentTypeBlock {
 		return fmt.Errorf("Volume of content type %q cannot be refreshed", contentType)
@@ -4340,10 +4337,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	vol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, imgDBVol.Config)
 
@@ -4407,10 +4401,7 @@ func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName str
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	// Validate config.
 	vol := b.GetVolume(drivers.VolumeType(curVol.Type), contentType, volName, newConfig)
@@ -5355,10 +5346,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	}
 
 	// Get the source volume's content type.
-	contentType, err := VolumeDBContentTypeToContentType(contentDBType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(contentDBType)
 
 	storagePoolSupported := false
 	for _, supportedType := range b.Driver().Info().VolumeTypes {
@@ -5676,10 +5664,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	if args.Info == nil {
 		return fmt.Errorf("Migration info required")
@@ -6107,10 +6092,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	// Validate config.
 	newVol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, newConfig)
@@ -6286,10 +6268,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, curVol.Config)
 
@@ -6545,10 +6524,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(volDBContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(volDBContentType)
 
 	if contentType != drivers.ContentTypeFS && contentType != drivers.ContentTypeBlock {
 		return fmt.Errorf("Volume of content type %q does not support snapshots", contentType)
@@ -6680,10 +6656,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
@@ -6768,10 +6741,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(dbContentType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(dbContentType)
 
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
@@ -7241,10 +7211,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		return fmt.Errorf("Failed checking instance volume type for instance %q in project %q: %w", instName, projectName, err)
 	}
 
-	instVolType, err := VolumeDBTypeToType(instVolDBType)
-	if err != nil {
-		return fmt.Errorf("Failed checking instance volume type for instance %q in project %q: %w", instName, projectName, err)
-	}
+	instVolType := VolumeDBTypeToType(instVolDBType)
 
 	if volType != instVolType {
 		return fmt.Errorf("Instance %q in project %q has a different volume type in its backup file (%q)", instName, projectName, backupConf.Volume.Type)
@@ -7638,10 +7605,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 		return err
 	}
 
-	contentType, err := VolumeDBContentTypeToContentType(contentDBType)
-	if err != nil {
-		return err
-	}
+	contentType := VolumeDBContentTypeToContentType(contentDBType)
 
 	if contentType != drivers.ContentTypeFS && contentType != drivers.ContentTypeBlock {
 		return fmt.Errorf("Volume of content type %q cannot be backed up", contentType)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1294,7 +1294,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		desc = srcConfig.Volume.Description
 	}
 
-	contentDBType, err := VolumeContentTypeNameToContentType(srcConfig.Volume.ContentType)
+	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(srcConfig.Volume.ContentType)
 	if err != nil {
 		return err
 	}
@@ -4335,7 +4335,7 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 	}
 
 	// Get the content type.
-	dbContentType, err := VolumeContentTypeNameToContentType(imgDBVol.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(imgDBVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -4402,7 +4402,7 @@ func (b *lxdBackend) updateVolumeDescriptionOnly(projectName string, volName str
 	}
 
 	// Get content type.
-	dbContentType, err := VolumeContentTypeNameToContentType(curVol.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(curVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -5349,7 +5349,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		desc = srcConfig.Volume.Description
 	}
 
-	contentDBType, err := VolumeContentTypeNameToContentType(srcConfig.Volume.ContentType)
+	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(srcConfig.Volume.ContentType)
 	if err != nil {
 		return err
 	}
@@ -5671,7 +5671,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, args.Name)
 
-	dbContentType, err := VolumeContentTypeNameToContentType(args.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(args.ContentType)
 	if err != nil {
 		return err
 	}
@@ -6102,7 +6102,7 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 	}
 
 	// Get content type.
-	dbContentType, err := VolumeContentTypeNameToContentType(curVol.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(curVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -6281,7 +6281,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Get the content type.
-	dbContentType, err := VolumeContentTypeNameToContentType(curVol.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(curVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -6540,7 +6540,7 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 		return err
 	}
 
-	volDBContentType, err := VolumeContentTypeNameToContentType(parentVol.ContentType)
+	volDBContentType, err := cluster.StoragePoolVolumeContentTypeFromName(parentVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -6675,7 +6675,7 @@ func (b *lxdBackend) DeleteCustomVolumeSnapshot(projectName, volName string, op 
 	}
 
 	// Get the content type.
-	dbContentType, err := VolumeContentTypeNameToContentType(volume.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(volume.ContentType)
 	if err != nil {
 		return err
 	}
@@ -6763,7 +6763,7 @@ func (b *lxdBackend) RestoreCustomVolume(projectName, volName string, snapshotNa
 		return err
 	}
 
-	dbContentType, err := VolumeContentTypeNameToContentType(curVol.ContentType)
+	dbContentType, err := cluster.StoragePoolVolumeContentTypeFromName(curVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -7633,7 +7633,7 @@ func (b *lxdBackend) BackupCustomVolume(projectName string, volName string, tarW
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volume.Name)
 
-	contentDBType, err := VolumeContentTypeNameToContentType(volume.ContentType)
+	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(volume.ContentType)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7236,7 +7236,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		return fmt.Errorf("Instance %q in project %q has a different volume name in its backup file (%q)", instName, projectName, backupConf.Volume.Name)
 	}
 
-	instVolDBType, err := VolumeTypeNameToDBType(backupConf.Volume.Type)
+	instVolDBType, err := cluster.StoragePoolVolumeTypeFromName(backupConf.Volume.Type)
 	if err != nil {
 		return fmt.Errorf("Failed checking instance volume type for instance %q in project %q: %w", instName, projectName, err)
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -144,7 +144,7 @@ func VolumeTypeToAPIInstanceType(volType drivers.VolumeType) (api.InstanceType, 
 }
 
 // VolumeContentTypeToDBContentType converts volume type to internal code.
-func VolumeContentTypeToDBContentType(contentType drivers.ContentType) (int, error) {
+func VolumeContentTypeToDBContentType(contentType drivers.ContentType) (cluster.StoragePoolVolumeContentType, error) {
 	switch contentType {
 	case drivers.ContentTypeBlock:
 		return cluster.StoragePoolVolumeContentTypeBlock, nil
@@ -158,7 +158,7 @@ func VolumeContentTypeToDBContentType(contentType drivers.ContentType) (int, err
 }
 
 // VolumeDBContentTypeToContentType converts internal content type DB code to driver representation.
-func VolumeDBContentTypeToContentType(volDBType int) (drivers.ContentType, error) {
+func VolumeDBContentTypeToContentType(volDBType cluster.StoragePoolVolumeContentType) (drivers.ContentType, error) {
 	switch volDBType {
 	case cluster.StoragePoolVolumeContentTypeBlock:
 		return drivers.ContentTypeBlock, nil
@@ -172,7 +172,7 @@ func VolumeDBContentTypeToContentType(volDBType int) (drivers.ContentType, error
 }
 
 // VolumeContentTypeNameToContentType converts volume content type string internal code.
-func VolumeContentTypeNameToContentType(contentTypeName string) (int, error) {
+func VolumeContentTypeNameToContentType(contentTypeName string) (cluster.StoragePoolVolumeContentType, error) {
 	switch contentTypeName {
 	case cluster.StoragePoolVolumeContentTypeNameFS:
 		return cluster.StoragePoolVolumeContentTypeFS, nil

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -155,20 +155,6 @@ func VolumeDBContentTypeToContentType(volDBType cluster.StoragePoolVolumeContent
 	return "", fmt.Errorf("Invalid volume content type")
 }
 
-// VolumeContentTypeNameToContentType converts volume content type string internal code.
-func VolumeContentTypeNameToContentType(contentTypeName string) (cluster.StoragePoolVolumeContentType, error) {
-	switch contentTypeName {
-	case cluster.StoragePoolVolumeContentTypeNameFS:
-		return cluster.StoragePoolVolumeContentTypeFS, nil
-	case cluster.StoragePoolVolumeContentTypeNameBlock:
-		return cluster.StoragePoolVolumeContentTypeBlock, nil
-	case cluster.StoragePoolVolumeContentTypeNameISO:
-		return cluster.StoragePoolVolumeContentTypeISO, nil
-	}
-
-	return -1, fmt.Errorf("Invalid volume content type name")
-}
-
 // VolumeDBGet loads a volume from the database.
 func VolumeDBGet(pool Pool, projectName string, volumeName string, volumeType drivers.VolumeType) (*db.StorageVolume, error) {
 	p, ok := pool.(*lxdBackend)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -88,19 +88,19 @@ func VolumeTypeToDBType(volType drivers.VolumeType) (cluster.StoragePoolVolumeTy
 }
 
 // VolumeDBTypeToType converts internal volume type DB code to storage driver volume type.
-func VolumeDBTypeToType(volDBType cluster.StoragePoolVolumeType) (drivers.VolumeType, error) {
+func VolumeDBTypeToType(volDBType cluster.StoragePoolVolumeType) drivers.VolumeType {
 	switch volDBType {
 	case cluster.StoragePoolVolumeTypeContainer:
-		return drivers.VolumeTypeContainer, nil
+		return drivers.VolumeTypeContainer
 	case cluster.StoragePoolVolumeTypeVM:
-		return drivers.VolumeTypeVM, nil
+		return drivers.VolumeTypeVM
 	case cluster.StoragePoolVolumeTypeImage:
-		return drivers.VolumeTypeImage, nil
+		return drivers.VolumeTypeImage
 	case cluster.StoragePoolVolumeTypeCustom:
-		return drivers.VolumeTypeCustom, nil
+		return drivers.VolumeTypeCustom
 	}
 
-	return "", fmt.Errorf("Invalid storage volume DB type: %d", volDBType)
+	return drivers.VolumeTypeCustom
 }
 
 // InstanceTypeToVolumeType converts instance type to storage driver volume type.
@@ -142,17 +142,17 @@ func VolumeContentTypeToDBContentType(contentType drivers.ContentType) (cluster.
 }
 
 // VolumeDBContentTypeToContentType converts internal content type DB code to driver representation.
-func VolumeDBContentTypeToContentType(volDBType cluster.StoragePoolVolumeContentType) (drivers.ContentType, error) {
+func VolumeDBContentTypeToContentType(volDBType cluster.StoragePoolVolumeContentType) drivers.ContentType {
 	switch volDBType {
 	case cluster.StoragePoolVolumeContentTypeBlock:
-		return drivers.ContentTypeBlock, nil
+		return drivers.ContentTypeBlock
 	case cluster.StoragePoolVolumeContentTypeFS:
-		return drivers.ContentTypeFS, nil
+		return drivers.ContentTypeFS
 	case cluster.StoragePoolVolumeContentTypeISO:
-		return drivers.ContentTypeISO, nil
+		return drivers.ContentTypeISO
 	}
 
-	return "", fmt.Errorf("Invalid volume content type")
+	return drivers.ContentTypeFS
 }
 
 // VolumeDBGet loads a volume from the database.
@@ -229,11 +229,7 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 		volumeConfig = map[string]string{}
 	}
 
-	volType, err := VolumeDBTypeToType(volDBType)
-	if err != nil {
-		return err
-	}
-
+	volType := VolumeDBTypeToType(volDBType)
 	vol := drivers.NewVolume(pool.Driver(), pool.Name(), volType, contentType, volumeName, volumeConfig, pool.Driver().Config())
 
 	// Set source indicator.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -72,7 +72,7 @@ func ConfigDiff(oldConfig map[string]string, newConfig map[string]string) ([]str
 }
 
 // VolumeTypeNameToDBType converts a volume type string to internal volume type DB code.
-func VolumeTypeNameToDBType(volumeTypeName string) (int, error) {
+func VolumeTypeNameToDBType(volumeTypeName string) (cluster.StoragePoolVolumeType, error) {
 	switch volumeTypeName {
 	case cluster.StoragePoolVolumeTypeNameContainer:
 		return cluster.StoragePoolVolumeTypeContainer, nil
@@ -88,7 +88,7 @@ func VolumeTypeNameToDBType(volumeTypeName string) (int, error) {
 }
 
 // VolumeTypeToDBType converts volume type to internal volume type DB code.
-func VolumeTypeToDBType(volType drivers.VolumeType) (int, error) {
+func VolumeTypeToDBType(volType drivers.VolumeType) (cluster.StoragePoolVolumeType, error) {
 	switch volType {
 	case drivers.VolumeTypeContainer:
 		return cluster.StoragePoolVolumeTypeContainer, nil
@@ -104,7 +104,7 @@ func VolumeTypeToDBType(volType drivers.VolumeType) (int, error) {
 }
 
 // VolumeDBTypeToType converts internal volume type DB code to storage driver volume type.
-func VolumeDBTypeToType(volDBType int) (drivers.VolumeType, error) {
+func VolumeDBTypeToType(volDBType cluster.StoragePoolVolumeType) (drivers.VolumeType, error) {
 	switch volDBType {
 	case cluster.StoragePoolVolumeTypeContainer:
 		return drivers.VolumeTypeContainer, nil
@@ -964,7 +964,7 @@ func volumeIsUsedByDevice(vol api.StorageVolume, inst *db.InstanceArgs, dev map[
 			return false, err
 		}
 
-		if inst.Name == vol.Name && cluster.StoragePoolVolumeTypeNames[rootVolumeDBType] == vol.Type {
+		if inst.Name == vol.Name && rootVolumeDBType.Name() == vol.Type {
 			return true, nil
 		}
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -71,22 +71,6 @@ func ConfigDiff(oldConfig map[string]string, newConfig map[string]string) ([]str
 	return changedConfig, userOnly
 }
 
-// VolumeTypeNameToDBType converts a volume type string to internal volume type DB code.
-func VolumeTypeNameToDBType(volumeTypeName string) (cluster.StoragePoolVolumeType, error) {
-	switch volumeTypeName {
-	case cluster.StoragePoolVolumeTypeNameContainer:
-		return cluster.StoragePoolVolumeTypeContainer, nil
-	case cluster.StoragePoolVolumeTypeNameVM:
-		return cluster.StoragePoolVolumeTypeVM, nil
-	case cluster.StoragePoolVolumeTypeNameImage:
-		return cluster.StoragePoolVolumeTypeImage, nil
-	case cluster.StoragePoolVolumeTypeNameCustom:
-		return cluster.StoragePoolVolumeTypeCustom, nil
-	}
-
-	return -1, fmt.Errorf("Invalid storage volume type name")
-}
-
 // VolumeTypeToDBType converts volume type to internal volume type DB code.
 func VolumeTypeToDBType(volType drivers.VolumeType) (cluster.StoragePoolVolumeType, error) {
 	switch volType {
@@ -999,7 +983,7 @@ func volumeIsUsedByDevice(vol api.StorageVolume, inst *db.InstanceArgs, dev map[
 // the volume.
 func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, profileFunc func(profileID int64, profile api.Profile, project api.Project, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
-	volumeType, err := VolumeTypeNameToDBType(vol.Type)
+	volumeType, err := cluster.StoragePoolVolumeTypeFromName(vol.Type)
 	if err != nil {
 		return err
 	}
@@ -1106,7 +1090,7 @@ func VolumeUsedByProfileDevices(s *state.State, poolName string, projectName str
 // names that are using the volume.
 func VolumeUsedByInstanceDevices(s *state.State, poolName string, projectName string, vol *api.StorageVolume, expandDevices bool, instanceFunc func(inst db.InstanceArgs, project api.Project, usedByDevices []string) error) error {
 	// Convert the volume type name to our internal integer representation.
-	volumeType, err := VolumeTypeNameToDBType(vol.Type)
+	volumeType, err := cluster.StoragePoolVolumeTypeFromName(vol.Type)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1031,7 +1031,7 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 		req.ContentType = cluster.StoragePoolVolumeContentTypeNameFS
 	}
 
-	_, err = storagePools.VolumeContentTypeNameToContentType(req.ContentType)
+	_, err = cluster.StoragePoolVolumeContentTypeFromName(req.ContentType)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -1229,7 +1229,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		}
 	}
 
-	volumeDBContentType, err := storagePools.VolumeContentTypeNameToContentType(req.ContentType)
+	volumeDBContentType, err := cluster.StoragePoolVolumeContentTypeFromName(req.ContentType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -641,7 +641,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	// Convert volume type name to internal integer representation if requested.
 	var volumeType cluster.StoragePoolVolumeType
 	if volumeTypeName != "" {
-		volumeType, err = storagePools.VolumeTypeNameToDBType(volumeTypeName)
+		volumeType, err = cluster.StoragePoolVolumeTypeFromName(volumeTypeName)
 		if err != nil {
 			return response.BadRequest(err)
 		}
@@ -2756,7 +2756,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 	details.volumeTypeName = volumeTypeName
 
 	// Convert the volume type name to our internal integer representation.
-	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
+	volumeType, err := cluster.StoragePoolVolumeTypeFromName(volumeTypeName)
 	if err != nil {
 		return api.StatusErrorf(http.StatusBadRequest, "Failed to get storage volume type: %w", err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -639,7 +639,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Convert volume type name to internal integer representation if requested.
-	var volumeType int
+	var volumeType cluster.StoragePoolVolumeType
 	if volumeTypeName != "" {
 		volumeType, err = storagePools.VolumeTypeNameToDBType(volumeTypeName)
 		if err != nil {
@@ -2703,7 +2703,7 @@ const ctxStorageVolumeDetails request.CtxKey = "storage-volume-details"
 type storageVolumeDetails struct {
 	volumeName         string
 	volumeTypeName     string
-	volumeType         int
+	volumeType         cluster.StoragePoolVolumeType
 	location           string
 	pool               storagePools.Pool
 	forwardingNodeInfo *db.NodeInfo
@@ -2822,7 +2822,7 @@ func addStoragePoolVolumeDetailsToRequestContext(s *state.State, r *http.Request
 // the local cluster member it returns nil and no error. If it is another cluster member it returns a db.NodeInfo containing
 // the name and address of the remote member. If there is more than one cluster member with a matching volume name, an
 // error is returned.
-func getRemoteVolumeNodeInfo(ctx context.Context, s *state.State, poolName string, projectName string, volumeName string, volumeType int) (*db.NodeInfo, error) {
+func getRemoteVolumeNodeInfo(ctx context.Context, s *state.State, poolName string, projectName string, volumeName string, volumeType cluster.StoragePoolVolumeType) (*db.NodeInfo, error) {
 	localNodeID := s.DB.Cluster.GetNodeID()
 	var err error
 	var nodes []db.NodeInfo

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1234,10 +1234,7 @@ func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName st
 		return response.SmartError(err)
 	}
 
-	contentType, err := storagePools.VolumeDBContentTypeToContentType(volumeDBContentType)
-	if err != nil {
-		return response.SmartError(err)
-	}
+	contentType := storagePools.VolumeDBContentTypeToContentType(volumeDBContentType)
 
 	run := func(op *operations.Operation) error {
 		if req.Source.Name == "" {

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -883,7 +883,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 	return doStoragePoolVolumeSnapshotUpdate(s, r, effectiveProjectName, dbVolume.Name, details.volumeType, req)
 }
 
-func doStoragePoolVolumeSnapshotUpdate(s *state.State, r *http.Request, projectName string, volName string, volumeType int, req api.StorageVolumeSnapshotPut) response.Response {
+func doStoragePoolVolumeSnapshotUpdate(s *state.State, r *http.Request, projectName string, volName string, volumeType dbCluster.StoragePoolVolumeType, req api.StorageVolumeSnapshotPut) response.Response {
 	expiry := time.Time{}
 	if req.ExpiresAt != nil {
 		expiry = *req.ExpiresAt

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -95,7 +95,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Convert the volume type name to our internal integer representation.
-	volumeType, err := storagePools.VolumeTypeNameToDBType(volumeTypeName)
+	volumeType, err := cluster.StoragePoolVolumeTypeFromName(volumeTypeName)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -101,7 +101,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Check that the storage volume type is valid.
-	if !shared.ValueInSlice(volumeType, []int{cluster.StoragePoolVolumeTypeCustom, cluster.StoragePoolVolumeTypeContainer, cluster.StoragePoolVolumeTypeVM}) {
+	if !shared.ValueInSlice(volumeType, []cluster.StoragePoolVolumeType{cluster.StoragePoolVolumeTypeCustom, cluster.StoragePoolVolumeTypeContainer, cluster.StoragePoolVolumeTypeVM}) {
 		return response.BadRequest(fmt.Errorf("Invalid storage volume type %q", volumeTypeName))
 	}
 

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -18,7 +18,7 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
-var supportedVolumeTypes = []int{cluster.StoragePoolVolumeTypeContainer, cluster.StoragePoolVolumeTypeVM, cluster.StoragePoolVolumeTypeCustom, cluster.StoragePoolVolumeTypeImage}
+var supportedVolumeTypes = []cluster.StoragePoolVolumeType{cluster.StoragePoolVolumeTypeContainer, cluster.StoragePoolVolumeTypeVM, cluster.StoragePoolVolumeTypeCustom, cluster.StoragePoolVolumeTypeImage}
 
 func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolName string, oldVol *api.StorageVolume, newPoolName string, newVol *api.StorageVolume) (revert.Hook, error) {
 	revert := revert.New()


### PR DESCRIPTION
This:
- Communicates intent via a variable's type, not just its name
- Prevents accidental assignment of e.g. a volume type where a content type was expected
- Enforces the type safety at the database boundary; any type IDs coming out of the database layer can be assumed to be correct
- Provides convenient conversions using `Name()`