### PR TITLE
VM: Fix nvram file update from older non-symlinked templates file in LXD 4.0

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6786,7 +6786,7 @@ func (d *qemu) migrateSendLive(pool storagePools.Pool, clusterMoveSourceName str
 		// Create qcow2 disk image with the maximum size set to the instance's root disk size for use as
 		// a CoW target for the migration snapshot. This will be used during migration to store writes in
 		// the guest whilst the storage driver is transferring the root disk and snapshots to the taget.
-		_, err = shared.RunCommandContext(d.state.ShutdownCtx, "qemu-img", "create", "-f", "qcow2", snapshotFile, fmt.Sprintf("%d", rootDiskSize))
+		_, err = shared.RunCommandContext(d.state.ShutdownCtx, "qemu-img", "create", "-f", "qcow2", snapshotFile, strconv.FormatInt(rootDiskSize, 10))
 		if err != nil {
 			return fmt.Errorf("Failed opening file image for migration storage snapshot %q: %w", snapshotFile, err)
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2598,6 +2598,7 @@ func (d *qemu) monitorPath() string {
 	return filepath.Join(d.LogPath(), "qemu.monitor")
 }
 
+// nvramPath returns the path to the UEFI firmware variables file.
 func (d *qemu) nvramPath() string {
 	return filepath.Join(d.Path(), "qemu.nvram")
 }


### PR DESCRIPTION
In LXD 4.0 the EFI firmware variables file was copied directly from the template file to the qemu.nvram file, rather than the copy being a separate file named after the firmware variant and symlinked to the qemu.nvram file.

Following on from https://github.com/canonical/lxd/pull/14555 this PR now considers that the EFI firmware variables file needs regenerating if the qemu.nvram file isn't a symlink.