### PR TITLE
Network: Parse host physical NIC MAC address for storing in device configuration

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1007,7 +1007,7 @@ This option specifies whether to register the VLAN using the GARP VLAN Registrat
 ```
 
 ```{config:option} hwaddr device-nic-physical-device-conf
-:defaultdesc: "randomly assigned"
+:defaultdesc: "parent MAC address"
 :managed: "no"
 :shortdesc: "MAC address of the new interface"
 :type: "string"

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -107,12 +107,13 @@ lxc profile device add [<remote>:]profile1 <device-name> disk pool=some-pool sou
 			}
 		}
 
-		if len(args) == 1 {
+		// The second positional argument is used for the device name, so we provide device completions for the third positional argument.
+		if len(args) == 2 {
 			return c.global.cmpInstanceAllDevices(toComplete)
 		}
 
-		if len(args) == 2 {
-			return c.global.cmpInstanceAllDeviceOptions(args[0], args[1])
+		if len(args) == 3 {
+			return c.global.cmpInstanceAllDeviceOptions(args[0], args[2])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -161,11 +161,19 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to use GARP VLAN Registration Protocol
 		"gvrp": validate.Optional(validate.IsBool),
-		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+physical+ovn}; group=device-conf; key=hwaddr)
+		// lxdmeta:generate(entities=device-nic-{bridged+macvlan+sriov+ovn}; group=device-conf; key=hwaddr)
 		//
 		// ---
 		//  type: string
 		//  defaultdesc: randomly assigned
+		//  managed: no
+		//  shortdesc: MAC address of the new interface
+
+		// lxdmeta:generate(entities=device-nic-physical; group=device-conf; key=hwaddr)
+		//
+		// ---
+		//  type: string
+		//  defaultdesc: parent MAC address
 		//  managed: no
 		//  shortdesc: MAC address of the new interface
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1147,7 +1147,7 @@
 					},
 					{
 						"hwaddr": {
-							"defaultdesc": "randomly assigned",
+							"defaultdesc": "parent MAC address",
 							"longdesc": "",
 							"managed": "no",
 							"shortdesc": "MAC address of the new interface",


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14879.

This PR adds parsing of the host physical NIC MAC address, allowing `agent.nic_config` to be set to `true` for physical NIC devices. I've also updated the metadata and included a small completion fix for a bug I discovered while testing this.

Summary of changes:
- Fixes conditional completions for `lxc config device add`.
- Updates metadata for physical NIC `hwaddr` config key.
- Updates the physical NIC `Start` method to retrieve host physical NIC MAC address and store in device config (for use in `addNetDevConfig` -> `writeNICDevConfig`).