### PR TITLE
Storage: Context linter fixes

### DIFF
--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -52,7 +52,7 @@ func (d *ceph) load() error {
 
 	// Detect and record the version.
 	if cephVersion == "" {
-		out, err := shared.RunCommand("rbd", "--version")
+		out, err := shared.RunCommandContext(d.state.ShutdownCtx, "rbd", "--version")
 		if err != nil {
 			return err
 		}
@@ -250,7 +250,7 @@ func (d *ceph) Create() error {
 		}
 
 		// Use existing OSD pool.
-		msg, err := shared.RunCommand("ceph",
+		msg, err := shared.RunCommandContext(d.state.ShutdownCtx, "ceph",
 			"--name", "client."+d.config["ceph.user.name"],
 			"--cluster", d.config["ceph.cluster_name"],
 			"osd",

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -51,7 +51,7 @@ func (d *cephfs) load() error {
 
 	// Detect and record the version.
 	if cephfsVersion == "" {
-		out, err := shared.RunCommand("rbd", "--version")
+		out, err := shared.RunCommandContext(d.state.ShutdownCtx, "rbd", "--version")
 		if err != nil {
 			return err
 		}
@@ -186,7 +186,7 @@ func (d *cephfs) Create() error {
 
 			if !osdPoolExists {
 				// Create new osd pool.
-				_, err := shared.RunCommand("ceph",
+				_, err := shared.RunCommandContext(d.state.ShutdownCtx, "ceph",
 					"--name", "client."+d.config["cephfs.user.name"],
 					"--cluster", d.config["cephfs.cluster_name"],
 					"osd",
@@ -201,7 +201,7 @@ func (d *cephfs) Create() error {
 
 				revert.Add(func() {
 					// Delete the OSD pool.
-					_, _ = shared.RunCommand("ceph",
+					_, _ = shared.RunCommandContext(d.state.ShutdownCtx, "ceph",
 						"--name", "client."+d.config["cephfs.user.name"],
 						"--cluster", d.config["cephfs.cluster_name"],
 						"osd",
@@ -237,7 +237,7 @@ func (d *cephfs) Create() error {
 		}
 
 		// Create the filesystem.
-		_, err := shared.RunCommand("ceph",
+		_, err := shared.RunCommandContext(d.state.ShutdownCtx, "ceph",
 			"--name", "client."+d.config["cephfs.user.name"],
 			"--cluster", d.config["cephfs.cluster_name"],
 			"fs",
@@ -252,7 +252,7 @@ func (d *cephfs) Create() error {
 
 		revert.Add(func() {
 			// Set the FS to fail so that we can remove it.
-			_, _ = shared.RunCommand("ceph",
+			_, _ = shared.RunCommandContext(d.state.ShutdownCtx, "ceph",
 				"--name", "client."+d.config["cephfs.user.name"],
 				"--cluster", d.config["cephfs.cluster_name"],
 				"fs",
@@ -261,7 +261,7 @@ func (d *cephfs) Create() error {
 			)
 
 			// Delete the FS.
-			_, _ = shared.RunCommand("ceph",
+			_, _ = shared.RunCommandContext(d.state.ShutdownCtx, "ceph",
 				"--name", "client."+d.config["cephfs.user.name"],
 				"--cluster", d.config["cephfs.cluster_name"],
 				"fs",

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -50,7 +50,7 @@ func (d *cephobject) load() error {
 
 	// Detect and record the version.
 	if cephobjectVersion == "" {
-		out, err := shared.RunCommand("radosgw-admin", "--version")
+		out, err := shared.RunCommandContext(d.state.ShutdownCtx, "radosgw-admin", "--version")
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -53,7 +53,7 @@ func (d *lvm) load() error {
 
 	// Detect and record the version.
 	if lvmVersion == "" {
-		output, err := shared.RunCommand("lvm", "version")
+		output, err := shared.RunCommandContext(d.state.ShutdownCtx, "lvm", "version")
 		if err != nil {
 			return fmt.Errorf("Error getting LVM version: %w", err)
 		}
@@ -643,7 +643,7 @@ func (d *lvm) Update(changedConfig map[string]string) error {
 		}
 
 		// Resize physical volume so that lvresize is able to resize as well.
-		_, err = shared.RunCommand("pvresize", "-y", loopDevPath)
+		_, err = shared.RunCommandContext(d.state.ShutdownCtx, "pvresize", "-y", loopDevPath)
 		if err != nil {
 			return err
 		}
@@ -652,7 +652,7 @@ func (d *lvm) Update(changedConfig map[string]string) error {
 			lvPath := d.lvmDevPath(d.config["lvm.vg_name"], "", "", d.thinpoolName())
 
 			// Use the remaining space in the volume group.
-			_, err = shared.RunCommand("lvresize", "-f", "-l", "+100%FREE", lvPath)
+			_, err = shared.RunCommandContext(d.state.ShutdownCtx, "lvresize", "-f", "-l", "+100%FREE", lvPath)
 			if err != nil {
 				return fmt.Errorf("Error resizing LV named %q: %w", lvPath, err)
 			}
@@ -761,7 +761,7 @@ func (d *lvm) GetResources() (*api.ResourcesStoragePool, error) {
 			"-o", "vg_size,vg_free",
 		}
 
-		out, err := shared.RunCommand("vgs", args...)
+		out, err := shared.RunCommandContext(d.state.ShutdownCtx, "vgs", args...)
 		if err != nil {
 			return nil, err
 		}

--- a/test/extras/stresstest.sh
+++ b/test/extras/stresstest.sh
@@ -21,7 +21,6 @@ fi
 
 echo "==> Running the LXD testsuite"
 
-BASEURL=https://127.0.0.1:18443
 my_curl() {
   curl -k -s --cert "${LXD_CONF}/client.crt" --key "${LXD_CONF}/client.key" "${@}"
 }


### PR DESCRIPTION
Addresses linter issues from https://github.com/canonical/lxd/pull/14599.

Replaces the usage of `RunCommand` with `RunCommandContext`. And removes one duplicate line in tests.