### PR TITLE
Storage: Avoid filling volume config on `VolumeDBCreate`

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -250,10 +250,14 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 }
 
 // GetNewVolume returns a drivers.Volume that doesn't yet exist in the database.
-// It contains copies of the supplied volume config, including a new UUID, and the pools config.
+// It contains copies of the supplied volume config, including a new UUID and
+// default configuration for the poo driver, as well as the pool's config.
 // Use the returned drivers.Volume as the base for actions performed on the new volume.
 func (b *lxdBackend) GetNewVolume(volType drivers.VolumeType, contentType drivers.ContentType, volName string, volConfig map[string]string) drivers.Volume {
 	newVol := b.GetVolume(volType, contentType, volName, volConfig)
+
+	// Fill default config.
+	b.Driver().FillVolumeConfig(newVol)
 
 	// Set a new UUID.
 	newVol.Config()["volatile.uuid"] = uuid.New().String()

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -874,6 +874,9 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 			}
 		}
 
+		// Fill volume config with driver defaults before writing to the database.
+		b.driver.FillVolumeConfig(vol)
+
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
 		err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), vol, volumeDescription, false, volumeCreationDate, time.Time{}, true, true)
@@ -2244,6 +2247,9 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 				return fmt.Errorf("Cannot create volume, already exists on migration target storage")
 			}
 		} else {
+			// Ensure driver specific default config is filled in new volume.
+			b.driver.FillVolumeConfig(vol)
+
 			// Validate config and create database entry for new storage volume if not refreshing.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
 			err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), vol, volumeDescription, false, inst.CreationDate(), time.Time{}, true, true)
@@ -5800,6 +5806,9 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 	defer revert.Fail()
 
 	if !args.Refresh {
+		// Ensure driver specific default config is filled in new volume.
+		b.driver.FillVolumeConfig(vol)
+
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).
 		err = VolumeDBCreate(b, projectName, args.Name, vol, args.Description, false, time.Now().UTC(), time.Time{}, true, true)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4143,9 +4143,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 			// Reset img volume as we just deleted the old one.
 			imgDBVol = nil
 		}
-	}
-
-	if imgDBVol == nil {
+	} else {
 		// Instantiate a new volume including its own UUID.
 		imgVol = b.GetNewVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, nil)
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6444,8 +6444,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 	for _, poolVolSnap := range poolVol.VolumeSnapshots {
 		fullSnapName := drivers.GetSnapshotVolumeName(poolVol.Volume.Name, poolVolSnap.Name)
 
-		// Copy volume config from backup file if present
-		// (so VolumeDBCreate can safely modify the copy if needed).
+		// Ensure driver specific default config is filled in new volume.
 		snapVol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(poolVolSnap.ContentType), fullSnapName, poolVolSnap.Config)
 
 		// Validate config and create database entry for restored storage volume.
@@ -6550,7 +6549,6 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	}
 
 	// Validate config and create database entry for new storage volume.
