### PR TITLE
doc: increase linkcheck max rate limit timeout and retries

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -180,6 +180,10 @@ linkcheck_exclude_documents = [r'.*/manpages/.*']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_timeout
 linkcheck_rate_limit_timeout = 600
 
+# Increase linkcheck retries, default when unset is 1
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_retries
+linkcheck_retries = 3
+
 ############################################################
 ### Additions to default configuration
 ############################################################

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -150,7 +150,7 @@ redirects = {
 }
 
 ############################################################
-### Link checker exceptions
+### Link checker
 ############################################################
 
 # Links to ignore when checking links
@@ -175,6 +175,10 @@ custom_linkcheck_anchors_ignore_for_url = [
     ]
 
 linkcheck_exclude_documents = [r'.*/manpages/.*']
+
+# Increase linkcheck rate limit timeout max, default when unset is 300
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_timeout
+linkcheck_rate_limit_timeout = 600
 
 ############################################################
 ### Additions to default configuration


### PR DESCRIPTION
Increasing the max rate limit timeout should help with linkcheck issues due to rate limits. 
Increasing the number of retries might also help with this & other linkcheck issues.