### PR TITLE
Storage: Attach VM snapshots as disk devices

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2552,11 +2552,9 @@ Adds optional `target` parameter to `GET /1.0/network`. When target is set, forw
 
 This adds support for listing network zones across all projects using the `all-projects` parameter in `GET /1.0/network-zones` requests.
 
-## `instance_root_volume_attachment`
+## `vm_root_volume_attachment`
 
-Adds support for instance root volumes to be attached to other instances as disk
-devices. Introduces the `<type>/<volume>` syntax for the `source` property of
-disk devices.
+Adds support for virtual-machine root volumes and snapshots to be attached to other instances as disk devices. Introduces the `source.type` and `source.snapshot` keys for disk devices.
 
 ## `projects_limits_uplink_ips`
 

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -207,6 +207,13 @@ can be unset from `vm1`:
 `security.shared` can also be used on `virtual-machine` volumes to enable concurrent
 access. Note that concurrent access to block volumes may result in data loss.
 
+### Attaching virtual machine snapshots to other instances
+Virtual-machine snapshots can also be attached to instances with the
+{config:option}`device-disk-device-conf:source.snapshot` disk device
+configuration key.
+
+    lxc config device add v1 v2-root-snap0 disk pool=my-pool source=vm2 source.type=virtual-machine source.snapshot=snap0
+
 ## Resize a storage volume
 
 If you need more storage in a volume, you can increase the size of your storage volume.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -186,6 +186,13 @@ See {ref}`devices-disk-types` for details.
 
 ```
 
+```{config:option} source.snapshot device-disk-device-conf
+:required: "no"
+:shortdesc: "`source` snapshot name"
+:type: "string"
+Snapshot of the volume given by `source`.
+```
+
 ```{config:option} source.type device-disk-device-conf
 :defaultdesc: "`custom`"
 :required: "no"

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -23,7 +23,7 @@ See {ref}`devices-disk-examples` for more detailed information on how to add eac
 
 Storage volume
 : The most common type of disk device is a storage volume.
