### PR TITLE
doc: fix looping local sphinx-autobuild

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,5 +56,9 @@ html:
 html-rtd:
 	$(MAKE) -f Makefile.sp sp-html LOCAL_SPHINX_BUILD=False ADDPREREQS='gitpython pyyaml'
 
+.PHONY: run
+run:
+	$(MAKE) -f Makefile.sp sp-run LOCAL_SPHINX_BUILD=True ADDPREREQS='gitpython pyyaml' SPHINXOPTS="--ignore '.sphinx/deps/manpages/*' -c . -d .sphinx/.doctrees -j auto"
+
 %:
 	$(MAKE) -f Makefile.sp sp-$@ LOCAL_SPHINX_BUILD=True ALLFILES='*.md **/*.md' ADDPREREQS='gitpython pyyaml'


### PR DESCRIPTION
This overrides the behavior of `make run` to `--ignore` the manpages. It was infinitely looping after a single change was made due to the change triggering a build, which would auto-generate manpages, which would trigger another build, which would auto-generate manpages, and so on. Only affects local builds for testing (`make run` in doc folder builds, serves, and watches for changes locally).