### PR TITLE
OIDC: Make scopes configurable

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -148,7 +148,13 @@ func (r *ProtocolLXD) DoHTTP(req *http.Request) (*http.Response, error) {
 	r.addClientHeaders(req)
 
 	if r.oidcClient != nil {
-		return r.oidcClient.do(req)
+		var oidcScopesExtensionPresent bool
+		err := r.CheckExtension("oidc_scopes")
+		if err == nil {
+			oidcScopesExtensionPresent = true
+		}
+
+		return r.oidcClient.do(req, oidcScopesExtensionPresent)
 	}
 
 	return r.http.Do(req)

--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -3,6 +3,7 @@ package lxd
 import (
 	"context"
 	"crypto/rand"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -65,7 +66,6 @@ func (o *oidcTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 var errRefreshAccessToken = fmt.Errorf("Failed refreshing access token")
-var oidcScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}
 
 type oidcClient struct {
 	httpClient    *http.Client
@@ -101,7 +101,8 @@ func (o *oidcClient) getAccessToken() string {
 
 // do function executes an HTTP request using the oidcClient's http client, and manages authorization by refreshing or authenticating as needed.
 // If the request fails with an HTTP Unauthorized status, it attempts to refresh the access token, or perform an OIDC authentication if refresh fails.
-func (o *oidcClient) do(req *http.Request) (*http.Response, error) {
+// The oidcScopesExtensionPresent argument changes the behaviour of this function based on the presence of an API extension.
+func (o *oidcClient) do(req *http.Request, oidcScopesExtensionPresent bool) (*http.Response, error) {
 	resp, err := o.httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -115,11 +116,32 @@ func (o *oidcClient) do(req *http.Request) (*http.Response, error) {
 	issuer := resp.Header.Get("X-LXD-OIDC-issuer")
 	clientID := resp.Header.Get("X-LXD-OIDC-clientid")
 	audience := resp.Header.Get("X-LXD-OIDC-audience")
-	groupsClaim := resp.Header.Get("X-LXD-OIDC-groups-claim")
 
-	err = o.refresh(issuer, clientID, groupsClaim)
+	var scopes []string
+	if oidcScopesExtensionPresent {
+		// If we have the `oidc_scopes` extension, get the scopes from the header and ignore the groups claim header.
+		scopesJSON := resp.Header.Get("X-LXD-OIDC-scopes")
+		if scopesJSON == "" {
+			return nil, fmt.Errorf("LXD server did not return OIDC scopes")
+		}
+
+		err = json.Unmarshal([]byte(scopesJSON), &scopes)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse OIDC scopes: %w", err)
+		}
+	} else {
+		// Otherwise, use the default scopes from before the API extension was added, and append the groups claim header
+		// if set.
+		scopes = []string{oidc.ScopeOpenID, oidc.ScopeEmail, oidc.ScopeOfflineAccess, oidc.ScopeProfile}
+		groupsClaim := resp.Header.Get("X-LXD-OIDC-groups-claim")
+		if groupsClaim != "" {
+			scopes = append(scopes, groupsClaim)
+		}
+	}
+
+	err = o.refresh(issuer, clientID, scopes)
 	if err != nil {
-		err = o.authenticate(issuer, clientID, audience, groupsClaim)
+		err = o.authenticate(issuer, clientID, audience, scopes)
 		if err != nil {
 			return nil, err
 		}
@@ -138,7 +160,7 @@ func (o *oidcClient) do(req *http.Request) (*http.Response, error) {
 
 // getProvider initializes a new OpenID Connect Relying Party for a given issuer and clientID.
 // The function also creates a secure CookieHandler with random encryption and hash keys, and applies a series of configurations on the Relying Party.
-func (o *oidcClient) getProvider(issuer string, clientID string, groupsClaim string) (rp.RelyingParty, error) {
+func (o *oidcClient) getProvider(issuer string, clientID string, scopes []string) (rp.RelyingParty, error) {
 	hashKey := make([]byte, 16)
 	encryptKey := make([]byte, 16)
 
@@ -160,11 +182,6 @@ func (o *oidcClient) getProvider(issuer string, clientID string, groupsClaim str
 		rp.WithHTTPClient(o.httpClient),
 	}
 
-	scopes := oidcScopes
-	if groupsClaim != "" {
-		scopes = append(oidcScopes, groupsClaim)
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -178,12 +195,12 @@ func (o *oidcClient) getProvider(issuer string, clientID string, groupsClaim str
 
 // refresh attempts to refresh the OpenID Connect access token for the client using the refresh token.
 // If no token is present or the refresh token is empty, it returns an error. If successful, it updates the access token and other relevant token fields.
-func (o *oidcClient) refresh(issuer string, clientID string, groupsClaim string) error {
+func (o *oidcClient) refresh(issuer string, clientID string, scopes []string) error {
 	if o.tokens.Token == nil || o.tokens.RefreshToken == "" {
 		return errRefreshAccessToken
 	}
 
-	provider, err := o.getProvider(issuer, clientID, groupsClaim)
+	provider, err := o.getProvider(issuer, clientID, scopes)
 	if err != nil {
 		return errRefreshAccessToken
 	}
@@ -210,7 +227,7 @@ func (o *oidcClient) refresh(issuer string, clientID string, groupsClaim string)
 // authenticate initiates the OpenID Connect device flow authentication process for the client.
 // It presents a user code for the end user to input in the device that has web access and waits for them to complete the authentication,
 // subsequently updating the client's tokens upon successful authentication.
-func (o *oidcClient) authenticate(issuer string, clientID string, audience string, groupsClaim string) error {
+func (o *oidcClient) authenticate(issuer string, clientID string, audience string, scopes []string) error {
 	// Store the old transport and restore it in the end.
 	oldTransport := o.httpClient.Transport
 	o.oidcTransport.audience = audience
@@ -220,7 +237,7 @@ func (o *oidcClient) authenticate(issuer string, clientID string, audience strin
 		o.httpClient.Transport = oldTransport
 	}()
 
-	provider, err := o.getProvider(issuer, clientID, groupsClaim)
+	provider, err := o.getProvider(issuer, clientID, scopes)
 	if err != nil {
 		return err
 	}
@@ -230,7 +247,7 @@ func (o *oidcClient) authenticate(issuer string, clientID string, audience strin
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT)
 	defer stop()
 
-	resp, err := rp.DeviceAuthorization(ctx, oidcScopes, provider, nil)
+	resp, err := rp.DeviceAuthorization(ctx, scopes, provider, nil)
 	if err != nil {
 		return err
 	}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2607,3 +2607,10 @@ Adds support for injecting additional SSH public keys into instances through {re
 To achieve this, the `cloud-init.ssh-keys.KEYNAME` configuration key is added for both instances and profiles. This key is used to define a public key to be injected. `KEYNAME` can be any arbitrary name for the injected key.
 
 The value for `cloud-init.ssh-keys.KEYNAME` should be `<user>:<key>`, where `<user>` is the name of the user for whom to inject the key. For `<key>`, provide either the public key or a `cloud-init` import ID for a key hosted elsewhere. Example valid values for `cloud-init.ssh-keys.KEYNAME` are `root:gh:githubUser` or `myUser:ssh-keyAlg base64PublicKey`.
+
+## `oidc_scopes`
+
+This API extension enables setting an {config:option}`server-oidc:oidc.scopes` configuration key, which accepts a space-separated list of OIDC scopes to request from the identity provider.
+This configuration option can be used to request additional scopes that might be required for retrieving {ref}`identity provider groups <identity-provider-groups>` from the identity provider.
+Additionally, the optional scopes `profile` and `offline_access` can be unset via this setting.
+Note that the `openid` and `email` scopes are always required.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4873,6 +4873,18 @@ for automatic access control.
 
 ```
 
+```{config:option} oidc.scopes server-oidc
+:scope: "global"
+:shortdesc: "Space-separated list of OpenID Connect scopes"
+:type: "space-delimited string"
+A list of OpenID Connect scopes to request from the identity provider.
+This must include the `openid` and `email` scopes.
+The remaining optional scopes are `offline_access` and `profile`.
+If you remove the `offline_access` scope, users might be required to log in more frequently.
+If you remove the `profile` scope, user information may not be displayed in LXD UI (or in `lxc auth identity` commands).
+You may add additional scopes if this is required by your identity provider, or if necessary for configuration of {ref}`identity provider groups <identity-provider-groups>`.
+```
+
 <!-- config group server-oidc end -->
 <!-- config group storage-btrfs-bucket-conf start -->
 ```{config:option} size storage-btrfs-bucket-conf

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4860,10 +4860,9 @@ This value is required by some providers.
 :scope: "global"
 :shortdesc: "A claim used for mapping identity provider groups to LXD groups."
 :type: "string"
-Specify a custom claim to be requested when performing OIDC flows.
-Configure a corresponding custom claim in your identity provider and
-add organization level groups to it. These can be mapped to LXD groups
-for automatic access control.
+Specify a custom token claim to denote groups defined at the identity provider.
+The contents of this claim can be mapped to LXD groups for managing access control.
+The value of the claim is expected to be a JSON string array.
 ```
 
 ```{config:option} oidc.issuer server-oidc

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -230,7 +230,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	// Get the authentication methods.
 	authMethods := []string{api.AuthenticationMethodTLS}
 
-	oidcIssuer, oidcClientID, _, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
@@ -1028,7 +1028,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcScopes, oidcAudience, oidcGroupsClaim := clusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil
@@ -1039,7 +1039,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 				return util.HTTPClient("", d.proxy)
 			}
 
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScopes, oidcAudience, s.ServerCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -880,7 +880,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			acmeCAURLChanged = true
 		case "acme.domain":
 			acmeDomainChanged = true
-		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.groups.claim":
+		case "oidc.issuer", "oidc.client.id", "oidc.scopes", "oidc.audience", "oidc.groups.claim":
 			oidcChanged = true
 		}
 	}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -287,6 +287,7 @@ func (o *Verifier) getGroupsFromClaims(customClaims map[string]any) []string {
 	groupsArr, ok := groupsClaimAny.([]any)
 	if !ok {
 		logger.Warn("Unexpected type for OIDC groups custom claim", logger.Ctx{"claim_name": o.groupsClaim, "claim_value": groupsClaimAny})
+		return nil
 	}
 
 	groups := make([]string, 0, len(groupsArr))
@@ -294,6 +295,7 @@ func (o *Verifier) getGroupsFromClaims(customClaims map[string]any) []string {
 		groupName, ok := groupNameAny.(string)
 		if !ok {
 			logger.Warn("Unexpected type for OIDC groups custom claim", logger.Ctx{"claim_name": o.groupsClaim, "claim_value": groupsClaimAny})
+			return nil
 		}
 
 		groups = append(groups, groupName)

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -50,6 +50,7 @@ type Verifier struct {
 
 	clientID       string
 	issuer         string
+	scopes         []string
 	audience       string
 	groupsClaim    string
 	clusterCert    func() *shared.CertInfo
@@ -453,12 +454,7 @@ func (o *Verifier) setRelyingParty(ctx context.Context, host string) error {
 		rp.WithHTTPClient(httpClient),
 	}
 
-	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail, oidc.ScopeProfile}
-	if o.groupsClaim != "" {
-		oidcScopes = append(oidcScopes, o.groupsClaim)
-	}
-
-	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, o.issuer, o.clientID, "", fmt.Sprintf("https://%s/oidc/callback", host), oidcScopes, options...)
+	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, o.issuer, o.clientID, "", "https://"+host+"/oidc/callback", o.scopes, options...)
 	if err != nil {
 		return fmt.Errorf("Failed to get OIDC relying party: %w", err)
 	}
@@ -652,7 +648,7 @@ type Opts struct {
 }
 
 // NewVerifier returns a Verifier.
-func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, httpClientFunc func() (*http.Client, error), options *Opts) (*Verifier, error) {
+func NewVerifier(issuer string, clientID string, scopes []string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, httpClientFunc func() (*http.Client, error), options *Opts) (*Verifier, error) {
 	opts := &Opts{}
 
 	if options != nil && options.GroupsClaim != "" {
@@ -662,6 +658,7 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 	verifier := &Verifier{
 		issuer:               issuer,
 		clientID:             clientID,
+		scopes:               scopes,
 		audience:             audience,
 		identityCache:        identityCache,
 		groupsClaim:          opts.GroupsClaim,

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"crypto/sha512"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -362,7 +363,16 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 	w.Header().Set("X-LXD-OIDC-issuer", o.issuer)
 	w.Header().Set("X-LXD-OIDC-clientid", o.clientID)
 	w.Header().Set("X-LXD-OIDC-audience", o.audience)
+
+	// Continue to sent groups claim header for compatibility with older clients
 	w.Header().Set("X-LXD-OIDC-groups-claim", o.groupsClaim)
+
+	scopesJSON, err := json.Marshal(o.scopes)
+	if err != nil {
+		return fmt.Errorf("Failed to marshal OIDC scopes: %w", err)
+	}
+
+	w.Header().Set("X-LXD-OIDC-scopes", string(scopesJSON))
 
 	return nil
 }

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	"github.com/canonical/lxd/lxd/config"
 	"github.com/canonical/lxd/lxd/db"
@@ -223,8 +224,8 @@ func (c *Config) RemoteTokenExpiry() string {
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
+func (c *Config) OIDCServer() (issuer string, clientID string, scopes []string, audience string, groupsClaim string) {
+	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), strings.Fields(c.m.GetString("oidc.scopes")), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
 }
 
 // ClusterHealingThreshold returns the configured healing threshold, i.e. the
@@ -678,6 +679,29 @@ var ConfigSchema = config.Schema{
 	//  scope: global
 	//  shortdesc: Expected audience value for the application
 	"oidc.audience": {},
+
+	// lxdmeta:generate(entities=server; group=oidc; key=oidc.scopes)
+	// A list of OpenID Connect scopes to request from the identity provider.
+	// This must include the `openid` and `email` scopes.
+	// The remaining optional scopes are `offline_access` and `profile`.
+	// If you remove the `offline_access` scope, users might be required to log in more frequently.
+	// If you remove the `profile` scope, user information may not be displayed in LXD UI (or in `lxc auth identity` commands).
+	// You may add additional scopes if this is required by your identity provider, or if necessary for configuration of {ref}`identity provider groups <identity-provider-groups>`.
+	// ---
+	//  type: space-delimited string
+	//  scope: global
+	//  shortdesc: Space-separated list of OpenID Connect scopes
+	"oidc.scopes": {
+		Default: strings.Join([]string{oidc.ScopeOpenID, oidc.ScopeEmail, oidc.ScopeOfflineAccess, oidc.ScopeProfile}, " "),
+		Validator: validate.Optional(func(value string) error {
+			scopes := strings.Fields(value)
+			if !shared.ValueInSlice(oidc.ScopeOpenID, scopes) || !shared.ValueInSlice(oidc.ScopeEmail, scopes) {
+				return fmt.Errorf("oidc.scopes requires the %q and %q OpenID Connect scopes", oidc.ScopeOpenID, oidc.ScopeEmail)
+			}
+
+			return nil
+		}),
+	},
 
 	// lxdmeta:generate(entities=server; group=oidc; key=oidc.groups.claim)
 	// Specify a custom claim to be requested when performing OIDC flows.

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -704,10 +704,9 @@ var ConfigSchema = config.Schema{
 	},
 
 	// lxdmeta:generate(entities=server; group=oidc; key=oidc.groups.claim)
-	// Specify a custom claim to be requested when performing OIDC flows.
-	// Configure a corresponding custom claim in your identity provider and
-	// add organization level groups to it. These can be mapped to LXD groups
-	// for automatic access control.
+	// Specify a custom token claim to denote groups defined at the identity provider.
+	// The contents of this claim can be mapped to LXD groups for managing access control.
+	// The value of the claim is expected to be a JSON string array.
 	// ---
 	//  type: string
 	//  scope: global

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1667,7 +1667,7 @@ func (d *Daemon) init() error {
 	maasAPIURL, maasAPIKey = d.globalConfig.MAASController()
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := d.globalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, oidcScopes, oidcAudience, oidcGroupsClaim := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
 
@@ -1695,7 +1695,7 @@ func (d *Daemon) init() error {
 			return util.HTTPClient("", d.proxy)
 		}
 
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScopes, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 		if err != nil {
 			return err
 		}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5472,7 +5472,7 @@
 					},
 					{
 						"oidc.groups.claim": {
-							"longdesc": "Specify a custom claim to be requested when performing OIDC flows.\nConfigure a corresponding custom claim in your identity provider and\nadd organization level groups to it. These can be mapped to LXD groups\nfor automatic access control.",
+							"longdesc": "Specify a custom token claim to denote groups defined at the identity provider.\nThe contents of this claim can be mapped to LXD groups for managing access control.\nThe value of the claim is expected to be a JSON string array.",
 							"scope": "global",
 							"shortdesc": "A claim used for mapping identity provider groups to LXD groups.",
 							"type": "string"

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5485,6 +5485,14 @@
 							"shortdesc": "OpenID Connect Discovery URL for the provider",
 							"type": "string"
 						}
+					},
+					{
+						"oidc.scopes": {
+							"longdesc": "A list of OpenID Connect scopes to request from the identity provider.\nThis must include the `openid` and `email` scopes.\nThe remaining optional scopes are `offline_access` and `profile`.\nIf you remove the `offline_access` scope, users might be required to log in more frequently.\nIf you remove the `profile` scope, user information may not be displayed in LXD UI (or in `lxc auth identity` commands).\nYou may add additional scopes if this is required by your identity provider, or if necessary for configuration of {ref}`identity provider groups \u003cidentity-provider-groups\u003e`.",
+							"scope": "global",
+							"shortdesc": "Space-separated list of OpenID Connect scopes",
+							"type": "space-delimited string"
+						}
 					}
 				]
 			}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -437,6 +437,7 @@ var APIExtensions = []string{
 	"storage_driver_powerflex",
 	"storage_driver_pure",
 	"cloud_init_ssh_keys",
+	"oidc_scopes",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -4,6 +4,14 @@ test_oidc() {
   # shellcheck disable=2153
   ensure_has_localhost_remote "${LXD_ADDR}"
 
+  # Check OIDC scopes validation
+  ! lxc config set oidc.scopes "my-scope" || false # Doesn't contain "email" or "openid"
+  ! lxc config set oidc.scopes "my-scope email" || false # Doesn't contain "openid"
+  ! lxc config set oidc.scopes "my-scope openid" || false # Doesn't contain "email"
+
+  lxc config set oidc.scopes "my-scope email openid" # Valid
+  lxc config unset oidc.scopes # Should reset to include profile and offline access claims
+
   # Setup OIDC
   spawn_oidc
   lxc config set "oidc.issuer=http://127.0.0.1:$(cat "${TEST_DIR}/oidc.port")/"


### PR DESCRIPTION
In the end, just having `oidc.scopes` was the way to go (see https://github.com/canonical/lxd/pull/14888#issuecomment-2642783581). I've added tests for the validation of the config key and also tested it locally with Keycloak by disabling the `profile` claim.

Closes #14141.