-	// Copy volume config from parent.
 	err = VolumeDBCreate(b, projectName, fullSnapshotName, vol, description, true, time.Now().UTC(), newExpiryDate, false, true)
 	if err != nil {
 		return err
@@ -7440,7 +7438,6 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 	// Generate the effective root device volume for instance.
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
-	// Copy the volume's config so VolumeDBCreate can safely modify the copy if needed.
 	vol := b.GetNewVolume(volType, contentType, volStorageName, volumeConfig)
 
 	// Create storage volume database records if in recover mode.
@@ -7466,8 +7463,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			for _, poolVolSnap := range poolVol.VolumeSnapshots {
 				fullSnapName := drivers.GetSnapshotVolumeName(inst.Name(), poolVolSnap.Name)
 
-				// Copy volume config from backup file if present,
-				// so VolumeDBCreate can safely modify the copy if needed.
+				// Ensure driver specific default config is filled in new volume.
 				snapVol := b.GetNewVolume(volType, contentType, fullSnapName, poolVolSnap.Config)
 
 				// Validate config and create database entry for recovered storage volume.
@@ -7488,8 +7484,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			for _, i := range snapshots {
 				fullSnapName := i // Local var for revert.
 
-				// Copy the parent volume's config,
-				// so VolumeDBCreate can safely modify the copy if needed.
+				// Ensure driver specific default config is filled in new volume.
 				snapVol := b.GetNewVolume(volType, contentType, fullSnapName, volumeConfig)
 
 				// Validate config and create database entry for new storage volume.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2472,7 +2472,6 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 
 	// Ensure storage volume settings are honored when doing conversion.
 	vol.SetHasSource(false)
-	b.driver.FillVolumeConfig(vol)
 
 	// Check if the volume exists in database
 	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2203,10 +2203,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	if args.MigrationType.FSType == migration.MigrationFSType_RSYNC || args.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
 		vol.SetHasSource(false)
 
-		err = b.driver.FillVolumeConfig(vol)
-		if err != nil {
-			return fmt.Errorf("Failed filling volume config: %w", err)
-		}
+		b.driver.FillVolumeConfig(vol)
 	}
 
 	// Check if the volume exists on storage.
@@ -2462,10 +2459,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 
 	// Ensure storage volume settings are honored when doing conversion.
 	vol.SetHasSource(false)
-	err = b.driver.FillVolumeConfig(vol)
-	if err != nil {
-		return fmt.Errorf("Failed filling volume config: %w", err)
-	}
+	b.driver.FillVolumeConfig(vol)
 
 	// Check if the volume exists in database
 	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
@@ -4111,10 +4105,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 		// Generate a temporary volume instance that represents how a new volume using pool defaults would
 		// be configured.
 		tmpImgVol := imgVol.Clone()
-		err := b.Driver().FillVolumeConfig(tmpImgVol)
-		if err != nil {
-			return err
-		}
+		b.Driver().FillVolumeConfig(tmpImgVol)
 
 		// Add existing image volume's config to imgVol.
 		imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgDBVol.Config)
@@ -4258,17 +4249,11 @@ func (b *lxdBackend) shouldUseOptimizedImage(fingerprint string, contentType dri
 
 	// Create the image volume with the provided volume config.
 	newImgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, volConfig)
-	err := b.Driver().FillVolumeConfig(newImgVol)
-	if err != nil {
-		return false, err
-	}
+	b.Driver().FillVolumeConfig(newImgVol)
 
 	// Create the image volume with pool's default settings.
 	poolDefaultImgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, nil)
