### PR TITLE
Backup: Add consistent name validation

### DIFF
--- a/lxd/backup/backup_utils.go
+++ b/lxd/backup/backup_utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/canonical/lxd/lxd/archive"
 	"github.com/canonical/lxd/lxd/sys"
@@ -33,4 +34,23 @@ func TarReader(r io.ReadSeeker, sysOS *sys.OS, outputPath string) (*tar.Reader, 
 	}
 
 	return tr, cancelFunc, nil
+}
+
+// ValidateBackupName validates the given backup name.
+// If the name is legal, then the legal name and a nil error are returned.
+// If the name is illegal, then an empty string and an error are returned.
+func ValidateBackupName(backupName string) (string, error) {
+	if strings.Contains(backupName, "/") {
+		return "", fmt.Errorf("Backup name must not contain forward slashes")
+	}
+
+	if strings.Contains(backupName, "\\") {
+		return "", fmt.Errorf("Backup name must not contain back slashes")
+	}
+
+	if strings.Contains(backupName, "..") {
+		return "", fmt.Errorf("Backup name must not contain '..'")
+	}
+
+	return backupName, nil
 }

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/auth"
+	"github.com/canonical/lxd/lxd/backup"
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/instance"
@@ -329,11 +330,12 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the name.
-	if strings.Contains(req.Name, "/") {
-		return response.BadRequest(fmt.Errorf("Backup names may not contain slashes"))
+	backupName, err := backup.ValidateBackupName(req.Name)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
-	fullName := name + shared.SnapshotDelimiter + req.Name
+	fullName := name + shared.SnapshotDelimiter + backupName
 	instanceOnly := req.InstanceOnly || req.ContainerOnly
 
 	backup := func(op *operations.Operation) error {
@@ -362,7 +364,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 		resources["containers"] = resources["instances"]
 	}
 
-	resources["backups"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name, "backups", req.Name)}
+	resources["backups"] = []api.URL{*api.NewURL().Path(version.APIVersion, "instances", name, "backups", backupName)}
 
 	op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask,
 		operationtype.BackupCreate, resources, nil, backup, nil, nil, r)
@@ -526,9 +528,10 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Validate the name
-	if strings.Contains(req.Name, "/") {
-		return response.BadRequest(fmt.Errorf("Backup names may not contain slashes"))
+	// Validate the name.
+	newBackupName, err := backup.ValidateBackupName(req.Name)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
 	oldName := name + shared.SnapshotDelimiter + backupName
@@ -537,7 +540,7 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	newName := name + shared.SnapshotDelimiter + req.Name
+	newName := name + shared.SnapshotDelimiter + newBackupName
 
 	rename := func(op *operations.Operation) error {
 		err := backup.Rename(newName)

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -385,11 +385,12 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 	}
 
 	// Validate the name.
-	if strings.Contains(req.Name, "/") {
-		return response.BadRequest(fmt.Errorf("Backup names may not contain slashes"))
+	backupName, err := backup.ValidateBackupName(req.Name)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
-	fullName := details.volumeName + shared.SnapshotDelimiter + req.Name
+	fullName := details.volumeName + shared.SnapshotDelimiter + backupName
 	volumeOnly := req.VolumeOnly
 
 	backup := func(op *operations.Operation) error {
@@ -415,7 +416,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 
 	resources := map[string][]api.URL{}
 	resources["storage_volumes"] = []api.URL{*api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName)}
-	resources["backups"] = []api.URL{*api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", req.Name)}
+	resources["backups"] = []api.URL{*api.NewURL().Path(version.APIVersion, "storage-pools", details.pool.Name(), "volumes", details.volumeTypeName, details.volumeName, "backups", backupName)}
 
 	op, err := operations.OperationCreate(s, requestProjectName, operations.OperationClassTask, operationtype.CustomVolumeBackupCreate, resources, nil, backup, nil, nil, r)
 	if err != nil {
@@ -592,9 +593,10 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return response.BadRequest(err)
 	}
 
-	// Validate the name
-	if strings.Contains(req.Name, "/") {
-		return response.BadRequest(fmt.Errorf("Backup names may not contain slashes"))
+	// Validate the name.
+	newBackupName, err := backup.ValidateBackupName(req.Name)
+	if err != nil {
+		return response.BadRequest(err)
 	}
 
 	oldName := details.volumeName + shared.SnapshotDelimiter + backupName
@@ -604,7 +606,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return response.SmartError(err)
 	}
 
-	newName := details.volumeName + shared.SnapshotDelimiter + req.Name
+	newName := details.volumeName + shared.SnapshotDelimiter + newBackupName
 
 	rename := func(op *operations.Operation) error {
 		err := backup.Rename(newName)


### PR DESCRIPTION
This PR adds a function `ValidateBackupName` which enforces that backup names do not contain dangerous characters ('..', '/', '\').