### PR TITLE
lxd/instance/drivers/qemu: Fix double-escaped device name

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4136,7 +4136,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		revert := revert.New()
 		defer revert.Fail()
 
-		nodeName := qemuDeviceNameOrID(qemuDeviceNamePrefix, escapedDeviceName, "", qemuDeviceNameMaxLength)
+		nodeName := qemuDeviceNameOrID(qemuDeviceNamePrefix, driveConf.DevName, "", qemuDeviceNameMaxLength)
 
 		if isRBDImage {
 			secretID := fmt.Sprintf("pool_%s_%s", blockDev["pool"], blockDev["user"])


### PR DESCRIPTION
Volumes with a `-` in their name would fail to detach as the device name used at device removal was different than the one used at creation.

This only manifested in the LVM driver, although I didn't check zfs.

Fixes the failures from https://github.com/canonical/lxd-ci/pull/409