### PR TITLE
Storage: Delete potentially left snapshot temporary volume

### DIFF
--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -97,8 +97,7 @@ func (c *connectorISCSI) QualifiedName() (string, error) {
 
 // discoverTargets discovers the available iSCSI targets on a given address.
 func (c *connectorISCSI) discoverTargets(ctx context.Context, targetAddr string) error {
-	// Discover the available iSCSI targets on a given address.
-	_, _, err := shared.RunCommandSplit(ctx, nil, nil, "iscsiadm", "--mode", "discovery", "--type", "sendtargets", "--portal", targetAddr)
+	_, err := shared.RunCommandContext(ctx, "iscsiadm", "--mode", "discovery", "--type", "sendtargets", "--portal", targetAddr)
 	if err != nil {
 		return fmt.Errorf("Failed to discover available iSCSI targets on %q: %w", targetAddr, err)
 	}

--- a/lxd/storage/connectors/connector_iscsi.go
+++ b/lxd/storage/connectors/connector_iscsi.go
@@ -50,7 +50,7 @@ func (c *connectorISCSI) Version() (string, error) {
 
 	fields := strings.Split(strings.TrimSpace(out), " ")
 	if strings.HasPrefix(out, "iscsiadm version ") && len(fields) > 2 {
-		version := fmt.Sprintf("%s (iscsiadm)", fields[2])
+		version := fields[2] + " (iscsiadm)"
 		return version, nil
 	}
 

--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -1488,7 +1488,7 @@ func (d *pure) getMappedDevPath(vol Volume, mapVolume bool) (string, revert.Hook
 		// - "00"             - Padding
 		// - "8726b5033af243" - First 14 characters of serial number
 		// - "24a937"         - OUI (Organizationally Unique Identifier)
-		// - "3d00014196"     - Last 10 characters of serail number
+		// - "3d00014196"     - Last 10 characters of serial number
 		diskSuffix = "00" + pureVol.Serial[0:14] + "24a937" + pureVol.Serial[14:]
 	default:
 		return "", nil, fmt.Errorf("Unsupported Pure Storage mode %q", connector.Type())


### PR DESCRIPTION
Pure Storage does not allow mounting snapshots directly. Instead, we create a temporary volume with the snapshot's volume name. If the LXD was abruptly closed when temporary volume is being used, it may remain in the Pure Storage until the pool is removed.

To prevent such situation, when snapshot is removed also remove the potentially existing temporary snapshot volume.

Addresses comment: https://github.com/canonical/lxd/pull/14599#discussion_r1940802947