### PR TITLE
Storage: Restore specialized mount functions 

### DIFF
--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -107,7 +107,7 @@ func daemonStorageMount(s *state.State) error {
 		}
 
 		// Mount volume.
-		_, err = pool.MountVolume(api.ProjectDefaultName, volumeName, storageDrivers.VolumeTypeCustom, nil)
+		_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
 		if err != nil {
 			return fmt.Errorf("Failed to mount storage volume %q: %w", source, err)
 		}
@@ -196,7 +196,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 	}
 
 	// Mount volume.
-	_, err = pool.MountVolume(api.ProjectDefaultName, volumeName, storageDrivers.VolumeTypeCustom, nil)
+	_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to mount storage volume %q: %w", target, err)
 	}
@@ -322,7 +322,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 	}
 
 	// Mount volume.
-	_, err = pool.MountVolume(api.ProjectDefaultName, volumeName, storageDrivers.VolumeTypeCustom, nil)
+	_, err = pool.MountCustomVolume(api.ProjectDefaultName, volumeName, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to mount storage volume %q: %w", target, err)
 	}

--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -51,7 +51,7 @@ func daemonStorageVolumesUnmount(s *state.State) error {
 		}
 
 		// Mount volume.
-		_, err = pool.UnmountVolume(api.ProjectDefaultName, volumeName, storageDrivers.VolumeTypeCustom, nil)
+		_, err = pool.UnmountCustomVolume(api.ProjectDefaultName, volumeName, nil)
 		if err != nil {
 			return fmt.Errorf("Failed to unmount storage volume %q: %w", source, err)
 		}
@@ -201,9 +201,7 @@ func daemonStorageValidate(s *state.State, target string) error {
 		return fmt.Errorf("Failed to mount storage volume %q: %w", target, err)
 	}
 
-	defer func() {
-		_, _ = pool.UnmountVolume(api.ProjectDefaultName, volumeName, storageDrivers.VolumeTypeCustom, nil)
-	}()
+	defer func() { _, _ = pool.UnmountCustomVolume(api.ProjectDefaultName, volumeName, nil) }()
 
 	// Validate volume is empty (ignore lost+found).
 	volStorageName := project.StorageVolume(api.ProjectDefaultName, volumeName)
@@ -304,7 +302,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 
 		// Unmount old volume.
 		projectName, sourceVolumeName := project.StorageVolumeParts(sourceVolume)
-		_, err = pool.UnmountVolume(projectName, sourceVolumeName, storageDrivers.VolumeTypeCustom, nil)
+		_, err = pool.UnmountCustomVolume(projectName, sourceVolumeName, nil)
 		if err != nil {
 			return fmt.Errorf(`Failed to umount storage volume "%s/%s": %w`, sourcePool, sourceVolumeName, err)
 		}
@@ -371,7 +369,7 @@ func daemonStorageMove(s *state.State, storageType string, target string) error 
 
 		// Unmount old volume.
 		projectName, sourceVolumeName := project.StorageVolumeParts(sourceVolume)
