### PR TITLE
OIDC: Add additional scopes

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2599,3 +2599,9 @@ The following pool level configuration keys have been added:
 1. {config:option}`storage-pure-pool-conf:pure.api.token`
 1. {config:option}`storage-pure-pool-conf:pure.mode`
 1. {config:option}`storage-pure-pool-conf:pure.target`
+
+## `oidc_additional_scopes`
+
+This API extension enables setting an {config:option}`server-oidc:oidc.additional_scopes` configuration key.
+This configuration option can be used to request additional scopes that might be required for retrieving {ref}`identity provider groups <identity-provider-groups>` from the identity provider.
+Additionally, the optional scopes `profile` and `offline_access` can be unset via this setting.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4825,6 +4825,19 @@ Specify the volume using the syntax `POOL/VOLUME`.
 
 <!-- config group server-miscellaneous end -->
 <!-- config group server-oidc start -->
+```{config:option} oidc.additional_scopes server-oidc
+:defaultdesc: "`profile offline_access`"
+:scope: "global"
+:shortdesc: "Additional scopes to be requested during OIDC flows."
+:type: "space-delimited string list"
+Specify additional scopes to be requested when performing OIDC flows.
+Additional scopes might be required if managing access control in the Identity Provider (see {ref}`identity-provider-groups`).
+The default value for this configuration option contains two scopes which are optional, but will degrade LXD OIDC functionality if removed.
+These are:
+  - `profile`: This is requested by LXD to present display names for the identification of end users. If it is removed, only email addresses will be displayed.
+  - `offline_access`: This is requested by LXD to request refresh tokens from the identity provider. However, not all identity providers support this optional scope. If it is removed, end users might be required to log in more frequently.
+```
+
 ```{config:option} oidc.audience server-oidc
 :scope: "global"
 :shortdesc: "Expected audience value for the application"
@@ -4843,10 +4856,9 @@ This value is required by some providers.
 :scope: "global"
 :shortdesc: "A claim used for mapping identity provider groups to LXD groups."
 :type: "string"
-Specify a custom claim to be requested when performing OIDC flows.
-Configure a corresponding custom claim in your identity provider and
-add organization level groups to it. These can be mapped to LXD groups
-for automatic access control.
+Specify a custom token claim to denote groups defined at the identity provider.
+The contents of this claim can be mapped to LXD groups for managing access control.
+The value of the claim is expected to be a JSON string array.
 ```
 
 ```{config:option} oidc.issuer server-oidc

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -880,7 +880,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			acmeCAURLChanged = true
 		case "acme.domain":
 			acmeDomainChanged = true
-		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.groups.claim":
+		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.groups.claim", "oidc.additional_scopes":
 			oidcChanged = true
 		}
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -230,7 +230,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	// Get the authentication methods.
 	authMethods := []string{api.AuthenticationMethodTLS}
 
-	oidcIssuer, oidcClientID, _, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
@@ -1028,7 +1028,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim, oidcAdditionalScopes := clusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
@@ -1039,7 +1039,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 				return util.HTTPClient("", d.proxy)
 			}
 
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, httpClientFunc, oidc.NewOpts(oidcGroupsClaim, oidcAdditionalScopes))
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -290,6 +290,7 @@ func (o *Verifier) getGroupsFromClaims(customClaims map[string]any) []string {
 	groupsArr, ok := groupsClaimAny.([]any)
 	if !ok {
 		logger.Warn("Unexpected type for OIDC groups custom claim", logger.Ctx{"claim_name": o.opts.GroupsClaim, "claim_value": groupsClaimAny})
+		return nil
 	}
 
 	groups := make([]string, 0, len(groupsArr))
@@ -297,6 +298,7 @@ func (o *Verifier) getGroupsFromClaims(customClaims map[string]any) []string {
 		groupName, ok := groupNameAny.(string)
 		if !ok {
 			logger.Warn("Unexpected type for OIDC groups custom claim", logger.Ctx{"claim_name": o.opts.GroupsClaim, "claim_value": groupsClaimAny})
+			return nil
 		}
 
 		groups = append(groups, groupName)

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -42,6 +42,10 @@ const (
 	defaultConfigExpiryInterval = 5 * time.Minute
 )
 
+// requiredScopes are always requested. We need the `openid` scope to perform the OIDC flow, and `email` to retrieve
+// an email identifier for the identity.
+var requiredScopes = []string{oidc.ScopeOpenID, oidc.ScopeEmail}
+
 // Verifier holds all information needed to verify an access token offline.
 type Verifier struct {
 	accessTokenVerifier *op.AccessTokenVerifier
@@ -647,15 +651,17 @@ func (o *Verifier) secureCookieFromSession(sessionID uuid.UUID) (*securecookie.S
 }
 
 // NewOpts returns an Opts.
-func NewOpts(groupsClaim string) Opts {
+func NewOpts(groupsClaim string, additionalScopes []string) Opts {
 	return Opts{
-		GroupsClaim: groupsClaim,
+		GroupsClaim:      groupsClaim,
+		AdditionalScopes: additionalScopes,
 	}
 }
 
 // Opts contains optional configurable fields for the Verifier.
 type Opts struct {
-	GroupsClaim string
+	GroupsClaim      string
+	AdditionalScopes []string
 }
 
 // NewVerifier returns a Verifier.

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -459,10 +459,7 @@ func (o *Verifier) setRelyingParty(ctx context.Context, host string) error {
 		rp.WithHTTPClient(httpClient),
 	}
 
-	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}
-	if o.opts.GroupsClaim != "" {
-		oidcScopes = append(oidcScopes, o.opts.GroupsClaim)
-	}
+	oidcScopes := append(requiredScopes, o.opts.AdditionalScopes...)
 
 	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, o.issuer, o.clientID, "", fmt.Sprintf("https://%s/oidc/callback", host), oidcScopes, options...)
 	if err != nil {

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"crypto/sha512"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -365,6 +366,17 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 	w.Header().Set("X-LXD-OIDC-issuer", o.issuer)
 	w.Header().Set("X-LXD-OIDC-clientid", o.clientID)
 	w.Header().Set("X-LXD-OIDC-audience", o.audience)
+
+	if len(o.opts.AdditionalScopes) > 0 {
+		additionalScopesJSON, err := json.Marshal(o.opts.AdditionalScopes)
+		if err != nil {
+			return fmt.Errorf("Failed to marshal additional OIDC scopes: %w", err)
+		}
+
+		w.Header().Set("X-LXD-OIDC-additional-scopes", string(additionalScopesJSON))
+	}
+
+	// Continue to write the groups claim header for older clients.
 	w.Header().Set("X-LXD-OIDC-groups-claim", o.opts.GroupsClaim)
 
 	return nil

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -681,10 +681,9 @@ var ConfigSchema = config.Schema{
 	"oidc.audience": {},
 
 	// lxdmeta:generate(entities=server; group=oidc; key=oidc.groups.claim)
-	// Specify a custom claim to be requested when performing OIDC flows.
-	// Configure a corresponding custom claim in your identity provider and
-	// add organization level groups to it. These can be mapped to LXD groups
-	// for automatic access control.
+	// Specify a custom token claim to denote groups defined at the identity provider.
+	// The contents of this claim can be mapped to LXD groups for managing access control.
+	// The value of the claim is expected to be a JSON string array.
 	// ---
 	//  type: string
 	//  scope: global

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	"github.com/canonical/lxd/lxd/config"
 	"github.com/canonical/lxd/lxd/db"
@@ -689,6 +690,21 @@ var ConfigSchema = config.Schema{
 	//  scope: global
 	//  shortdesc: A claim used for mapping identity provider groups to LXD groups.
 	"oidc.groups.claim": {},
+
+	// lxdmeta:generate(entities=server; group=oidc; key=oidc.additional_scopes)
+	// Specify additional scopes to be requested when performing OIDC flows.
+	// Additional scopes might be required if managing access control in the Identity Provider (see: {ref}`identity-provider-groups`).
+	// The default value for this configuration option contains two scopes which are optional, but will degrade LXD OIDC functionality if removed.
+	// These are:
+	//   - `profile`: This is requested by LXD to present display names for the identification of end users. If it is removed, only email addresses are displayed.
+	//   - `offline_access`: This is requested by LXD to request refresh tokens from the identity provider. However, not all identity providers support this optional scope. If it is removed, end users might be required to log in more frequently.
+	// ---
+	//  type: space-delimited string list
+	//  scope: global
+	//  shortdesc: Additional scopes to be requested during OIDC flows.
+	//  defaultdesc: `profile offline_access`
+	"oidc.additional_scopes": {Default: strings.Join([]string{oidc.ScopeProfile, oidc.ScopeOfflineAccess}, " ")},
+
 	// OVN networking global keys.
 
 	// lxdmeta:generate(entities=server; group=miscellaneous; key=network.ovn.integration_bridge)

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -224,8 +224,8 @@ func (c *Config) RemoteTokenExpiry() string {
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
+func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string, additionalScopes []string) {
+	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim"), strings.Fields(c.m.GetString("oidc.additional_scopes"))
 }
 
 // ClusterHealingThreshold returns the configured healing threshold, i.e. the

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1667,7 +1667,7 @@ func (d *Daemon) init() error {
 	maasAPIURL, maasAPIKey = d.globalConfig.MAASController()
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := d.globalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim, oidcAdditionalScopes := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
 
@@ -1695,7 +1695,7 @@ func (d *Daemon) init() error {
 			return util.HTTPClient("", d.proxy)
 		}
 
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, oidc.NewOpts(oidcGroupsClaim, oidcAdditionalScopes))
 		if err != nil {
 			return err
 		}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5446,6 +5446,15 @@
 			"oidc": {
 				"keys": [
 					{
+						"oidc.additional_scopes": {
+							"defaultdesc": "`profile offline_access`",
+							"longdesc": "Specify additional scopes to be requested when performing OIDC flows.\nAdditional scopes might be required if managing access control in the Identity Provider (see {ref}`identity-provider-groups`).\nThe default value for this configuration option contains two scopes which are optional, but will degrade LXD OIDC functionality if removed.\nThese are:\n  - `profile`: This is requested by LXD to present display names for the identification of end users. If it is removed, only email addresses will be displayed.\n  - `offline_access`: This is requested by LXD to request refresh tokens from the identity provider. However, not all identity providers support this optional scope. If it is removed, end users might be required to log in more frequently.",
+							"scope": "global",
+							"shortdesc": "Additional scopes to be requested during OIDC flows.",
+							"type": "space-delimited string list"
+						}
+					},
+					{
 						"oidc.audience": {
 							"longdesc": "This value is required by some providers.",
 							"scope": "global",
@@ -5463,7 +5472,7 @@
 					},
 					{
 						"oidc.groups.claim": {
-							"longdesc": "Specify a custom claim to be requested when performing OIDC flows.\nConfigure a corresponding custom claim in your identity provider and\nadd organization level groups to it. These can be mapped to LXD groups\nfor automatic access control.",
+							"longdesc": "Specify a custom token claim to denote groups defined at the identity provider.\nThe contents of this claim can be mapped to LXD groups for managing access control.\nThe value of the claim is expected to be a JSON string array.",
 							"scope": "global",
 							"shortdesc": "A claim used for mapping identity provider groups to LXD groups.",
 							"type": "string"

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -922,7 +922,7 @@ func patchZfsSetContentTypeUserProperty(name string, d *Daemon) error {
 
 			zfsVolName := fmt.Sprintf("%s/%s/%s", poolName, storageDrivers.VolumeTypeCustom, project.StorageVolume(vol.Project, vol.Name))
 
-			_, err = shared.RunCommand("zfs", "set", fmt.Sprintf("lxd:content_type=%s", vol.ContentType), zfsVolName)
+			_, err = shared.RunCommandContext(d.shutdownCtx, "zfs", "set", fmt.Sprintf("lxd:content_type=%s", vol.ContentType), zfsVolName)
 			if err != nil {
 				logger.Debug("Failed setting lxd:content_type property", logger.Ctx{"name": zfsVolName, "err": err})
 			}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -436,6 +436,7 @@ var APIExtensions = []string{
 	"profiles_all_projects",
 	"storage_driver_powerflex",
 	"storage_driver_pure",
+	"oidc_additional_scopes",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Adds an `oidc.additional_scopes` configuration key which defaults to `profile,offline_access`.
Removes the `oidc.groups.claim` value from requested scopes.

Things I'm not sure on:
- Using a comma to delimit the scope values. Identity providers appear to be quite freeform. It might be better to accept this as a space delimited as in #14832 (as the author originally suggested) to avoid issues with splitting on the comma.
- Backwards and forwards compatibility. New clients talking to old servers will not request the configured scopes. Old clients talking to new servers will continue to request the groups claim, but will continue to request the `profile` and `offline_access` scopes. 

Requires #14871 
Closes #14141