-  Specify the storage volume name as the source to add a storage volume as a disk device.
+  Specify the storage volume name as the {config:option}`device-disk-device-conf:source` to add a storage volume as a disk device. `virtual-machine' storage volumes (and their snapshots) can also be attached as disk devices.
 
 Path on the host
 : You can share a path on your host (either a file system or a block device) to your instance.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -922,7 +922,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 
 		options := []string{}
-		if isReadOnly {
+		if isReadOnly || d.config["source.snapshot"] != "" {
 			options = append(options, "ro")
 		}
 
@@ -1228,7 +1228,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				mount.Opts = append(mount.Opts, d.detectVMPoolMountOpts()...)
 			}
 
-			if shared.IsTrue(d.config["readonly"]) {
+			if shared.IsTrue(d.config["readonly"]) || d.config["source.snapshot"] != "" {
 				mount.Opts = append(mount.Opts, "ro")
 			}
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -201,6 +201,14 @@
 						}
 					},
 					{
+						"source.snapshot": {
+							"longdesc": "Snapshot of the volume given by `source`.",
+							"required": "no",
+							"shortdesc": "`source` snapshot name",
+							"type": "string"
+						}
+					},
+					{
 						"source.type": {
 							"defaultdesc": "`custom`",
 							"longdesc": "Possible values are `custom` (the default) or `virtual-machine`. This\nkey is only valid when `source` is the name of a storage volume.",

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -969,12 +969,25 @@ func volumeIsUsedByDevice(vol api.StorageVolume, inst *db.InstanceArgs, dev map[
 		}
 	}
 
+	var volName string
+	var snapName string
+
+	if shared.IsSnapshot(vol.Name) {
+		parts := strings.SplitN(vol.Name, shared.SnapshotDelimiter, 2)
+		volName, snapName = parts[0], parts[1]
+	} else if dev["source.snapshot"] != "" {
+		// vol is not a snapshot but dev refers to one
+		return false, nil
+	} else {
+		volName = vol.Name
+	}
+
 	volumeTypeName := cluster.StoragePoolVolumeTypeNameCustom
 	if dev["source.type"] != "" {
 		volumeTypeName = dev["source.type"]
 	}
 
-	if volumeTypeName == vol.Type && dev["source"] == vol.Name {
+	if volumeTypeName == vol.Type && dev["source"] == volName && dev["source.snapshot"] == snapName {
 		return true, nil
 	}
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -796,22 +796,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -866,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1233,17 +1233,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1553,7 +1553,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1773,28 +1773,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1806,11 +1806,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2132,8 +2132,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2175,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2212,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2481,7 +2481,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2669,11 +2669,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3025,7 +3025,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3051,9 +3051,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3420,11 +3420,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,7 +3483,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3737,11 +3737,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3952,13 +3952,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3977,11 +3977,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4018,8 +4018,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4056,7 +4056,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4064,11 +4064,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4095,7 +4095,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4147,8 +4147,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4156,7 +4156,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4346,21 +4346,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4372,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4385,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4415,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4432,7 +4427,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4506,8 +4501,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4624,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4638,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4654,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4684,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4783,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4982,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5042,7 +5037,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5366,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5455,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5604,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5676,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5789,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5867,11 +5862,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6028,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6052,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6128,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6143,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6151,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6210,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6232,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6271,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6376,7 +6371,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6428,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6436,7 +6431,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6472,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6544,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6603,12 +6598,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7031,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7066,65 +7064,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7230,7 +7231,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7706,7 +7707,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7714,13 +7715,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -1019,7 +1019,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1080,23 +1080,23 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1153,17 +1153,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1340,12 +1340,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1471,14 +1471,14 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1495,7 +1495,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
 
@@ -1541,17 +1541,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1625,13 +1625,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1644,7 +1644,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1791,7 +1791,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1854,7 +1854,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1890,7 +1890,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1910,7 +1910,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -2016,7 +2016,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2121,28 +2121,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2156,12 +2156,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2434,7 +2434,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2444,7 +2444,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2502,7 +2502,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2516,8 +2516,8 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2568,8 +2568,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2593,7 +2593,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2608,12 +2608,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2882,7 +2882,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3015,7 +3015,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3091,11 +3091,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3226,7 +3226,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3240,7 +3240,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3292,7 +3292,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3300,7 +3300,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3324,11 +3324,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3456,7 +3456,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -3465,7 +3465,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3484,9 +3484,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3537,7 +3537,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3888,12 +3888,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3953,7 +3953,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4245,12 +4245,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4480,13 +4480,13 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4507,12 +4507,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4551,8 +4551,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4592,7 +4592,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4602,11 +4602,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4634,7 +4634,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4686,8 +4686,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4695,7 +4695,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4843,7 +4843,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4865,11 +4865,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4883,7 +4883,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4892,21 +4892,16 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4918,7 +4913,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4931,7 +4926,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4961,7 +4956,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4978,7 +4973,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5056,8 +5051,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5180,7 +5175,7 @@ msgstr "Eigenschaften:\n"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5194,7 +5189,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5210,7 +5205,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5231,7 +5226,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5240,7 +5235,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5253,7 +5248,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5344,7 +5339,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5564,17 +5559,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5629,7 +5624,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5973,12 +5968,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6073,7 +6068,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6241,12 +6236,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -6318,16 +6313,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6437,22 +6432,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6518,11 +6513,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6685,12 +6680,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6709,8 +6704,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6790,7 +6785,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6805,7 +6800,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6813,7 +6808,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6874,7 +6869,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6896,13 +6891,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6936,7 +6931,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7057,7 +7052,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7118,7 +7113,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7127,7 +7122,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7165,12 +7160,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7241,7 +7236,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -7309,17 +7304,20 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
@@ -8142,7 +8140,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8209,7 +8207,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8220,7 +8218,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8229,7 +8227,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8238,7 +8236,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8247,7 +8245,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8255,7 +8253,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8264,7 +8262,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8272,23 +8270,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-"Ändert den Laufzustand eines Containers in %s.\n"
-"\n"
-"lxd %s <Name>\n"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-"Ändert den Laufzustand eines Containers in %s.\n"
-"\n"
-"lxd %s <Name>\n"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8296,7 +8278,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8304,7 +8286,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8313,7 +8295,26 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8322,7 +8323,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8330,7 +8331,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8544,7 +8545,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -9042,7 +9043,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9050,13 +9051,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -802,22 +802,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -872,16 +872,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -902,7 +902,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -945,7 +945,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1048,12 +1048,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1173,14 +1173,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1197,7 +1197,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1240,17 +1240,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1312,7 +1312,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1338,7 +1338,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1474,7 +1474,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1563,7 +1563,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1684,7 +1684,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1788,28 +1788,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -1822,11 +1822,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2078,7 +2078,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2087,7 +2087,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2144,7 +2144,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2158,8 +2158,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2201,8 +2201,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2226,7 +2226,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2238,11 +2238,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2507,7 +2507,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2637,7 +2637,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2708,11 +2708,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2854,7 +2854,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2912,7 +2912,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2934,11 +2934,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3090,9 +3090,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3138,7 +3138,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3461,11 +3461,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3524,7 +3524,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3791,11 +3791,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4017,13 +4017,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4042,11 +4042,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
@@ -4084,8 +4084,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4122,7 +4122,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4130,11 +4130,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4161,7 +4161,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4213,8 +4213,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4222,7 +4222,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4368,7 +4368,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4388,11 +4388,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4406,7 +4406,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4414,21 +4414,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4440,7 +4435,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4453,7 +4448,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4483,7 +4478,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4500,7 +4495,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4575,8 +4570,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4693,7 +4688,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4707,7 +4702,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4723,7 +4718,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4744,7 +4739,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4753,7 +4748,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4766,7 +4761,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4852,7 +4847,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5056,15 +5051,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5116,7 +5111,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5448,11 +5443,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5543,7 +5538,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5702,11 +5697,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5775,15 +5770,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5888,21 +5883,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5966,11 +5961,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6127,12 +6122,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6151,8 +6146,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6228,7 +6223,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6243,7 +6238,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6251,7 +6246,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6310,7 +6305,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6332,13 +6327,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6371,7 +6366,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6486,7 +6481,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6545,7 +6540,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6553,7 +6548,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6589,12 +6584,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6661,7 +6656,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6720,12 +6715,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7148,7 +7146,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7183,65 +7181,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7347,7 +7348,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7823,7 +7824,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7831,13 +7832,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -991,7 +991,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -1048,22 +1048,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1118,16 +1118,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1148,7 +1148,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1192,7 +1192,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1281,7 +1281,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1298,12 +1298,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1425,14 +1425,14 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1449,7 +1449,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
 
@@ -1494,17 +1494,17 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1566,7 +1566,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1574,12 +1574,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1593,7 +1593,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1736,7 +1736,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1826,7 +1826,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1846,7 +1846,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2052,28 +2052,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2086,11 +2086,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2354,7 +2354,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2411,7 +2411,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2425,8 +2425,8 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2469,8 +2469,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2495,7 +2495,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2509,11 +2509,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2779,7 +2779,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2910,7 +2910,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2981,11 +2981,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3116,7 +3116,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3130,7 +3130,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3180,7 +3180,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3188,7 +3188,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3211,11 +3211,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3344,7 +3344,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3353,7 +3353,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3371,9 +3371,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3420,7 +3420,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3754,11 +3754,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3818,7 +3818,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4086,11 +4086,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4318,13 +4318,13 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4344,11 +4344,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -4388,8 +4388,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4427,7 +4427,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4435,11 +4435,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4466,7 +4466,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4518,8 +4518,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4671,7 +4671,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4691,11 +4691,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4717,21 +4717,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4743,7 +4738,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4756,7 +4751,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4803,7 +4798,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4878,8 +4873,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5000,7 +4995,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5014,7 +5009,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5030,7 +5025,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5051,7 +5046,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5060,7 +5055,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5073,7 +5068,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5161,7 +5156,7 @@ msgstr "Aliases:"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5368,15 +5363,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5431,7 +5426,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5766,11 +5761,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5861,7 +5856,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6021,11 +6016,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6094,15 +6089,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6208,21 +6203,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6286,11 +6281,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6449,12 +6444,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6473,8 +6468,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6551,7 +6546,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6566,7 +6561,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6574,7 +6569,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6635,7 +6630,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6657,13 +6652,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6696,7 +6691,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6812,7 +6807,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6871,7 +6866,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6879,7 +6874,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6916,12 +6911,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6988,7 +6983,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -7047,14 +7042,17 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7568,7 +7566,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7611,79 +7609,82 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr "No se puede proveer el nombre del container a la lista"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr "No se puede proveer el nombre del container a la lista"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7815,7 +7816,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8295,7 +8296,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8303,13 +8304,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1023,7 +1023,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -1083,23 +1083,23 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1156,17 +1156,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1187,7 +1187,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1338,12 +1338,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1465,14 +1465,14 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1489,7 +1489,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -1543,17 +1543,17 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1627,13 +1627,13 @@ msgstr "Copie de l'image : %s"
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1647,7 +1647,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1811,7 +1811,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1874,7 +1874,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1910,7 +1910,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2041,7 +2041,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2147,28 +2147,28 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2181,12 +2181,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2456,7 +2456,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2466,7 +2466,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2524,7 +2524,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2538,8 +2538,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2598,8 +2598,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2625,7 +2625,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2640,12 +2640,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2917,7 +2917,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -3049,7 +3049,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3127,11 +3127,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3264,7 +3264,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3281,7 +3281,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3335,7 +3335,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3343,7 +3343,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3368,11 +3368,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3502,7 +3502,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3511,7 +3511,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3530,9 +3530,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3580,7 +3580,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3977,12 +3977,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -4042,7 +4042,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4329,12 +4329,12 @@ msgstr "Copie de l'image : %s"
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4567,13 +4567,13 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4594,12 +4594,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4640,8 +4640,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -4682,7 +4682,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4692,11 +4692,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -4724,7 +4724,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr "NOM"
 
@@ -4776,8 +4776,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4786,7 +4786,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4934,7 +4934,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -4956,11 +4956,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4974,7 +4974,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4983,27 +4983,20 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 #, fuzzy
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:353
-#, fuzzy
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-"Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -5018,7 +5011,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -5034,7 +5027,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5065,7 +5058,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -5082,7 +5075,7 @@ msgid "PROFILES"
 msgstr "PROFILS"
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5161,8 +5154,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5285,7 +5278,7 @@ msgstr "Propriétés :"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5299,7 +5292,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5315,7 +5308,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5336,7 +5329,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5345,7 +5338,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5358,7 +5351,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5451,7 +5444,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -5673,17 +5666,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5755,7 +5748,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -6104,12 +6097,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6204,7 +6197,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6377,12 +6370,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -6455,16 +6448,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6575,22 +6568,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6658,11 +6651,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6829,12 +6822,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6853,8 +6846,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -6935,7 +6928,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6950,7 +6943,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6958,7 +6951,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -7020,7 +7013,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -7042,13 +7035,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7082,7 +7075,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -7206,7 +7199,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7267,7 +7260,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7276,7 +7269,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7314,12 +7307,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7388,7 +7381,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -7456,17 +7449,20 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
@@ -8367,7 +8363,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8434,7 +8430,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8448,7 +8444,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8460,7 +8456,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8472,7 +8468,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8484,7 +8480,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8492,7 +8488,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8504,7 +8500,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8512,23 +8508,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-"Change l'état d'un ou plusieurs conteneurs à %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-"Change l'état d'un ou plusieurs conteneurs à %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8536,7 +8516,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8544,7 +8524,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8556,7 +8536,26 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8568,7 +8567,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8576,7 +8575,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8802,7 +8801,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -9325,7 +9324,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9333,13 +9332,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9407,6 +9406,13 @@ msgstr "o"
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy
+#~ msgid ""
+#~ "Only \"custom\" and \"virtual-machine\" volumes can be attached to "
+#~ "profiles"
+#~ msgstr ""
+#~ "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Action (GET par défaut)"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -800,22 +800,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -870,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1237,17 +1237,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1557,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1777,28 +1777,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1810,11 +1810,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2065,7 +2065,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2136,8 +2136,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2179,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2216,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2485,7 +2485,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2609,7 +2609,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2673,11 +2673,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2805,7 +2805,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3029,7 +3029,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3055,9 +3055,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3103,7 +3103,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3741,11 +3741,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3956,13 +3956,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3981,11 +3981,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4022,8 +4022,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4060,7 +4060,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4068,11 +4068,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4099,7 +4099,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4151,8 +4151,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4160,7 +4160,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4324,11 +4324,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4350,21 +4350,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4376,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4389,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4419,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4436,7 +4431,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4510,8 +4505,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4628,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4642,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4658,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4688,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4701,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4787,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4986,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5041,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5370,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5459,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5608,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5680,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5793,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5871,11 +5866,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6032,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6056,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6132,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6147,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6155,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6214,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6236,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6275,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6380,7 +6375,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6432,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6440,7 +6435,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6476,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6548,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6607,12 +6602,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7035,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7070,65 +7068,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7234,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7710,7 +7711,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7718,13 +7719,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -993,7 +993,7 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -1050,22 +1050,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1120,16 +1120,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1296,12 +1296,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1423,14 +1423,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1447,7 +1447,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
 
@@ -1490,17 +1490,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1563,7 +1563,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1571,12 +1571,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1589,7 +1589,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1732,7 +1732,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1787,7 +1787,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1823,7 +1823,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1944,7 +1944,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2048,28 +2048,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2082,11 +2082,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2352,7 +2352,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2423,8 +2423,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2467,8 +2467,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2492,7 +2492,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2506,11 +2506,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2777,7 +2777,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2906,7 +2906,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2976,11 +2976,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3109,7 +3109,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3123,7 +3123,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3174,7 +3174,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3182,7 +3182,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3205,11 +3205,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3337,7 +3337,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -3346,7 +3346,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3365,9 +3365,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3414,7 +3414,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3749,11 +3749,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3813,7 +3813,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4087,11 +4087,11 @@ msgstr "Creazione del container in corso"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4318,13 +4318,13 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4344,11 +4344,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -4387,8 +4387,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4426,7 +4426,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4434,11 +4434,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4465,7 +4465,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4517,8 +4517,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4526,7 +4526,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4670,7 +4670,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4691,11 +4691,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4709,7 +4709,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4718,21 +4718,16 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4744,7 +4739,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4757,7 +4752,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4787,7 +4782,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4804,7 +4799,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4880,8 +4875,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5000,7 +4995,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5014,7 +5009,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5030,7 +5025,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5051,7 +5046,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5060,7 +5055,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5073,7 +5068,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5162,7 +5157,7 @@ msgstr "Creazione del container in corso"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5370,15 +5365,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5433,7 +5428,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5766,11 +5761,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5859,7 +5854,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -6019,11 +6014,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6093,15 +6088,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6208,21 +6203,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6287,11 +6282,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -6450,12 +6445,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6474,8 +6469,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6552,7 +6547,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6567,7 +6562,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6575,7 +6570,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6635,7 +6630,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6657,13 +6652,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6697,7 +6692,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6811,7 +6806,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6867,7 +6862,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6875,7 +6870,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6913,12 +6908,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6985,7 +6980,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -7047,14 +7042,17 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7568,7 +7566,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7611,79 +7609,82 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr "Creazione del container in corso"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr "Creazione del container in corso"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -7815,7 +7816,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -8295,7 +8296,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8303,13 +8304,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1001,7 +1001,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1057,22 +1057,22 @@ msgstr "プロファイルにネットワークインターフェースを追加
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1131,16 +1131,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1163,7 +1163,7 @@ msgstr "不適切なキー/値のペア: %s"
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1206,7 +1206,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1292,7 +1292,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1309,14 +1309,14 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
@@ -1439,14 +1439,14 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1463,7 +1463,7 @@ msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -1510,17 +1510,17 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1598,7 +1598,7 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1606,12 +1606,12 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1624,7 +1624,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1768,7 +1768,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1820,7 +1820,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1855,7 +1855,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1875,7 +1875,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1974,7 +1974,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -2078,28 +2078,28 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2111,11 +2111,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -2373,7 +2373,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2382,7 +2382,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2451,7 +2451,7 @@ msgstr "イメージの取得中: %s"
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2465,8 +2465,8 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2519,8 +2519,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2547,7 +2547,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2559,12 +2559,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2845,7 +2845,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2978,7 +2978,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3043,11 +3043,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3179,7 +3179,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3195,7 +3195,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3245,7 +3245,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3256,7 +3256,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3283,11 +3283,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3418,7 +3418,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -3428,7 +3428,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -3448,9 +3448,9 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3496,7 +3496,7 @@ msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3950,11 +3950,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -4046,7 +4046,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4318,11 +4318,11 @@ msgstr "ストレージバケットを管理します。"
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr "ストレージボリュームを管理します"
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4542,13 +4542,13 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4567,11 +4567,11 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4611,8 +4611,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -4662,7 +4662,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -4670,11 +4670,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -4703,7 +4703,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr "NAME"
 
@@ -4756,8 +4756,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr "名前"
 
@@ -4765,7 +4765,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4912,7 +4912,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -4934,11 +4934,11 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4952,7 +4952,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4960,23 +4960,17 @@ msgstr "スナップショット名ではありません"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 #, fuzzy
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:353
-#, fuzzy
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -4988,7 +4982,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -5001,7 +4995,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -5031,7 +5025,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -5048,7 +5042,7 @@ msgid "PROFILES"
 msgstr "PROFILES"
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -5123,8 +5117,8 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5243,7 +5237,7 @@ msgstr "プロパティ:"
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5257,7 +5251,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5273,7 +5267,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5294,7 +5288,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5306,7 +5300,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5319,7 +5313,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5410,7 +5404,7 @@ msgstr "インスタンスを一覧表示します"
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -5615,16 +5609,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5682,7 +5676,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -6062,11 +6056,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6167,7 +6161,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6320,11 +6314,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -6393,15 +6387,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6506,21 +6500,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6584,11 +6578,11 @@ msgstr "TOKEN"
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6751,12 +6745,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6777,8 +6771,8 @@ msgstr "サーバには新しい v2 resource API が実装されていません"
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -6874,7 +6868,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6889,7 +6883,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6897,7 +6891,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -6959,7 +6953,7 @@ msgstr ""
 "フィカル出力の場合は 'vga'"
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -6981,13 +6975,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -7020,7 +7014,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -7126,7 +7120,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7186,7 +7180,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7195,7 +7189,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7233,12 +7227,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7310,7 +7304,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7374,14 +7368,17 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7825,7 +7822,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7860,7 +7857,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7868,66 +7865,69 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
@@ -8035,7 +8035,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -8716,7 +8716,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8729,7 +8729,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8737,7 +8737,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 #, fuzzy
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
@@ -8811,6 +8811,12 @@ msgstr "y"
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid ""
+#~ "Only \"custom\" and \"virtual-machine\" volumes can be attached to "
+#~ "profiles"
+#~ msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "使用するHTTPのメソッド (デフォルト: GET)"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -796,22 +796,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -866,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1233,17 +1233,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1553,7 +1553,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1773,28 +1773,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1806,11 +1806,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2132,8 +2132,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2175,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2212,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2481,7 +2481,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2669,11 +2669,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3025,7 +3025,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3051,9 +3051,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3420,11 +3420,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,7 +3483,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3737,11 +3737,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3952,13 +3952,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3977,11 +3977,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4018,8 +4018,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4056,7 +4056,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4064,11 +4064,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4095,7 +4095,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4147,8 +4147,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4156,7 +4156,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4346,21 +4346,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4372,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4385,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4415,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4432,7 +4427,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4506,8 +4501,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4624,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4638,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4654,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4684,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4783,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4982,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5042,7 +5037,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5366,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5455,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5604,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5676,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5789,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5867,11 +5862,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6028,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6052,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6128,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6143,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6151,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6210,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6232,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6271,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6376,7 +6371,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6428,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6436,7 +6431,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6472,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6544,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6603,12 +6598,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7031,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7066,65 +7064,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7230,7 +7231,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7706,7 +7707,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7714,13 +7715,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-03-03 10:13+0100\n"
+        "POT-Creation-Date: 2025-03-03 09:58-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -702,7 +702,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid   "All projects"
 msgstr  ""
 
@@ -757,21 +757,21 @@ msgstr  ""
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid   "Attach new storage volumes to instances\n"
         "\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr  ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid   "Attach new storage volumes to profiles\n"
         "\n"
         "<type> must be one of \"custom\" or \"virtual-machine\""
@@ -824,16 +824,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid   "Backups:"
 msgstr  ""
 
@@ -852,7 +852,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -895,7 +895,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -980,7 +980,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -997,11 +997,11 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
@@ -1101,7 +1101,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:409 lxc/storage_volume.go:633 lxc/storage_volume.go:738 lxc/storage_volume.go:1040 lxc/storage_volume.go:1266 lxc/storage_volume.go:1395 lxc/storage_volume.go:1886 lxc/storage_volume.go:1984 lxc/storage_volume.go:2123 lxc/storage_volume.go:2283 lxc/storage_volume.go:2399 lxc/storage_volume.go:2460 lxc/storage_volume.go:2587 lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:389 lxc/storage_volume.go:613 lxc/storage_volume.go:718 lxc/storage_volume.go:1020 lxc/storage_volume.go:1246 lxc/storage_volume.go:1375 lxc/storage_volume.go:1866 lxc/storage_volume.go:1964 lxc/storage_volume.go:2103 lxc/storage_volume.go:2263 lxc/storage_volume.go:2379 lxc/storage_volume.go:2440 lxc/storage_volume.go:2567 lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1117,7 +1117,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1152,16 +1152,16 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185 lxc/storage_volume.go:1217
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165 lxc/storage_volume.go:1197
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1217,7 +1217,7 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -1225,11 +1225,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:412
+#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:392
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1242,7 +1242,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1376,7 +1376,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1428,7 +1428,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1456,7 +1456,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1770
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1750
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1476,7 +1476,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1572,7 +1572,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1580,16 +1580,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:291 lxc/storage_volume.go:405 lxc/storage_volume.go:626 lxc/storage_volume.go:735 lxc/storage_volume.go:822 lxc/storage_volume.go:927 lxc/storage_volume.go:1031 lxc/storage_volume.go:1252 lxc/storage_volume.go:1383 lxc/storage_volume.go:1545 lxc/storage_volume.go:1629 lxc/storage_volume.go:1882 lxc/storage_volume.go:1981 lxc/storage_volume.go:2108 lxc/storage_volume.go:2266 lxc/storage_volume.go:2387 lxc/storage_volume.go:2449 lxc/storage_volume.go:2585 lxc/storage_volume.go:2668 lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:309 lxc/storage_volume.go:385 lxc/storage_volume.go:606 lxc/storage_volume.go:715 lxc/storage_volume.go:802 lxc/storage_volume.go:907 lxc/storage_volume.go:1011 lxc/storage_volume.go:1232 lxc/storage_volume.go:1363 lxc/storage_volume.go:1525 lxc/storage_volume.go:1609 lxc/storage_volume.go:1862 lxc/storage_volume.go:1961 lxc/storage_volume.go:2088 lxc/storage_volume.go:2246 lxc/storage_volume.go:2367 lxc/storage_volume.go:2429 lxc/storage_volume.go:2565 lxc/storage_volume.go:2648 lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1601,11 +1601,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1840,7 +1840,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1848,7 +1848,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1896,7 +1896,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1906,7 +1906,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2193 lxc/storage_volume.go:2231
+#: lxc/cluster.go:457 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2173 lxc/storage_volume.go:2211
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1946,7 +1946,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546 lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526 lxc/storage_volume.go:1576
 msgid   "Expires at"
 msgstr  ""
 
@@ -1969,7 +1969,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1981,11 +1981,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2233,7 +2233,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2357,7 +2357,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2421,11 +2421,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2553,7 +2553,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2565,7 +2565,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2615,7 +2615,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2623,7 +2623,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2643,11 +2643,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2772,7 +2772,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2780,7 +2780,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2798,7 +2798,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316 lxc/storage_volume.go:1440 lxc/storage_volume.go:2029 lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296 lxc/storage_volume.go:1420 lxc/storage_volume.go:2009 lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2842,7 +2842,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -3150,11 +3150,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3211,7 +3211,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3462,11 +3462,11 @@ msgstr  ""
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid   "Manage storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid   "Manage storage volumes\n"
         "\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
@@ -3620,7 +3620,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:211 lxc/storage_volume.go:333 lxc/storage_volume.go:664 lxc/storage_volume.go:771 lxc/storage_volume.go:862 lxc/storage_volume.go:967 lxc/storage_volume.go:1088 lxc/storage_volume.go:1305 lxc/storage_volume.go:2018 lxc/storage_volume.go:2159 lxc/storage_volume.go:2317 lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:281 lxc/storage_volume.go:351 lxc/storage_volume.go:644 lxc/storage_volume.go:751 lxc/storage_volume.go:842 lxc/storage_volume.go:947 lxc/storage_volume.go:1068 lxc/storage_volume.go:1285 lxc/storage_volume.go:1998 lxc/storage_volume.go:2139 lxc/storage_volume.go:2297 lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3636,11 +3636,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -3676,7 +3676,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889 lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869 lxc/storage_volume.go:973
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -3708,7 +3708,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3716,11 +3716,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -3741,7 +3741,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1074 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid   "NAME"
 msgstr  ""
 
@@ -3791,7 +3791,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544 lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524 lxc/storage_volume.go:1574
 msgid   "Name"
 msgstr  ""
 
@@ -3799,7 +3799,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3942,7 +3942,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -3962,11 +3962,11 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -3980,7 +3980,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3988,19 +3988,15 @@ msgstr  ""
 msgid   "OVN:"
 msgstr  ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:353
-msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr  ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -4012,7 +4008,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -4025,7 +4021,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4055,7 +4051,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid   "POOL"
 msgstr  ""
 
@@ -4071,7 +4067,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4137,7 +4133,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186 lxc/storage_volume.go:1218
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166 lxc/storage_volume.go:1198
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4254,7 +4250,7 @@ msgstr  ""
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4265,7 +4261,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4278,7 +4274,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4294,7 +4290,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4302,7 +4298,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4313,7 +4309,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4397,7 +4393,7 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -4594,15 +4590,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4652,7 +4648,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -4949,11 +4945,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5036,7 +5032,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5181,11 +5177,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5251,15 +5247,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5364,21 +5360,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5439,11 +5435,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid   "Taken at"
 msgstr  ""
 
@@ -5596,12 +5592,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -5618,7 +5614,7 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903 lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883 lxc/storage_volume.go:987
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -5687,7 +5683,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5702,7 +5698,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5710,7 +5706,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -5766,7 +5762,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1490
+#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1470
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5788,11 +5784,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581 lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid   "USED BY"
 msgstr  ""
 
@@ -5824,7 +5820,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5929,7 +5925,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5981,7 +5977,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -5989,7 +5985,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid   "Unsupported content type for attaching to instances"
 msgstr  ""
 
@@ -6023,12 +6019,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6093,7 +6089,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6146,12 +6142,12 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:925
-msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:289
-msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid   "[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] [<path>]"
 msgstr  ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:980 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:707 lxc/project.go:475 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
@@ -6542,7 +6538,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6574,63 +6570,63 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:820
-msgid   "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr  ""
-
-#: lxc/storage_volume.go:167
-msgid   "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr  ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr  ""
+
+#: lxc/storage_volume.go:237
+msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] [<path>]"
+msgstr  ""
+
+#: lxc/storage_volume.go:1230
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -6734,7 +6730,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -7132,19 +7128,19 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -968,7 +968,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -1023,22 +1023,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1093,16 +1093,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1268,12 +1268,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1393,14 +1393,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1417,7 +1417,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1460,17 +1460,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1532,7 +1532,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1540,12 +1540,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1558,7 +1558,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1780,7 +1780,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1896,7 +1896,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2000,28 +2000,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2033,11 +2033,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2279,7 +2279,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2288,7 +2288,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2359,8 +2359,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2402,8 +2402,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2427,7 +2427,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2439,11 +2439,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2708,7 +2708,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2832,7 +2832,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2896,11 +2896,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3042,7 +3042,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3122,11 +3122,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3252,7 +3252,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3278,9 +3278,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3326,7 +3326,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3647,11 +3647,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3710,7 +3710,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3964,11 +3964,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4179,13 +4179,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4204,11 +4204,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4245,8 +4245,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4283,7 +4283,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4291,11 +4291,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4322,7 +4322,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4374,8 +4374,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4383,7 +4383,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4527,7 +4527,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4547,11 +4547,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4565,7 +4565,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4573,21 +4573,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4599,7 +4594,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4612,7 +4607,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4642,7 +4637,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4659,7 +4654,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4733,8 +4728,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4851,7 +4846,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4865,7 +4860,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4881,7 +4876,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4902,7 +4897,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4911,7 +4906,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4924,7 +4919,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5010,7 +5005,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5209,15 +5204,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5269,7 +5264,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5593,11 +5588,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5682,7 +5677,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5831,11 +5826,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5903,15 +5898,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6016,21 +6011,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6094,11 +6089,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6255,12 +6250,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6279,8 +6274,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6355,7 +6350,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6370,7 +6365,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6378,7 +6373,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6437,7 +6432,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6459,13 +6454,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6498,7 +6493,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6603,7 +6598,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6655,7 +6650,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6663,7 +6658,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6699,12 +6694,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6771,7 +6766,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6830,12 +6825,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7258,7 +7256,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7293,65 +7291,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7457,7 +7458,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7933,7 +7934,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7941,13 +7942,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -1061,22 +1061,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1131,16 +1131,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1204,7 +1204,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1306,12 +1306,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1431,14 +1431,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1455,7 +1455,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1498,17 +1498,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1570,7 +1570,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1578,12 +1578,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1596,7 +1596,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1731,7 +1731,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1818,7 +1818,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1934,7 +1934,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2038,28 +2038,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2071,11 +2071,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2317,7 +2317,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2326,7 +2326,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2383,7 +2383,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2397,8 +2397,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2440,8 +2440,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2465,7 +2465,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2477,11 +2477,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2746,7 +2746,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2870,7 +2870,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2934,11 +2934,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3066,7 +3066,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3080,7 +3080,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3130,7 +3130,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3138,7 +3138,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3290,7 +3290,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3298,7 +3298,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3316,9 +3316,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3364,7 +3364,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3685,11 +3685,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3748,7 +3748,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4002,11 +4002,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4217,13 +4217,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4242,11 +4242,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4283,8 +4283,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4321,7 +4321,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4329,11 +4329,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4360,7 +4360,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4412,8 +4412,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4421,7 +4421,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4565,7 +4565,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4585,11 +4585,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4603,7 +4603,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4611,21 +4611,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4637,7 +4632,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4650,7 +4645,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4680,7 +4675,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4697,7 +4692,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4771,8 +4766,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4889,7 +4884,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4903,7 +4898,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4919,7 +4914,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4940,7 +4935,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4949,7 +4944,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4962,7 +4957,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5048,7 +5043,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5247,15 +5242,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5307,7 +5302,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5631,11 +5626,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5720,7 +5715,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5869,11 +5864,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5941,15 +5936,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6054,21 +6049,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6132,11 +6127,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6293,12 +6288,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6317,8 +6312,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6393,7 +6388,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6408,7 +6403,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6416,7 +6411,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6475,7 +6470,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6497,13 +6492,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6536,7 +6531,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6641,7 +6636,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6693,7 +6688,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6701,7 +6696,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6737,12 +6732,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6809,7 +6804,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6868,12 +6863,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7296,7 +7294,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7331,65 +7329,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7495,7 +7496,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7971,7 +7972,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7979,13 +7980,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -796,22 +796,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -866,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1233,17 +1233,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1553,7 +1553,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1773,28 +1773,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1806,11 +1806,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2132,8 +2132,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2175,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2212,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2481,7 +2481,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2669,11 +2669,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3025,7 +3025,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3051,9 +3051,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3420,11 +3420,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,7 +3483,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3737,11 +3737,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3952,13 +3952,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3977,11 +3977,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4018,8 +4018,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4056,7 +4056,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4064,11 +4064,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4095,7 +4095,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4147,8 +4147,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4156,7 +4156,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4346,21 +4346,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4372,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4385,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4415,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4432,7 +4427,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4506,8 +4501,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4624,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4638,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4654,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4684,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4783,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4982,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5042,7 +5037,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5366,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5455,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5604,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5676,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5789,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5867,11 +5862,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6028,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6052,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6128,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6143,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6151,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6210,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6232,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6271,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6376,7 +6371,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6428,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6436,7 +6431,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6472,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6544,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6603,12 +6598,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7031,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7066,65 +7064,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7230,7 +7231,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7706,7 +7707,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7714,13 +7715,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -1011,7 +1011,7 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1072,23 +1072,23 @@ msgstr "Anexar interfaces de rede aos perfis"
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1145,16 +1145,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr "par de chave/valor inválido %s"
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1218,7 +1218,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1305,7 +1305,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1322,12 +1322,12 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1449,14 +1449,14 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1473,7 +1473,7 @@ msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
 
@@ -1525,17 +1525,17 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1599,7 +1599,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1607,12 +1607,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1626,7 +1626,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1773,7 +1773,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1868,7 +1868,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1998,7 +1998,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2102,28 +2102,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2137,12 +2137,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2419,7 +2419,7 @@ msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2476,7 +2476,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2490,8 +2490,8 @@ msgstr "Editar propriedades da imagem"
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2534,8 +2534,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2559,7 +2559,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2571,11 +2571,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2841,7 +2841,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2973,7 +2973,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3049,11 +3049,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3181,7 +3181,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3195,7 +3195,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3247,7 +3247,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3255,7 +3255,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3277,11 +3277,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3407,7 +3407,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -3416,7 +3416,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3434,9 +3434,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3483,7 +3483,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3813,11 +3813,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3876,7 +3876,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4155,11 +4155,11 @@ msgstr "Criar novas redes"
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4387,13 +4387,13 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4412,11 +4412,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -4455,8 +4455,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4494,7 +4494,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4502,11 +4502,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4533,7 +4533,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4585,8 +4585,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4594,7 +4594,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4738,7 +4738,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4758,11 +4758,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4776,7 +4776,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4784,21 +4784,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4810,7 +4805,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4823,7 +4818,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4853,7 +4848,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4870,7 +4865,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4945,8 +4940,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5068,7 +5063,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5082,7 +5077,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5098,7 +5093,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5119,7 +5114,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5128,7 +5123,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5141,7 +5136,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5230,7 +5225,7 @@ msgstr "Editar arquivos no container"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5446,15 +5441,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5513,7 +5508,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5853,11 +5848,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5948,7 +5943,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -6116,11 +6111,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6192,15 +6187,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6305,21 +6300,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6384,11 +6379,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6549,12 +6544,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6573,8 +6568,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6651,7 +6646,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6666,7 +6661,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6674,7 +6669,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6735,7 +6730,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6757,13 +6752,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6797,7 +6792,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6919,7 +6914,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6978,7 +6973,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6986,7 +6981,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7024,12 +7019,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7096,7 +7091,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -7155,14 +7150,17 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7631,7 +7629,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7671,74 +7669,77 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr "Criar perfis"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr "Criar perfis"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr "Criar perfis"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr "Criar perfis"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -7856,7 +7857,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -8336,7 +8337,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8344,13 +8345,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1070,23 +1070,23 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1142,16 +1142,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1302,7 +1302,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1319,12 +1319,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1449,14 +1449,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -1516,17 +1516,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1589,7 +1589,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1598,12 +1598,12 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1617,7 +1617,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1762,7 +1762,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1823,7 +1823,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1859,7 +1859,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1984,7 +1984,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -2089,28 +2089,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2123,12 +2123,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2387,7 +2387,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2453,7 +2453,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2467,8 +2467,8 @@ msgstr "Копирование образа: %s"
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2514,8 +2514,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2540,7 +2540,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2555,12 +2555,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2826,7 +2826,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2958,7 +2958,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -3030,11 +3030,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3163,7 +3163,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3177,7 +3177,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3228,7 +3228,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3236,7 +3236,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3261,11 +3261,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3394,7 +3394,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -3403,7 +3403,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3421,9 +3421,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3470,7 +3470,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3807,12 +3807,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3872,7 +3872,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4152,12 +4152,12 @@ msgstr "Копирование образа: %s"
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 #, fuzzy
 msgid "Manage storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4386,13 +4386,13 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4412,12 +4412,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -4456,8 +4456,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4495,7 +4495,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -4504,11 +4504,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -4535,7 +4535,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4587,8 +4587,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4596,7 +4596,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4742,7 +4742,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -4763,11 +4763,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4781,7 +4781,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4790,21 +4790,16 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4816,7 +4811,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4829,7 +4824,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4859,7 +4854,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4876,7 +4871,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4951,8 +4946,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5069,7 +5064,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5083,7 +5078,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5099,7 +5094,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5120,7 +5115,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5129,7 +5124,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5142,7 +5137,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5230,7 +5225,7 @@ msgstr "Псевдонимы:"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -5442,17 +5437,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5507,7 +5502,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5843,11 +5838,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5939,7 +5934,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6103,11 +6098,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6179,16 +6174,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -6296,21 +6291,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6375,11 +6370,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6536,12 +6531,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6560,8 +6555,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6637,7 +6632,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6652,7 +6647,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6660,7 +6655,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6720,7 +6715,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6742,13 +6737,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6781,7 +6776,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6897,7 +6892,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6957,7 +6952,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6966,7 +6961,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7004,12 +6999,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7076,7 +7071,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -7135,17 +7130,20 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
+#: lxc/storage_volume.go:905
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:289
+#: lxc/storage_volume.go:307
 #, fuzzy
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -7939,7 +7937,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8006,7 +8004,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8016,7 +8014,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8024,7 +8022,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8032,7 +8030,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8040,7 +8038,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8048,7 +8046,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8056,7 +8054,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8064,23 +8062,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:820
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-"Изменение состояния одного или нескольких контейнеров %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-"Изменение состояния одного или нескольких контейнеров %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8088,7 +8070,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8096,7 +8078,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8104,7 +8086,26 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:237
+#, fuzzy
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:1230
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8112,7 +8113,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8120,7 +8121,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8330,7 +8331,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8822,7 +8823,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8830,13 +8831,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -800,22 +800,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -870,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1237,17 +1237,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1557,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1777,28 +1777,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1810,11 +1810,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2065,7 +2065,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2136,8 +2136,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2179,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2216,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2485,7 +2485,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2609,7 +2609,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2673,11 +2673,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2805,7 +2805,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3029,7 +3029,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3055,9 +3055,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3103,7 +3103,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3741,11 +3741,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3956,13 +3956,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3981,11 +3981,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4022,8 +4022,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4060,7 +4060,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4068,11 +4068,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4099,7 +4099,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4151,8 +4151,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4160,7 +4160,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4324,11 +4324,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4350,21 +4350,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4376,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4389,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4419,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4436,7 +4431,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4510,8 +4505,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4628,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4642,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4658,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4688,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4701,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4787,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4986,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5041,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5370,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5459,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5608,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5680,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5793,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5871,11 +5866,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6032,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6056,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6132,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6147,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6155,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6214,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6236,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6275,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6380,7 +6375,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6432,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6440,7 +6435,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6476,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6548,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6607,12 +6602,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7035,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7070,65 +7068,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7234,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7710,7 +7711,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7718,13 +7719,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -800,22 +800,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -870,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1237,17 +1237,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1557,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1777,28 +1777,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1810,11 +1810,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2065,7 +2065,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2136,8 +2136,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2179,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2216,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2485,7 +2485,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2609,7 +2609,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2673,11 +2673,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2805,7 +2805,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3029,7 +3029,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3055,9 +3055,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3103,7 +3103,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3741,11 +3741,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3956,13 +3956,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3981,11 +3981,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4022,8 +4022,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4060,7 +4060,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4068,11 +4068,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4099,7 +4099,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4151,8 +4151,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4160,7 +4160,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4324,11 +4324,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4350,21 +4350,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4376,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4389,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4419,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4436,7 +4431,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4510,8 +4505,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4628,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4642,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4658,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4688,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4701,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4787,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4986,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5041,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5370,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5459,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5608,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5680,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5793,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5871,11 +5866,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6032,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6056,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6132,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6147,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6155,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6214,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6236,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6275,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6380,7 +6375,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6432,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6440,7 +6435,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6476,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6548,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6607,12 +6602,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7035,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7070,65 +7068,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7234,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7710,7 +7711,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7718,13 +7719,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -796,22 +796,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -866,16 +866,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -939,7 +939,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1041,12 +1041,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1166,14 +1166,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1190,7 +1190,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1233,17 +1233,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1305,7 +1305,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1313,12 +1313,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1553,7 +1553,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1669,7 +1669,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1773,28 +1773,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1806,11 +1806,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2061,7 +2061,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2118,7 +2118,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2132,8 +2132,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2175,8 +2175,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2200,7 +2200,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2212,11 +2212,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2481,7 +2481,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2605,7 +2605,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2669,11 +2669,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3025,7 +3025,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3051,9 +3051,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3099,7 +3099,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3420,11 +3420,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3483,7 +3483,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3737,11 +3737,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3952,13 +3952,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3977,11 +3977,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4018,8 +4018,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4056,7 +4056,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4064,11 +4064,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4095,7 +4095,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4147,8 +4147,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4156,7 +4156,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4300,7 +4300,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4320,11 +4320,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4338,7 +4338,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4346,21 +4346,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4372,7 +4367,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4385,7 +4380,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4415,7 +4410,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4432,7 +4427,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4506,8 +4501,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4624,7 +4619,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4638,7 +4633,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4654,7 +4649,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,7 +4670,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4684,7 +4679,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4697,7 +4692,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4783,7 +4778,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4982,15 +4977,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5042,7 +5037,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5366,11 +5361,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5455,7 +5450,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5604,11 +5599,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5676,15 +5671,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5789,21 +5784,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5867,11 +5862,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6028,12 +6023,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6052,8 +6047,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6128,7 +6123,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6143,7 +6138,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6151,7 +6146,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6210,7 +6205,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6232,13 +6227,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6271,7 +6266,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6376,7 +6371,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6428,7 +6423,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6436,7 +6431,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6472,12 +6467,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6544,7 +6539,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6603,12 +6598,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7031,7 +7029,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7066,65 +7064,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7230,7 +7231,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7706,7 +7707,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7714,13 +7715,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -800,22 +800,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -870,16 +870,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -943,7 +943,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1045,12 +1045,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1170,14 +1170,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1194,7 +1194,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1237,17 +1237,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1317,12 +1317,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1470,7 +1470,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1557,7 +1557,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1777,28 +1777,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1810,11 +1810,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2056,7 +2056,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2065,7 +2065,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2122,7 +2122,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2136,8 +2136,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2179,8 +2179,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2204,7 +2204,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2216,11 +2216,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2485,7 +2485,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2609,7 +2609,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2673,11 +2673,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2805,7 +2805,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,7 +2877,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3029,7 +3029,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3055,9 +3055,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3103,7 +3103,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3424,11 +3424,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3487,7 +3487,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3741,11 +3741,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3956,13 +3956,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3981,11 +3981,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4022,8 +4022,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4060,7 +4060,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4068,11 +4068,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4099,7 +4099,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4151,8 +4151,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4160,7 +4160,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4304,7 +4304,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4324,11 +4324,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4342,7 +4342,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4350,21 +4350,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4376,7 +4371,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4389,7 +4384,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4419,7 +4414,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4436,7 +4431,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4510,8 +4505,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4628,7 +4623,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4642,7 +4637,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4658,7 +4653,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,7 +4674,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4688,7 +4683,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4701,7 +4696,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4787,7 +4782,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4986,15 +4981,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5046,7 +5041,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5370,11 +5365,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5459,7 +5454,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5608,11 +5603,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5680,15 +5675,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5793,21 +5788,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5871,11 +5866,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6032,12 +6027,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6056,8 +6051,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6132,7 +6127,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6147,7 +6142,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6155,7 +6150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6214,7 +6209,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6236,13 +6231,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6275,7 +6270,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6380,7 +6375,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6432,7 +6427,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6440,7 +6435,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6476,12 +6471,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6548,7 +6543,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6607,12 +6602,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7035,7 +7033,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7070,65 +7068,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7234,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7710,7 +7711,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7718,13 +7719,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -960,22 +960,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -1030,16 +1030,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1188,7 +1188,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1205,12 +1205,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1330,14 +1330,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1354,7 +1354,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1397,17 +1397,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1477,12 +1477,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1495,7 +1495,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1717,7 +1717,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1737,7 +1737,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1937,28 +1937,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1970,11 +1970,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2216,7 +2216,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2225,7 +2225,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2282,7 +2282,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2296,8 +2296,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2339,8 +2339,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2364,7 +2364,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2376,11 +2376,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2645,7 +2645,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2833,11 +2833,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2965,7 +2965,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3037,7 +3037,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3059,11 +3059,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3189,7 +3189,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3197,7 +3197,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3215,9 +3215,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3263,7 +3263,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3584,11 +3584,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3647,7 +3647,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3901,11 +3901,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -4116,13 +4116,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -4141,11 +4141,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4182,8 +4182,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4220,7 +4220,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4228,11 +4228,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4259,7 +4259,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4311,8 +4311,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4320,7 +4320,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4464,7 +4464,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4484,11 +4484,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4502,7 +4502,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4510,21 +4510,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4536,7 +4531,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4549,7 +4544,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4579,7 +4574,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4596,7 +4591,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4670,8 +4665,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4788,7 +4783,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4802,7 +4797,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4818,7 +4813,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4839,7 +4834,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4848,7 +4843,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4861,7 +4856,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4947,7 +4942,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5146,15 +5141,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5206,7 +5201,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5530,11 +5525,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5619,7 +5614,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5768,11 +5763,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5840,15 +5835,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5953,21 +5948,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6031,11 +6026,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6192,12 +6187,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6216,8 +6211,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6292,7 +6287,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6307,7 +6302,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6315,7 +6310,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6374,7 +6369,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6396,13 +6391,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6435,7 +6430,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6540,7 +6535,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6592,7 +6587,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6600,7 +6595,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6636,12 +6631,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6708,7 +6703,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6767,12 +6762,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7195,7 +7193,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7230,65 +7228,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7394,7 +7395,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7870,7 +7871,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7878,13 +7879,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 10:13+0100\n"
+"POT-Creation-Date: 2025-03-03 09:58-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1059
+#: lxc/storage_volume.go:1039
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1628
+#: lxc/storage_volume.go:1608
 msgid "All projects"
 msgstr ""
 
@@ -799,22 +799,22 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168
+#: lxc/storage_volume.go:238
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:169
+#: lxc/storage_volume.go:239
 msgid ""
 "Attach new storage volumes to instances\n"
 "\n"
 "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
-#: lxc/storage_volume.go:290
+#: lxc/storage_volume.go:308
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:291
+#: lxc/storage_volume.go:309
 msgid ""
 "Attach new storage volumes to profiles\n"
 "\n"
@@ -869,16 +869,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2740
+#: lxc/storage_volume.go:2720
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2817
+#: lxc/export.go:192 lxc/storage_volume.go:2797
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1559
+#: lxc/info.go:666 lxc/storage_volume.go:1539
 msgid "Backups:"
 msgstr ""
 
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:700
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:680
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -942,7 +942,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1771
+#: lxc/storage_volume.go:1751
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1781 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1761 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1044,12 +1044,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:507
+#: lxc/storage_volume.go:487
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:461
+#: lxc/storage_volume.go:441
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1169,14 +1169,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:409
-#: lxc/storage_volume.go:633 lxc/storage_volume.go:738
-#: lxc/storage_volume.go:1040 lxc/storage_volume.go:1266
-#: lxc/storage_volume.go:1395 lxc/storage_volume.go:1886
-#: lxc/storage_volume.go:1984 lxc/storage_volume.go:2123
-#: lxc/storage_volume.go:2283 lxc/storage_volume.go:2399
-#: lxc/storage_volume.go:2460 lxc/storage_volume.go:2587
-#: lxc/storage_volume.go:2675 lxc/storage_volume.go:2839
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:389
+#: lxc/storage_volume.go:613 lxc/storage_volume.go:718
+#: lxc/storage_volume.go:1020 lxc/storage_volume.go:1246
+#: lxc/storage_volume.go:1375 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
+#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgid "Clustering enabled"
 msgstr ""
 
 #: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
-#: lxc/storage_volume.go:1627 lxc/warning.go:93
+#: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
 
@@ -1236,17 +1236,17 @@ msgstr ""
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
 #: lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1185
-#: lxc/storage_volume.go:1217
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165
+#: lxc/storage_volume.go:1197
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:634
+#: lxc/storage_volume.go:614
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1496
+#: lxc/storage_volume.go:1476
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:404 lxc/storage_volume.go:405
+#: lxc/storage_volume.go:384 lxc/storage_volume.go:385
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1316,12 +1316,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:411
+#: lxc/storage_volume.go:391
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
-#: lxc/storage_volume.go:412
+#: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1334,7 +1334,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:529
+#: lxc/storage_volume.go:509
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:625 lxc/storage_volume.go:626
+#: lxc/storage_volume.go:605 lxc/storage_volume.go:606
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1513
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1770
+#: lxc/storage_volume.go:1750
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2674
+#: lxc/storage_volume.go:2654
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1672,7 +1672,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:734 lxc/storage_volume.go:735
+#: lxc/storage_volume.go:714 lxc/storage_volume.go:715
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1776,28 +1776,28 @@ msgstr ""
 #: lxc/storage_bucket.go:699 lxc/storage_bucket.go:733
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
-#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:291
-#: lxc/storage_volume.go:405 lxc/storage_volume.go:626
-#: lxc/storage_volume.go:735 lxc/storage_volume.go:822
-#: lxc/storage_volume.go:927 lxc/storage_volume.go:1031
-#: lxc/storage_volume.go:1252 lxc/storage_volume.go:1383
-#: lxc/storage_volume.go:1545 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1882 lxc/storage_volume.go:1981
-#: lxc/storage_volume.go:2108 lxc/storage_volume.go:2266
-#: lxc/storage_volume.go:2387 lxc/storage_volume.go:2449
-#: lxc/storage_volume.go:2585 lxc/storage_volume.go:2668
-#: lxc/storage_volume.go:2834 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_bucket.go:1158 lxc/storage_volume.go:66
+#: lxc/storage_volume.go:239 lxc/storage_volume.go:309
+#: lxc/storage_volume.go:385 lxc/storage_volume.go:606
+#: lxc/storage_volume.go:715 lxc/storage_volume.go:802
+#: lxc/storage_volume.go:907 lxc/storage_volume.go:1011
+#: lxc/storage_volume.go:1232 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1525 lxc/storage_volume.go:1609
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
+#: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1483
+#: lxc/storage_volume.go:1463
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:410 lxc/storage_volume.go:1887
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:1867
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1809,11 +1809,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:821 lxc/storage_volume.go:822
+#: lxc/storage_volume.go:801 lxc/storage_volume.go:802
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:926 lxc/storage_volume.go:927
+#: lxc/storage_volume.go:906 lxc/storage_volume.go:907
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2055,7 +2055,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1030 lxc/storage_volume.go:1031
+#: lxc/storage_volume.go:1010 lxc/storage_volume.go:1011
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgid "Edit trust configurations as YAML"
 msgstr ""
 
 #: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
-#: lxc/storage_volume.go:1804 lxc/warning.go:236
+#: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -2121,7 +2121,7 @@ msgstr ""
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
 #: lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2199 lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2135,8 +2135,8 @@ msgstr ""
 #: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:1076 lxc/project.go:720 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2193
-#: lxc/storage_volume.go:2231
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2173
+#: lxc/storage_volume.go:2211
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2178,8 +2178,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1546
-#: lxc/storage_volume.go:1596
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1526
+#: lxc/storage_volume.go:1576
 msgid "Expires at"
 msgstr ""
 
@@ -2203,7 +2203,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2667 lxc/storage_volume.go:2668
+#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2215,11 +2215,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2671
+#: lxc/storage_volume.go:2651
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2800
+#: lxc/export.go:152 lxc/storage_volume.go:2780
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2484,7 +2484,7 @@ msgstr ""
 #: lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480
 #: lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1646 lxc/warning.go:94
+#: lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2608,7 +2608,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1267
+#: lxc/storage_volume.go:1247
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2672,11 +2672,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1251 lxc/storage_volume.go:1252
+#: lxc/storage_volume.go:1231 lxc/storage_volume.go:1232
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:490
+#: lxc/storage_volume.go:470
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2804,7 +2804,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2459
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2439
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2458
+#: lxc/storage_volume.go:2438
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2834
+#: lxc/storage_volume.go:2814
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,7 +2876,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2833
+#: lxc/storage_volume.go:2813
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2841
+#: lxc/storage_volume.go:2821
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2915
+#: lxc/storage_volume.go:2895
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3028,7 +3028,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:153 lxc/storage_volume.go:2044
+#: lxc/move.go:153 lxc/storage_volume.go:2024
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3036,7 +3036,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2040
+#: lxc/storage_volume.go:2020
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3054,9 +3054,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1099 lxc/storage_volume.go:1316
-#: lxc/storage_volume.go:1440 lxc/storage_volume.go:2029
-#: lxc/storage_volume.go:2176 lxc/storage_volume.go:2328
+#: lxc/storage_volume.go:1079 lxc/storage_volume.go:1296
+#: lxc/storage_volume.go:1420 lxc/storage_volume.go:2009
+#: lxc/storage_volume.go:2156 lxc/storage_volume.go:2308
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3102,7 +3102,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1777 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1757 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3423,11 +3423,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1624
+#: lxc/storage_volume.go:1604
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1629
+#: lxc/storage_volume.go:1609
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3486,7 +3486,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1499
+#: lxc/info.go:489 lxc/storage_volume.go:1479
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3740,11 +3740,11 @@ msgstr ""
 msgid "Manage storage pools and volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:57
+#: lxc/storage_volume.go:65
 msgid "Manage storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:58
+#: lxc/storage_volume.go:66
 msgid ""
 "Manage storage volumes\n"
 "\n"
@@ -3955,13 +3955,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
-#: lxc/storage_volume.go:333 lxc/storage_volume.go:664
-#: lxc/storage_volume.go:771 lxc/storage_volume.go:862
-#: lxc/storage_volume.go:967 lxc/storage_volume.go:1088
-#: lxc/storage_volume.go:1305 lxc/storage_volume.go:2018
-#: lxc/storage_volume.go:2159 lxc/storage_volume.go:2317
-#: lxc/storage_volume.go:2508 lxc/storage_volume.go:2625
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:281
+#: lxc/storage_volume.go:351 lxc/storage_volume.go:644
+#: lxc/storage_volume.go:751 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:947 lxc/storage_volume.go:1068
+#: lxc/storage_volume.go:1285 lxc/storage_volume.go:1998
+#: lxc/storage_volume.go:2139 lxc/storage_volume.go:2297
+#: lxc/storage_volume.go:2488 lxc/storage_volume.go:2605
 msgid "Missing pool name"
 msgstr ""
 
@@ -3980,11 +3980,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1928
+#: lxc/storage_volume.go:433 lxc/storage_volume.go:1908
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1409
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4021,8 +4021,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:889
-#: lxc/storage_volume.go:993
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:869
+#: lxc/storage_volume.go:973
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4059,7 +4059,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1881 lxc/storage_volume.go:1882
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1862
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4067,11 +4067,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1888
+#: lxc/storage_volume.go:1868
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:533
+#: lxc/storage_volume.go:513
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4098,7 +4098,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:748 lxc/project.go:573
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1769
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1749
 msgid "NAME"
 msgstr ""
 
@@ -4150,8 +4150,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1544
-#: lxc/storage_volume.go:1594
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1524
+#: lxc/storage_volume.go:1574
 msgid "Name"
 msgstr ""
 
@@ -4159,7 +4159,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1481
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1461
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4303,7 +4303,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:898 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:878 lxc/storage_volume.go:982
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4323,11 +4323,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:467 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:447 lxc/storage_volume.go:1917
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:517 lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:497 lxc/storage_volume.go:1928
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4341,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2056
+#: lxc/storage_volume.go:2036
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4349,21 +4349,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:216
+#: lxc/storage_volume.go:169
 msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:353
-msgid ""
-"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
-msgstr ""
-
-#: lxc/storage_volume.go:2722
+#: lxc/storage_volume.go:2702
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2521
+#: lxc/storage_volume.go:2501
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4375,7 +4370,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1447
+#: lxc/storage_volume.go:1427
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4388,7 +4383,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1598
+#: lxc/info.go:705 lxc/storage_volume.go:1578
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4418,7 +4413,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1788
+#: lxc/storage_volume.go:1768
 msgid "POOL"
 msgstr ""
 
@@ -4435,7 +4430,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
-#: lxc/storage_volume.go:1794 lxc/warning.go:213
+#: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4509,8 +4504,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
 #: lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1186
-#: lxc/storage_volume.go:1218
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166
+#: lxc/storage_volume.go:1198
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4627,7 +4622,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1385
+#: lxc/storage_volume.go:1365
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4641,7 +4636,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1254
+#: lxc/storage_volume.go:1234
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4657,7 +4652,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2268
+#: lxc/storage_volume.go:2248
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,7 +4673,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1033
+#: lxc/storage_volume.go:1013
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4687,7 +4682,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2113
+#: lxc/storage_volume.go:2093
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4695,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2389
+#: lxc/storage_volume.go:2369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4781,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:413
+#: lxc/storage_volume.go:393
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4985,15 +4980,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1981
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1980
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2069 lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2049 lxc/storage_volume.go:2069
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5045,7 +5040,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2584 lxc/storage_volume.go:2585
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2565
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5369,11 +5364,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2107
+#: lxc/storage_volume.go:2087
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2108
+#: lxc/storage_volume.go:2088
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5458,7 +5453,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2124
+#: lxc/storage_volume.go:2104
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5607,11 +5602,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2265 lxc/storage_volume.go:2266
+#: lxc/storage_volume.go:2245 lxc/storage_volume.go:2246
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1382 lxc/storage_volume.go:1383
+#: lxc/storage_volume.go:1362 lxc/storage_volume.go:1363
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5679,15 +5674,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2448 lxc/storage_volume.go:2449
+#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2429
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2211
+#: lxc/storage_volume.go:2191
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1523
+#: lxc/info.go:619 lxc/storage_volume.go:1503
 msgid "Snapshots:"
 msgstr ""
 
@@ -5792,21 +5787,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:697
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:785
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:530
+#: lxc/storage_volume.go:510
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:534
+#: lxc/storage_volume.go:514
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5870,11 +5865,11 @@ msgstr ""
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1768 lxc/warning.go:216
+#: lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1595
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1575
 msgid "Taken at"
 msgstr ""
 
@@ -6031,12 +6026,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1338
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1335
+#: lxc/storage_volume.go:1315
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6055,8 +6050,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:903
-#: lxc/storage_volume.go:1007
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:883
+#: lxc/storage_volume.go:987
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6131,7 +6126,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1508
+#: lxc/storage_volume.go:1488
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6146,7 +6141,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1885
+#: lxc/storage_volume.go:1865
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6154,7 +6149,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:408
+#: lxc/storage_volume.go:388
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6213,7 +6208,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1490
+#: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6235,13 +6230,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:1001 lxc/storage_volume.go:1773
+#: lxc/project.go:1001 lxc/storage_volume.go:1753
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:751 lxc/project.go:581
-#: lxc/storage.go:724 lxc/storage_volume.go:1772
+#: lxc/storage.go:724 lxc/storage_volume.go:1752
 msgid "USED BY"
 msgstr ""
 
@@ -6274,7 +6269,7 @@ msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
 #: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
-#: lxc/storage_volume.go:1810 lxc/warning.go:242
+#: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -6379,7 +6374,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2386 lxc/storage_volume.go:2387
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2367
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6431,7 +6426,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2400
+#: lxc/storage_volume.go:2380
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6439,7 +6434,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:250
+#: lxc/storage_volume.go:200
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6475,12 +6470,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1504
+#: lxc/storage_volume.go:1484
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2673
+#: lxc/export.go:42 lxc/storage_volume.go:2653
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6547,7 +6542,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1577
 msgid "Volume Only"
 msgstr ""
 
@@ -6606,12 +6601,15 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:925
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:905
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:289
-msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:307
+msgid ""
+"[<remote:>]<pool> [<type>/]<volume>[/<snapshot>] <profile> [<device name>] "
+"[<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1897
@@ -7034,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2832
+#: lxc/storage_volume.go:2812
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7069,65 +7067,68 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1979
+#: lxc/storage_volume.go:1959
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2583
+#: lxc/storage_volume.go:2563
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2666
+#: lxc/storage_volume.go:2646
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2447
+#: lxc/storage_volume.go:2427
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:624
+#: lxc/storage_volume.go:604
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:732
+#: lxc/storage_volume.go:712
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1029 lxc/storage_volume.go:1381
+#: lxc/storage_volume.go:1009 lxc/storage_volume.go:1361
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:820
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2385
+#: lxc/storage_volume.go:2365
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2106
+#: lxc/storage_volume.go:2086
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2264
+#: lxc/storage_volume.go:2244
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:800
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:237
+msgid ""
+"[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <instance> [<device name>] "
+"[<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:1230
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1879
+#: lxc/storage_volume.go:1859
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:382
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7233,7 +7234,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1622
+#: lxc/storage_volume.go:1602
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7709,7 +7710,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:628
+#: lxc/storage_volume.go:608
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7717,13 +7718,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2836
+#: lxc/storage_volume.go:2816
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2451
+#: lxc/storage_volume.go:2431
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -431,7 +431,7 @@ var APIExtensions = []string{
 	"storage_ceph_osd_pool_size",
 	"network_get_target",
 	"network_zones_all_projects",
-	"instance_root_volume_attachment",
+	"vm_root_volume_attachment",
 	"projects_limits_uplink_ips",
 	"entities_with_entitlements",
 	"profiles_all_projects",


### PR DESCRIPTION
Attach a snapshot of `v1` to another VM as a disk device using this device config:
```
devices:
  v1-snap0:
    pool: default
    source: v1
    source.type: virtual-machine
    source.snapshot: snap0
    type: disk
```

Attempting to attach custom volume snapshots using this API will fail. I am planning to complete that functionality next week.

~~Tests in the works for lxd-ci~~https://github.com/canonical/lxd-ci/pull/413