-		_, err = pool.UnmountVolume(projectName, sourceVolumeName, storageDrivers.VolumeTypeCustom, nil)
+		_, err = pool.UnmountCustomVolume(projectName, sourceVolumeName, nil)
 		if err != nil {
 			return fmt.Errorf(`Failed to umount storage volume "%s/%s": %w`, sourcePool, sourceVolumeName, err)
 		}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -738,7 +738,7 @@ func (d *disk) Register() error {
 			return err
 		}
 	} else if d.config["path"] != "/" && d.config["source"] != "" && d.config["pool"] != "" {
-		volumeName, volumeType, dbVolumeType, volumeTypeName, err := d.sourceVolumeFields()
+		volumeName, _, dbVolumeType, volumeTypeName, err := d.sourceVolumeFields()
 		if err != nil {
 			return err
 		}
@@ -747,7 +747,7 @@ func (d *disk) Register() error {
 		storageProjectName := project.StorageVolumeProjectFromRecord(&instProj, dbVolumeType)
 
 		// Try to mount the volume that should already be mounted to reinitialise the ref counter.
-		_, err = d.pool.MountVolume(storageProjectName, volumeName, volumeType, nil)
+		_, err = d.pool.MountCustomVolume(storageProjectName, volumeName, nil)
 		if err != nil {
 			return fmt.Errorf(`Failed mounting storage volume "%s/%s": %w`, volumeTypeName, volumeName, err)
 		}
@@ -1636,7 +1636,7 @@ func (d *disk) mountPoolVolume() (func(), string, *storagePools.MountInfo, error
 	instProj := d.inst.Project()
 	storageProjectName := project.StorageVolumeProjectFromRecord(&instProj, dbVolumeType)
 
-	mountInfo, err = d.pool.MountVolume(storageProjectName, volumeName, volumeType, nil)
+	mountInfo, err = d.pool.MountCustomVolume(storageProjectName, volumeName, nil)
 	if err != nil {
 		return nil, "", nil, fmt.Errorf(`Failed mounting storage volume "%s/%s" from storage pool %q: %w`, volumeTypeName, volumeName, d.pool.Name(), err)
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6421,20 +6421,20 @@ func (b *lxdBackend) MountVolume(projectName string, volName string, volType dri
 	return mountInfo, nil
 }
 
-// UnmountVolume unmounts a custom volume.
-func (b *lxdBackend) UnmountVolume(projectName, volName string, volType drivers.VolumeType, op *operations.Operation) (bool, error) {
+// UnmountCustomVolume unmounts a custom volume.
+func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operations.Operation) (bool, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
-	l.Debug("UnmountVolume started")
-	defer l.Debug("UnmountVolume finished")
+	l.Debug("UnmountCustomVolume started")
+	defer l.Debug("UnmountCustomVolume finished")
 
-	volume, err := VolumeDBGet(b, projectName, volName, volType)
+	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return false, err
 	}
 
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
-	vol := b.GetVolume(volType, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	return b.driver.UnmountVolume(vol, false, op)
 }

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6360,25 +6360,25 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 	return &val, nil
 }
 
-// MountVolume mounts a custom volume.
-func (b *lxdBackend) MountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (*MountInfo, error) {
+// MountCustomVolume mounts a custom volume.
+func (b *lxdBackend) MountCustomVolume(projectName, volName string, op *operations.Operation) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
-	l.Debug("MountVolume started")
-	defer l.Debug("MountVolume finished")
+	l.Debug("MountCustomVolume started")
+	defer l.Debug("MountCustomVolume finished")
 
 	err := b.isStatusReady()
 	if err != nil {
 		return nil, err
 	}
 
-	volume, err := VolumeDBGet(b, projectName, volName, volType)
+	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(projectName, volName)
-	vol := b.GetVolume(volType, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	// Perform the mount.
 	mountInfo := &MountInfo{}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6360,20 +6360,7 @@ func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeU
 	return &val, nil
 }
 
-// volumeStorageName returns storage-facing name of a storage volume based on its type.
-func volumeStorageName(projectName string, volName string, volType drivers.VolumeType) (string, error) {
-	if volType == drivers.VolumeTypeCustom {
-		return project.StorageVolume(projectName, volName), nil
-	}
-
-	if volType == drivers.VolumeTypeVM || volType == drivers.VolumeTypeContainer {
-		return project.Instance(projectName, volName), nil
-	}
-
-	return "", fmt.Errorf("Cannot mount %s volumes", volType)
-}
-
-// MountVolume mounts custom, virtual-machine, and container volumes for attachment to instances.
+// MountVolume mounts a custom volume.
 func (b *lxdBackend) MountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (*MountInfo, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("MountVolume started")
@@ -6390,11 +6377,7 @@ func (b *lxdBackend) MountVolume(projectName string, volName string, volType dri
 	}
 
 	// Get the volume name on storage.
-	volStorageName, err := volumeStorageName(projectName, volName, volType)
-	if err != nil {
-		return nil, err
-	}
-
+	volStorageName := project.StorageVolume(projectName, volName)
 	vol := b.GetVolume(volType, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	// Perform the mount.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6421,7 +6421,7 @@ func (b *lxdBackend) MountVolume(projectName string, volName string, volType dri
 	return mountInfo, nil
 }
 
-// UnmountVolume unmounts a custom, virtual-machine, or container volume.
+// UnmountVolume unmounts a custom volume.
 func (b *lxdBackend) UnmountVolume(projectName, volName string, volType drivers.VolumeType, op *operations.Operation) (bool, error) {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName})
 	l.Debug("UnmountVolume started")
@@ -6433,11 +6433,7 @@ func (b *lxdBackend) UnmountVolume(projectName, volName string, volType drivers.
 	}
 
 	// Get the volume name on storage.
-	volStorageName, err := volumeStorageName(projectName, volName, volType)
-	if err != nil {
-		return false, err
-	}
-
+	volStorageName := project.StorageVolume(projectName, volName)
 	vol := b.GetVolume(volType, drivers.ContentType(volume.ContentType), volStorageName, volume.Config)
 
 	return b.driver.UnmountVolume(vol, false, op)

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -387,8 +387,8 @@ func (b *mockBackend) MountVolume(projectName string, volName string, volType dr
 	return nil, nil
 }
 
-// UnmountVolume ...
-func (b *mockBackend) UnmountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (bool, error) {
+// UnmountCustomVolume ...
+func (b *mockBackend) UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error) {
 	return true, nil
 }
 

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -382,8 +382,8 @@ func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (
 	return nil, nil
 }
 
-// MountVolume ...
-func (b *mockBackend) MountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (*MountInfo, error) {
+// MountCustomVolume ...
+func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error) {
 	return nil, nil
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -61,7 +61,6 @@ type Pool interface {
 	ApplyPatch(name string) error
 
 	GetVolume(volumeType drivers.VolumeType, contentType drivers.ContentType, name string, config map[string]string) drivers.Volume
-	MountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (*MountInfo, error)
 
 	// Instances.
 	CreateInstance(inst instance.Instance, op *operations.Operation) error
@@ -121,6 +120,7 @@ type Pool interface {
 	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
 	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
 	GetCustomVolumeUsage(projectName string, volName string) (*VolumeUsage, error)
+	MountCustomVolume(projectName string, volName string, op *operations.Operation) (*MountInfo, error)
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -62,7 +62,6 @@ type Pool interface {
 
 	GetVolume(volumeType drivers.VolumeType, contentType drivers.ContentType, name string, config map[string]string) drivers.Volume
 	MountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (*MountInfo, error)
-	UnmountVolume(projectName string, volName string, volType drivers.VolumeType, op *operations.Operation) (bool, error)
 
 	// Instances.
 	CreateInstance(inst instance.Instance, op *operations.Operation) error
@@ -122,6 +121,7 @@ type Pool interface {
 	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
 	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
 	GetCustomVolumeUsage(projectName string, volName string) (*VolumeUsage, error)
+	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
 	RefreshCustomVolume(projectName string, srcProjectName string, volName, desc string, config map[string]string, srcPoolName, srcVolName string, snapshots bool, op *operations.Operation) error
 	GenerateCustomVolumeBackupConfig(projectName string, volName string, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)


### PR DESCRIPTION
This is largely a revert of #14491. The functionality provided by the reverted commits is implemented in the last commit here.

Rather than using a common `MountVolume` which changes its behavior based on volume type, the disk device driver should choose the function to call based on the volume type provided by the user in the `source-type` field.