### PR TITLE
Network: Update physical NIC device options for added clarity

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1007,6 +1007,7 @@ This option specifies whether to register the VLAN using the GARP VLAN Registrat
 ```
 
 ```{config:option} hwaddr device-nic-physical-device-conf
+:condition: "container"
 :defaultdesc: "parent MAC address"
 :managed: "no"
 :shortdesc: "MAC address of the new interface"
@@ -1029,6 +1030,7 @@ This option specifies whether to register the VLAN using the GARP VLAN Registrat
 ```
 
 ```{config:option} mtu device-nic-physical-device-conf
+:condition: "container"
 :defaultdesc: "parent MTU"
 :managed: "no"
 :shortdesc: "MTU of the new interface"
@@ -1060,6 +1062,7 @@ You can specify this option instead of specifying the `nictype` directly.
 ```
 
 ```{config:option} vlan device-nic-physical-device-conf
+:condition: "container"
 :managed: "no"
 :shortdesc: "VLAN ID to attach to"
 :type: "integer"
@@ -1795,8 +1798,7 @@ Enabling this option prevents the use of some features that are incompatible wit
 :liveupdate: "no"
 :shortdesc: "Whether to use the name and MTU of the default network interfaces"
 :type: "bool"
-For containers, the name and MTU of the default network interfaces is used for the instance devices.
-For virtual machines, set this option to `true` to set the name and MTU of the default network interfaces to be the same as the instance devices.
+When set to true, the name and MTU of the default network interfaces inside the virtual machine will match those of the instance devices.
 ```
 
 ```{config:option} cluster.evacuate instance-miscellaneous

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -97,6 +97,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		//  defaultdesc: parent MTU
 		//  managed: no
 		//  shortdesc: MTU of the new interface
+		//  condition: container
 
 		// lxdmeta:generate(entities=device-nic-{ipvlan+routed}; group=device-conf; key=mtu)
 		//
@@ -126,12 +127,20 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		//  managed: no
 		//  shortdesc: VLAN IDs or VLAN ranges to join for tagged traffic
 
-		// lxdmeta:generate(entities=device-nic-{macvlan+sriov+physical}; group=device-conf; key=vlan)
+		// lxdmeta:generate(entities=device-nic-{macvlan+sriov}; group=device-conf; key=vlan)
 		//
 		// ---
 		//  type: integer
 		//  managed: no
 		//  shortdesc: VLAN ID to attach to
+
+		// lxdmeta:generate(entities=device-nic-physical; group=device-conf; key=vlan)
+		//
+		// ---
+		//  type: integer
+		//  managed: no
+		//  shortdesc: VLAN ID to attach to
+		//  condition: container
 
 		// lxdmeta:generate(entities=device-nic-ovn; group=device-conf; key=vlan)
 		// See also {config:option}`device-nic-ovn-device-conf:nested`.
@@ -176,6 +185,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		//  defaultdesc: parent MAC address
 		//  managed: no
 		//  shortdesc: MAC address of the new interface
+		//  condition: container
 
 		// lxdmeta:generate(entities=device-nic-{ipvlan+p2p+routed}; group=device-conf; key=hwaddr)
 		//

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1073,8 +1073,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  shortdesc: Free-form user key/value storage
 
 	// lxdmeta:generate(entities=instance; group=miscellaneous; key=agent.nic_config)
-	// For containers, the name and MTU of the default network interfaces is used for the instance devices.
-	// For virtual machines, set this option to `true` to set the name and MTU of the default network interfaces to be the same as the instance devices.
+	// When set to true, the name and MTU of the default network interfaces inside the virtual machine will match those of the instance devices.
 	// ---
 	//  type: bool
 	//  defaultdesc: `false`

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1147,6 +1147,7 @@
 					},
 					{
 						"hwaddr": {
+							"condition": "container",
 							"defaultdesc": "parent MAC address",
 							"longdesc": "",
 							"managed": "no",
@@ -1172,6 +1173,7 @@
 					},
 					{
 						"mtu": {
+							"condition": "container",
 							"defaultdesc": "parent MTU",
 							"longdesc": "",
 							"managed": "no",
@@ -1207,6 +1209,7 @@
 					},
 					{
 						"vlan": {
+							"condition": "container",
 							"longdesc": "",
 							"managed": "no",
 							"shortdesc": "VLAN ID to attach to",
@@ -2076,7 +2079,7 @@
 							"condition": "virtual machine",
 							"defaultdesc": "`false`",
 							"liveupdate": "no",
-							"longdesc": "For containers, the name and MTU of the default network interfaces is used for the instance devices.\nFor virtual machines, set this option to `true` to set the name and MTU of the default network interfaces to be the same as the instance devices.",
+							"longdesc": "When set to true, the name and MTU of the default network interfaces inside the virtual machine will match those of the instance devices.",
 							"shortdesc": "Whether to use the name and MTU of the default network interfaces",
 							"type": "bool"
 						}


### PR DESCRIPTION
This PR updates the long description for `agent.nic_config` and adds a container condition to container-specific physical NIC device options.