### PR TITLE
Storage: Minor fixes for `pure` storage driver

### DIFF
--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -189,7 +189,7 @@ Create a storage pool named `pool3` that uses iSCSI to connect to Pure Storage a
 
 Create a storage pool named `pool4` that uses NVMe/TCP to connect to Pure Storage array via specific target addresses:
 
-    lxc storage create pool4 pure pure.gateway=https://<pure-storage-address> pure.api.token=<pure-storage-api-token> pure.mode=iscsi pure.target=<target_address_1>,<target_address_2>
+    lxc storage create pool4 pure pure.gateway=https://<pure-storage-address> pure.api.token=<pure-storage-api-token> pure.mode=nvme pure.target=<target_address_1>,<target_address_2>
 
 (storage-pools-cluster)=
 ## Create a storage pool in a cluster

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5957,9 +5957,7 @@ Supported values are `iscsi` and `nvme`.
 :defaultdesc: "the discovered mode"
 :shortdesc: "List of target addresses."
 :type: "string"
-A comma-separated list of target addresses. If empty, LXD discovers and
-connects to all available targets. Otherwise, it only connects to the
-specified addresses.
+A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.
 ```
 
 ```{config:option} volume.size storage-pure-pool-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6650,7 +6650,7 @@
 					{
 						"pure.target": {
 							"defaultdesc": "the discovered mode",
-							"longdesc": "A comma-separated list of target addresses. If empty, LXD discovers and\nconnects to all available targets. Otherwise, it only connects to the\nspecified addresses.",
+							"longdesc": "A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.",
 							"shortdesc": "List of target addresses.",
 							"type": "string"
 						}

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -147,9 +147,7 @@ func (d *pure) Validate(config map[string]string) error {
 		//  shortdesc: Whether to verify the Pure Storage gateway's certificate
 		"pure.gateway.verify": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-pure; group=pool-conf; key=pure.target)
-		// A comma-separated list of target addresses. If empty, LXD discovers and
-		// connects to all available targets. Otherwise, it only connects to the
-		// specified addresses.
+		// A comma-separated list of target addresses. If empty, LXD discovers and connects to all available targets. Otherwise, it only connects to the specified addresses.
 		// ---
 		//  type: string
 		//  defaultdesc: the discovered mode

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -1286,7 +1286,7 @@ func (d *pure) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		return err
 	}
 
-	// Ensure temporary snapshot volume is remooved in case of an error.
+	// Ensure temporary snapshot volume is removed in case of an error.
 	revert.Add(func() { _ = d.client().deleteVolume(snapVol.pool, snapVolName) })
 
 	// For VMs, also create the temporary filesystem volume snapshot.


### PR DESCRIPTION
Fixes:
- Some typos
- Metadata description for `pure.target` to not include newlines (`\n`)
- Improve disk device ID construction when waiting for mapped NVMe disk device (inspired by [Cinder Pure Storage - get_nguid()](https://github.com/openstack/cinder/blob/651bb416899007b49bf4de2a9bd76afafb70de31/cinder/volume/drivers/pure.py#L3548-L3563))