### PR TITLE
Follow-up on `fmt.Sprintf()` replacement

### DIFF
--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -1052,7 +1052,7 @@ func (r *ProtocolLXD) ExportImage(fingerprint string, image api.ImageExportPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", "/images/"+url.PathEscape(fingerprint)+"/export", image, "", true)
+	op, _, err := r.queryOperation("POST", "/images/"+url.PathEscape(fingerprint)+"/export", &image, "", true)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -126,7 +126,7 @@ func (o *oidcClient) do(req *http.Request) (*http.Response, error) {
 	}
 
 	// Set the new access token in the header.
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", o.tokens.AccessToken))
+	req.Header.Set("Authorization", "Bearer "+o.tokens.AccessToken)
 
 	resp, err = o.httpClient.Do(req)
 	if err != nil {

--- a/client/lxd_profiles.go
+++ b/client/lxd_profiles.go
@@ -1,7 +1,6 @@
 package lxd
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -58,7 +57,7 @@ func (r *ProtocolLXD) GetProfile(name string) (*api.Profile, string, error) {
 	profile := api.Profile{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), nil, "", &profile)
+	etag, err := r.queryStruct("GET", "/profiles/"+url.PathEscape(name), nil, "", &profile)
 	if err != nil {
 		return nil, "", err
 	}
@@ -80,7 +79,7 @@ func (r *ProtocolLXD) CreateProfile(profile api.ProfilesPost) error {
 // UpdateProfile updates the profile to match the provided Profile struct.
 func (r *ProtocolLXD) UpdateProfile(name string, profile api.ProfilePut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), profile, ETag)
+	_, _, err := r.query("PUT", "/profiles/"+url.PathEscape(name), profile, ETag)
 	if err != nil {
 		return err
 	}
@@ -91,7 +90,7 @@ func (r *ProtocolLXD) UpdateProfile(name string, profile api.ProfilePut, ETag st
 // RenameProfile renames an existing profile entry.
 func (r *ProtocolLXD) RenameProfile(name string, profile api.ProfilePost) error {
 	// Send the request
-	_, _, err := r.query("POST", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), profile, "")
+	_, _, err := r.query("POST", "/profiles/"+url.PathEscape(name), profile, "")
 	if err != nil {
 		return err
 	}
@@ -102,7 +101,7 @@ func (r *ProtocolLXD) RenameProfile(name string, profile api.ProfilePost) error 
 // DeleteProfile deletes a profile.
 func (r *ProtocolLXD) DeleteProfile(name string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), nil, "")
+	_, _, err := r.query("DELETE", "/profiles/"+url.PathEscape(name), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_projects.go
+++ b/client/lxd_projects.go
@@ -1,7 +1,6 @@
 package lxd
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/canonical/lxd/shared/api"
@@ -56,7 +55,7 @@ func (r *ProtocolLXD) GetProject(name string) (*api.Project, string, error) {
 	project := api.Project{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/projects/%s", url.PathEscape(name)), nil, "", &project)
+	etag, err := r.queryStruct("GET", "/projects/"+url.PathEscape(name), nil, "", &project)
 	if err != nil {
 		return nil, "", err
 	}
@@ -74,7 +73,7 @@ func (r *ProtocolLXD) GetProjectState(name string) (*api.ProjectState, error) {
 	projectState := api.ProjectState{}
 
 	// Fetch the raw value
-	_, err = r.queryStruct("GET", fmt.Sprintf("/projects/%s/state", url.PathEscape(name)), nil, "", &projectState)
+	_, err = r.queryStruct("GET", "/projects/"+url.PathEscape(name)+"/state", nil, "", &projectState)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +105,7 @@ func (r *ProtocolLXD) UpdateProject(name string, project api.ProjectPut, ETag st
 	}
 
 	// Send the request
-	_, _, err = r.query("PUT", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, ETag)
+	_, _, err = r.query("PUT", "/projects/"+url.PathEscape(name), project, ETag)
 	if err != nil {
 		return err
 	}
@@ -122,7 +121,7 @@ func (r *ProtocolLXD) RenameProject(name string, project api.ProjectPost) (Opera
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, "", true)
+	op, _, err := r.queryOperation("POST", "/projects/"+url.PathEscape(name), project, "", true)
 	if err != nil {
 		return nil, err
 	}
@@ -138,7 +137,7 @@ func (r *ProtocolLXD) DeleteProject(name string) error {
 	}
 
 	// Send the request
-	_, _, err = r.query("DELETE", fmt.Sprintf("/projects/%s", url.PathEscape(name)), nil, "")
+	_, _, err = r.query("DELETE", "/projects/"+url.PathEscape(name), nil, "")
 	if err != nil {
 		return err
 	}

--- a/lxc/config/cert.go
+++ b/lxc/config/cert.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"io"
 	"os"
 
@@ -33,8 +32,8 @@ func (c *Config) GenerateClientCertificate() error {
 
 // CopyGlobalCert will copy global (system-wide) certificate to the user config path.
 func (c *Config) CopyGlobalCert(src string, dst string) error {
-	oldPath := c.GlobalConfigPath("servercerts", fmt.Sprintf("%s.crt", src))
-	newPath := c.ConfigPath("servercerts", fmt.Sprintf("%s.crt", dst))
+	oldPath := c.GlobalConfigPath("servercerts", src+".crt")
+	newPath := c.ConfigPath("servercerts", dst+".crt")
 	sourceFile, err := os.Open(oldPath)
 	if err != nil {
 		return err

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -129,7 +129,7 @@ func (c *cmdNetworkPeerList) run(cmd *cobra.Command, args []string) error {
 		targetPeer := "Unknown"
 
 		if peer.TargetProject != "" && peer.TargetNetwork != "" {
-			targetPeer = fmt.Sprintf("%s/%s", peer.TargetProject, peer.TargetNetwork)
+			targetPeer = peer.TargetProject + "/" + peer.TargetNetwork
 		}
 
 		details := []string{

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -362,7 +362,7 @@ func (n *physical) setup(oldConfig map[string]string) error {
 	// Record if we created this device or not (if we have not already recorded that we created it previously),
 	// so it can be removed on stop. This way we won't overwrite the setting on LXD restart.
 	if shared.IsFalseOrEmpty(n.config["volatile.last_state.created"]) {
-		n.config["volatile.last_state.created"] = fmt.Sprintf("%t", created)
+		n.config["volatile.last_state.created"] = fmt.Sprint(created)
 		err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			return tx.UpdateNetwork(ctx, n.project, n.name, n.description, n.config)
 		})

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"strconv"
 
 	"github.com/canonical/lxd/lxd/cluster/request"
@@ -536,7 +537,7 @@ func (n *physical) State() (*api.NetworkState, error) {
 	state, err := resources.GetNetworkState(GetHostDevice(n.config["parent"], n.config["vlan"]))
 	if err != nil {
 		// If the parent is not found, return a response indicating the network is unavailable.
-		if api.StatusErrorCheck(err, 404) {
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return &api.NetworkState{
 				State: "unavailable",
 				Type:  "unknown",


### PR DESCRIPTION
This fixes an unintended change introduced by https://github.com/canonical/lxd/commit/963f555865fbf8cdc4855fe458430f48bfd32aad