### PR TITLE
Storage: Add `TryLock` loop for faster connection attempts during errors

### DIFF
--- a/lxd/locking/lock.go
+++ b/lxd/locking/lock.go
@@ -69,3 +69,23 @@ func Lock(ctx context.Context, lockName string) (UnlockFunc, error) {
 		}
 	}
 }
+
+// TryLock attempts to acquire a lock without blocking.
+// If it succeeds it returns an unlock function.
+// If it fails it returns nil.
+func TryLock(lockName string) UnlockFunc {
+	// Create a new context and cancel it.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Request lock with an already cancelled context.
+	// If the lock is already acquired we give up.
+	unlock, err := Lock(ctx, lockName)
+	if err != nil {
+		return nil
+	}
+
+	// The lock has been successfully acquired.
+	// Return the respective unlock function.
+	return unlock
+}


### PR DESCRIPTION
This PR supersedes https://github.com/canonical/lxd/pull/14955.

It adds a new `TryLock` function which tries to acquire a lock but doesn't block if the lock is already acquired.
This beahvior is used to check if there already is an active connection so that subsequent callers don't try to run through the connection attempts again but rely on the already existing connection(s).