-	err = b.Driver().FillVolumeConfig(poolDefaultImgVol)
-	if err != nil {
-		return false, err
-	}
+	b.Driver().FillVolumeConfig(poolDefaultImgVol)
 
 	// If the new volume's config doesn't match the pool's default configuration, don't use an optimized image.
 	if !volumeConfigsMatch(newImgVol, poolDefaultImgVol) {
@@ -7315,10 +7300,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 
 	// This may not always be the correct thing to do, but seeing as we don't know what the volume's config
 	// was lets take a best guess that it was the default config.
-	err = b.driver.FillVolumeConfig(*vol)
-	if err != nil {
-		return fmt.Errorf("Failed filling custom volume default config: %w", err)
-	}
+	b.driver.FillVolumeConfig(*vol)
 
 	// Check the filesystem detected is valid for the storage driver.
 	err = b.driver.ValidateVolume(*vol, false)
@@ -7375,10 +7357,7 @@ func (b *lxdBackend) detectUnknownBuckets(vol *drivers.Volume, projectVols map[s
 
 	// This may not always be the correct thing to do, but seeing as we don't know what the volume's config
 	// was lets take a best guess that it was the default config.
-	err = b.driver.FillVolumeConfig(*vol)
-	if err != nil {
-		return fmt.Errorf("Failed filling bucket default config: %w", err)
-	}
+	b.driver.FillVolumeConfig(*vol)
 
 	// Check the detected filesystem is valid for the storage driver.
 	err = b.driver.ValidateVolume(*vol, false)

--- a/lxd/storage/backend_lxd_patches.go
+++ b/lxd/storage/backend_lxd_patches.go
@@ -114,7 +114,8 @@ func patchMissingSnapshotRecords(b *lxdBackend) error {
 
 				if !foundVolumeSnapshot {
 					b.logger.Info("Creating missing volume snapshot record", logger.Ctx{"project": snapshots[i].Project, "instance": snapshots[i].Name})
-					err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, "Auto repaired", volType, true, dbVol.Config, snapshots[i].CreationDate, time.Time{}, contentType, false, true)
+					snapVol := b.GetNewVolume(volType, contentType, snapshots[i].Name, dbVol.Config)
+					err = VolumeDBCreate(b, snapshots[i].Project, snapshots[i].Name, snapVol, "Auto repaired", true, snapshots[i].CreationDate, time.Time{}, false, true)
 					if err != nil {
 						return err
 					}

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1119,14 +1119,11 @@ func (d *ceph) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *ceph) FillVolumeConfig(vol Volume) error {
+func (d *ceph) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude 'block.filesystem' and 'block.mount_options'
 	// as this ones are handled below in this function and depends from volume type
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -1158,8 +1155,6 @@ func (d *ceph) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -106,7 +106,7 @@ func (d *common) validatePool(config map[string]string, driverRules map[string]f
 // excludeKeys allow exclude some keys from copying to volume config.
 // Sometimes that can be useful when copying is dependant from specific conditions
 // and shouldn't be done in generic way.
-func (d *common) fillVolumeConfig(vol *Volume, excludedKeys ...string) error {
+func (d *common) fillVolumeConfig(vol *Volume, excludedKeys ...string) {
 	for k := range d.config {
 		if !strings.HasPrefix(k, "volume.") {
 			continue
@@ -145,13 +145,11 @@ func (d *common) fillVolumeConfig(vol *Volume, excludedKeys ...string) error {
 			vol.config[volKey] = d.config[k]
 		}
 	}
-
-	return nil
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *common) FillVolumeConfig(vol Volume) error {
-	return d.fillVolumeConfig(&vol)
+func (d *common) FillVolumeConfig(vol Volume) {
+	d.fillVolumeConfig(&vol)
 }
 
 // validateVolume validates a volume config against common rules and optional driver specific rules.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -226,21 +226,16 @@ func (d *dir) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *dir) FillVolumeConfig(vol Volume) error {
+func (d *dir) FillVolumeConfig(vol Volume) {
 	initialSize := vol.config["size"]
 
-	err := d.fillVolumeConfig(&vol)
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol)
 
 	// Buckets do not support default volume size.
 	// If size is specified manually, do not remove, so it triggers validation failure and an error to user.
 	if vol.volType == VolumeTypeBucket && initialSize == "" {
 		delete(vol.config, "size")
 	}
-
-	return nil
 }
 
 // ValidateVolume validates the supplied volume config. Optionally removes invalid keys from the volume's config.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -265,14 +265,11 @@ func (d *lvm) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *lvm) FillVolumeConfig(vol Volume) error {
+func (d *lvm) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude "block.filesystem" and "block.mount_options" as they depend on volume type (handled below).
 	// Exclude "lvm.stripes", "lvm.stripes.size" as they only work on non-thin storage pools (handled below).
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "lvm.stripes", "lvm.stripes.size")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "lvm.stripes", "lvm.stripes.size")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -315,8 +312,6 @@ func (d *lvm) FillVolumeConfig(vol Volume) error {
 			vol.config["lvm.stripes.size"] = d.config["lvm.stripes.size"]
 		}
 	}
-
-	return nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -376,14 +376,11 @@ func (d *powerflex) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *powerflex) FillVolumeConfig(vol Volume) error {
+func (d *powerflex) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude 'block.filesystem' and 'block.mount_options'
 	// as these ones are handled below in this function and depend on the volume's type.
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -415,8 +412,6 @@ func (d *powerflex) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -671,14 +671,11 @@ func (d *pure) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *pure) FillVolumeConfig(vol Volume) error {
+func (d *pure) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude 'block.filesystem' and 'block.mount_options'
 	// as these ones are handled below in this function and depend on the volume's type.
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -710,8 +707,6 @@ func (d *pure) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 // ValidateVolume validates the supplied volume config.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -2570,6 +2570,7 @@ func (d *zfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArgs 
 
 	// If we haven't negotiated zvol support, ensure volume is not a zvol.
 	if !shared.ValueInSlice(migration.ZFSFeatureZvolFilesystems, volSrcArgs.MigrationType.Features) && d.isBlockBacked(vol.Volume) {
+		fmt.Println(shared.ValueInSlice(migration.ZFSFeatureZvolFilesystems, volSrcArgs.MigrationType.Features), d.isBlockBacked(vol.Volume))
 		return fmt.Errorf("Filesystem zvol detected in source but target does not support receiving zvols")
 	}
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -3508,7 +3508,7 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *zfs) FillVolumeConfig(vol Volume) error {
+func (d *zfs) FillVolumeConfig(vol Volume) {
 	var excludedKeys []string
 
 	// Copy volume.* configuration options from pool.
@@ -3519,10 +3519,7 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 		excludedKeys = []string{"block.filesystem", "block.mount_options"}
 	}
 
-	err := d.fillVolumeConfig(&vol, excludedKeys...)
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, excludedKeys...)
 
 	// Only validate filesystem config keys for filesystem volumes.
 	if d.isBlockBacked(vol) && vol.ContentType() == ContentTypeFS {
@@ -3553,8 +3550,6 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 func (d *zfs) isBlockBacked(vol Volume) bool {

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -63,7 +63,7 @@ type Driver interface {
 	DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error
 
 	// Volumes.
-	FillVolumeConfig(vol Volume) error
+	FillVolumeConfig(vol Volume)
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
 	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
 	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -189,7 +189,6 @@ func VolumeDBGet(pool Pool, projectName string, volumeName string, volumeType dr
 }
 
 // VolumeDBCreate creates a volume in the database.
-// If volumeConfig is supplied, it is modified with any driver level default config options (if not set).
 // If removeUnknownKeys is true, any unknown config keys are removed from volumeConfig rather than failing.
 func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDescription string, volumeType drivers.VolumeType, snapshot bool, volumeConfig map[string]string, creationDate time.Time, expiryDate time.Time, contentType drivers.ContentType, removeUnknownKeys bool, hasSource bool) error {
 	p, ok := pool.(*lxdBackend)
@@ -234,12 +233,6 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 
 	// Set source indicator.
 	vol.SetHasSource(hasSource)
-
-	// Fill default config.
-	err = pool.Driver().FillVolumeConfig(vol)
-	if err != nil {
-		return err
-	}
 
 	// Validate config.
 	err = pool.Driver().ValidateVolume(vol, removeUnknownKeys)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -361,13 +361,10 @@ func BucketDBCreate(ctx context.Context, pool Pool, projectName string, memberSp
 	bucketVol := drivers.NewVolume(pool.Driver(), pool.Name(), drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, bucket.Config, pool.Driver().Config())
 
 	// Fill default config.
-	err := pool.Driver().FillVolumeConfig(bucketVol)
-	if err != nil {
-		return -1, err
-	}
+	pool.Driver().FillVolumeConfig(bucketVol)
 
 	// Validate bucket name.
-	err = pool.Driver().ValidateBucket(bucketVol)
+	err := pool.Driver().ValidateBucket(bucketVol)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
This is a pre-requisite for https://github.com/canonical/lxd/pull/14595.

The whole idea here is that we want to adapt the provided volume config on `VolumeDBCreate` to populate `volatile.rootfs.size` without changing the original config passed in, as this would be a very easy and consistent way to keep track of volume sizes.

But we are currently relying on `VolumeDBCreate` to populate some fields within the volume for future use, which is giving many unrelated purposes to this function. So this instead proposed filling this config on `GetNewVolume` instead, as it makes sense for a new volume to have default conifg for the driver filled in. That, along with a few more tweaks, allows us to use `VolumeDBCreate` exclusively to create the database entry for the volume, adapting the volume config as needed without compromising the original config passed in as an argument.