### PR TITLE
cloud-init: Support injection of additional SSH keys on instances

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2599,3 +2599,11 @@ The following pool level configuration keys have been added:
 1. {config:option}`storage-pure-pool-conf:pure.api.token`
 1. {config:option}`storage-pure-pool-conf:pure.mode`
 1. {config:option}`storage-pure-pool-conf:pure.target`
+
+## `cloud_init_ssh_keys`
+
+Adds support for injecting additional SSH public keys into instances through {ref}`cloud-init <instance-options-cloud-init>` without conflicting with any configuration present on {config:option}`instance-cloud-init:cloud-init.vendor-data` or {config:option}`instance-cloud-init:cloud-init.user-data`.
+
+To achieve this, the `cloud-init.ssh-keys.KEYNAME` configuration key is added for both instances and profiles. This key is used to define a public key to be injected. `KEYNAME` can be any arbitrary name for the injected key.
+
+The value for `cloud-init.ssh-keys.KEYNAME` should be `<user>:<key>`, where `<user>` is the name of the user for whom to inject the key. For `<key>`, provide either the public key or a `cloud-init` import ID for a key hosted elsewhere. Example valid values for `cloud-init.ssh-keys.KEYNAME` are `root:gh:githubUser` or `myUser:ssh-keyAlg base64PublicKey`.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1716,6 +1716,17 @@ The instance with the highest value is shut down first.
 The content is used as seed value for `cloud-init`.
 ```
 
+```{config:option} cloud-init.ssh-keys.KEYNAME instance-cloud-init
+:condition: "If supported by image"
+:liveupdate: "no"
+:shortdesc: "Additional SSH key to be injected on the instance by `cloud-init`"
+:type: "string"
+Represents an additional SSH public key to be merged into existing `cloud-init` seed data
+and injected into an instance. Has the format `{user}:{key}`, where {user} is a Linux username and
+{key} can be either a pure SSH public key or an import ID for a key hosted elsewhere.
+// For example: `root:gh:githubUser`, `myUser:ssh-keyAlg publicKeyHash`
+```
+
 ```{config:option} cloud-init.user-data instance-cloud-init
 :condition: "If supported by image"
 :defaultdesc: "`#cloud-config`"

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/sys"
 	"github.com/canonical/lxd/lxd/ucred"
+	"github.com/canonical/lxd/lxd/util"
 )
 
 var testDir string
@@ -171,5 +172,108 @@ func TestHttpRequest(t *testing.T) {
 
 	if !strings.Contains(string(resp), errPIDNotInContainer.Error()) {
 		t.Fatal("resp error not expected: ", string(resp))
+	}
+}
+
+func TestMergeSSHKeyCloudConfig(t *testing.T) {
+	instanceConfig := map[string]string{"cloud-init.ssh-keys.mykey": "root:gh:user1"}
+
+	// First try with an empty cloud-config.
+	out, err := util.MergeSSHKeyCloudConfig(instanceConfig, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput := `#cloud-config
+users:
+- name: root
+  ssh-import-id:
+  - gh:user1 #lxd:cloud-init.ssh-keys
+  ssh_import_id:
+  - gh:user1 #lxd:cloud-init.ssh-keys
+`
+
+	if expectedOutput != out {
+		t.Fatalf("Output %q is different from expected %q", out, expectedOutput)
+	}
+
+	invalidCloudConfig := `#cloud-config
+users:
+	- name: root
+ssh-import-id: gh:user2
+`
+
+	// Check merging into invalid config returns an error.
+	_, err = util.MergeSSHKeyCloudConfig(instanceConfig, invalidCloudConfig)
+	if err == nil {
+		t.Fatal("Parsing invalid config did not return an error")
+	}
+
+	cloudConfig := `#cloud-config
+users:
+    - name: root
+      ssh-import-id: gh:user2
+      ssh-authorized-keys: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPfOyl6A6lSE+e57RLf4GwDzlg6PALjtiweokxQeCPL0
+      shell: /bin/bash
+`
+
+	// Merge the instance config into a cloud-config that already contain some keys
+	out, err = util.MergeSSHKeyCloudConfig(instanceConfig, cloudConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput = `#cloud-config
+users:
+- name: root
+  shell: /bin/bash
+  ssh-authorized-keys: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPfOyl6A6lSE+e57RLf4GwDzlg6PALjtiweokxQeCPL0
+  ssh-import-id:
+  - gh:user2
+  - gh:user1 #lxd:cloud-init.ssh-keys
+  ssh_import_id:
+  - gh:user1 #lxd:cloud-init.ssh-keys
+`
+
+	if expectedOutput != out {
+		t.Fatalf("Output %q is different from expected %q", out, expectedOutput)
+	}
+
+	// Add a pure public key to instance config.
+	instanceConfig["cloud-init.ssh-keys.otherkey"] = "user:ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPfOyl6A6lSE+e57RLf4GwDzlg6PALjtiweokxQeCPL0"
+
+	scalarUserCloudConfig := `#cloud-config
+users: foo
+`
+
+	// Merge the extended instance config with a cloud-config with a simple users string.
+	out, err = util.MergeSSHKeyCloudConfig(instanceConfig, scalarUserCloudConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedOutput = `#cloud-config
+users:
+- foo
+`
+
+	rootUserConfig := `- name: root
+  ssh-import-id:
+  - gh:user1 #lxd:cloud-init.ssh-keys
+  ssh_import_id:
+  - gh:user1 #lxd:cloud-init.ssh-keys
+`
+
+	customUserConfig := `- name: user
+  ssh-authorized-keys:
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPfOyl6A6lSE+e57RLf4GwDzlg6PALjtiweokxQeCPL0 #lxd:cloud-init.ssh-keys
+  ssh_authorized_keys:
+  - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPfOyl6A6lSE+e57RLf4GwDzlg6PALjtiweokxQeCPL0 #lxd:cloud-init.ssh-keys
+`
+
+	// The order of maps inside a list is not predicatable during YAML marshalling, so the order
+	// of users can change and generate two different but equivalent results.
+	if expectedOutput+rootUserConfig+customUserConfig != out && expectedOutput+customUserConfig+rootUserConfig != out {
+		t.Fatalf("Output %q is different from expected %q", out, expectedOutput)
 	}
 }

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -29,7 +29,7 @@ const (
 const ConfigVolatilePrefix = "volatile."
 
 // ConfigKeyPrefixesAny indicates valid prefixes for configuration options.
-var ConfigKeyPrefixesAny = []string{"environment.", "user.", "image."}
+var ConfigKeyPrefixesAny = []string{"environment.", "user.", "image.", "cloud-init.ssh-keys."}
 
 // ConfigKeyPrefixesContainer indicates valid prefixes for container configuration options.
 var ConfigKeyPrefixesContainer = []string{"linux.sysctl.", "limits.kernel."}

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1137,6 +1137,21 @@ func ConfigKeyChecker(key string, instanceType Type) (func(value string) error, 
 		}
 	}
 
+	// lxdmeta:generate(entities=instance; group=cloud-init; key=cloud-init.ssh-keys.KEYNAME)
+	// Represents an additional SSH public key to be merged into existing `cloud-init` seed data
+	// and injected into an instance. Has the format `{user}:{key}`, where {user} is a Linux username and
+	// {key} can be either a pure SSH public key or an import ID for a key hosted elsewhere.
+	// // For example: `root:gh:githubUser`, `myUser:ssh-keyAlg publicKeyHash`
+	// ---
+	//  type: string
+	//  liveupdate: no
+	//  condition: If supported by image
+	//  shortdesc: Additional SSH key to be injected on the instance by `cloud-init`
+	sshKeyName := strings.TrimPrefix(key, "cloud-init.ssh-keys.")
+	if sshKeyName != key && sshKeyName != "" {
+		return validate.Optional(validate.IsUserSSHKey), nil
+	}
+
 	if strings.HasPrefix(key, ConfigVolatilePrefix) {
 		// lxdmeta:generate(entities=instance; group=volatile; key=volatile.<name>.last_state.hwaddr)
 		// The original MAC that was used when moving a physical device into an instance.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1986,6 +1986,15 @@
 						}
 					},
 					{
+						"cloud-init.ssh-keys.KEYNAME": {
+							"condition": "If supported by image",
+							"liveupdate": "no",
+							"longdesc": "Represents an additional SSH public key to be merged into existing `cloud-init` seed data\nand injected into an instance. Has the format `{user}:{key}`, where {user} is a Linux username and\n{key} can be either a pure SSH public key or an import ID for a key hosted elsewhere.\n// For example: `root:gh:githubUser`, `myUser:ssh-keyAlg publicKeyHash`",
+							"shortdesc": "Additional SSH key to be injected on the instance by `cloud-init`",
+							"type": "string"
+						}
+					},
+					{
 						"cloud-init.user-data": {
 							"condition": "If supported by image",
 							"defaultdesc": "`#cloud-config`",

--- a/lxd/util/config.go
+++ b/lxd/util/config.go
@@ -1,9 +1,12 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/lxd/shared"
 )
@@ -59,4 +62,194 @@ func CopyConfig(config map[string]string) map[string]string {
 	}
 
 	return newConfig
+}
+
+// cloudInitUserSSHKeys is a struct that keeps the SSH keys to be injected using cloud-init for a certain user.
+type cloudInitUserSSHKeys struct {
+	importIDs  []string
+	publicKeys []string
+}
+
+// MergeSSHKeyCloudConfig merges any existing SSH keys defined in an instance config into a provided
+// cloud-config YAML string.
+// In the case where we were not able to parse the cloud config, return the original, unchanged config and
+// the error.
+func MergeSSHKeyCloudConfig(instanceConfig map[string]string, cloudConfig string) (string, error) {
+	// Use a pointer to cloudInitUserSSHKeys so we can append to its fields.
+	users := make(map[string]*cloudInitUserSSHKeys)
+
+	for key, value := range instanceConfig {
+		if strings.HasPrefix(key, "cloud-init.ssh-keys.") {
+			user, sshKey, found := strings.Cut(value, ":")
+
+			// If the "cloud-init.ssh-keys." is badly formatted, skip it.
+			if !found {
+				continue
+			}
+
+			// Create an empty cloudInitUserSSHKeys if the user is not configured.
+			_, ok := users[user]
+			if !ok {
+				users[user] = &cloudInitUserSSHKeys{}
+			}
+
+			// Check if ssh key is an import ID with with the "keyServer:UserName".
+			// This is done by checking if the value does not contain a space which is always present in
+			// valid public key representations and never present on import IDs.
+			if !strings.Contains(sshKey, " ") {
+				users[user].importIDs = append(users[user].importIDs, sshKey)
+				continue
+			}
+
+			users[user].publicKeys = append(users[user].publicKeys, sshKey)
+		}
+	}
+
+	// If no keys are defined, return the original config passed in.
+	if len(users) == 0 {
+		return cloudConfig, nil
+	}
+
+	// Parse YAML cloud-config into map.
+	cloudConfigMap := make(map[any]any)
+	err := yaml.Unmarshal([]byte(cloudConfig), cloudConfigMap)
+	if err != nil {
+		return cloudConfig, fmt.Errorf("Could not unmarshall cloud-config: %w", err)
+	}
+
+	// Get previously defined users list in provided config, if present.
+	userList, err := findOrCreateListInMap(cloudConfigMap, "users")
+	if err != nil {
+		return cloudConfig, err
+	}
+
+	// Define comment to be added on the side of added keys.
+	sshKeyExtendedConfigTag := "#lxd:cloud-init.ssh-keys"
+
+	// Merge the specified additional keys into the provided cloud config.
+	for user, keys := range users {
+		var targetUser map[any]any
+
+		for index, field := range userList {
+			mapField, ok := field.(map[any]any)
+
+			// The user has to be either a mapping yaml node or a simple string indicating the name of a user to be created.
+			if !ok {
+				// If the field is not the user name we want, skip this one.
+				userName, isString := field.(string)
+				if isString && userName == user {
+					// Else, create a user map for us to add the keys into. Use the previously defined name as the name in the user map.
+					targetUser = make(map[any]any)
+					targetUser["name"] = userName
+					userList[index] = targetUser
+					break
+				} else if !isString {
+					return cloudConfig, errors.New("Invalid user item on users list")
+				}
+			} else if mapField["name"] == user {
+				// If it is a map, check the name.
+				targetUser = mapField
+				break
+			}
+		}
+
+		// If the target user was not present in the cloud config, create an entry for it.
+		if targetUser == nil {
+			targetUser = make(map[any]any)
+			targetUser["name"] = user
+			userList = append(userList, targetUser)
+		}
+
+		// Using both the older and newer keys, since we do not know what version of cloud-init will be consuming this.
+		sshAuthorizedKeys := []string{"ssh_authorized_keys", "ssh-authorized-keys"}
+		importIDKeys := []string{"ssh_import_id", "ssh-import-id"}
+
+		// Add public keys to cloud-config.
+		err = addValueToListsInMap(targetUser, keys.publicKeys, sshAuthorizedKeys, sshKeyExtendedConfigTag)
+		if err != nil {
+			return cloudConfig, err
+		}
+
+		// Add import IDs to cloud-config.
+		err = addValueToListsInMap(targetUser, keys.importIDs, importIDKeys, sshKeyExtendedConfigTag)
+		if err != nil {
+			return cloudConfig, err
+		}
+	}
+
+	// Only modify the original config map if everything went well.
+	cloudConfigMap["users"] = userList
+	resultingConfigBytes, err := yaml.Marshal(cloudConfigMap)
+	if err != nil {
+		return cloudConfig, err
+	}
+
+	// Add cloud-config tag and space before comments, as doing the latter
+	// while parsing would result in the comment to be included in the value on the same line.
+	resultingConfig := "#cloud-config\n" + strings.ReplaceAll(string(resultingConfigBytes), sshKeyExtendedConfigTag, " "+sshKeyExtendedConfigTag)
+	return resultingConfig, nil
+}
+
+// addValueToListsInMap finds or creates a list referenced on the provided user map for each key on fieldKeys
+// and adds all provided values along with addedValueTag on the side to mark added values.
+// addedKeyTag is simply appended to the values added, any parsing to separate the tag from the
+// value should be done outside this function.
+func addValueToListsInMap(user map[any]any, addedValues []string, fieldKeys []string, addedValueTag string) error {
+	// If there are no keys to add, this function should be a no-op.
+	if len(addedValues) == 0 {
+		return nil
+	}
+
+	for _, fieldKey := range fieldKeys {
+		// Get the field with the provided key, if it exists.
+		// If it does not exist, create it as an empty list.
+		// If it exists and is not a list, switch it for a list containing the previously defined value.
+		targetList, err := findOrCreateListInMap(user, fieldKey)
+		if err != nil {
+			return err
+		}
+
+		// Add the keys to the lists that will not be filled with an alias afterwards.
+		// Do not add if the key is already present on the slice and mark added keys.
+		for _, key := range addedValues {
+			if !shared.ValueInSlice(any(key), targetList) {
+				targetList = append(targetList, key+addedValueTag)
+			}
+		}
+
+		// Update the map with the slice with appended keys.
+		user[fieldKey] = targetList
+	}
+
+	return nil
+}
+
+// findOrCreateListInMap finds a list under the provided key on a map that represents a YAML map field.
+// If there is no value for the provided key, this returns a slice than can be used for the key, but
+// this function does not change the provided map.
+// If the value under the key is a string, the returned slice will contain it.
+// If the value for the key is of any other type, return an error.
+func findOrCreateListInMap(yamlMap map[any]any, key string) ([]any, error) {
+	// Get previously defined list in provided map, if present.
+	field, hasField := yamlMap[key]
+	listField, isSlice := field.([]any)
+	_, isString := field.(string)
+
+	// If the field under the key is set to something other than a list or a string, both of which
+	// would be valid, return an error.
+	if hasField && !isSlice && !isString {
+		return nil, fmt.Errorf("Invalid value under %q", key)
+	}
+
+	// If provided map did not include a field under the key or included one that was simply a string and
+	// not a list, create a slice.
+	if !hasField || isString {
+		listField = make([]any, 0)
+		// Preserve the previous string field as an item on the new list so it is still applied.
+		if isString {
+			listField = append(listField, field)
+		}
+	}
+
+	return listField, nil
 }

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -800,6 +801,22 @@ func IsCloudInitUserData(value string) error {
 	}
 
 	// Since there are various other user-data formats besides cloud-config, consider those valid.
+	return nil
+}
+
+// IsUserSSHKey checks value is a valid SSH public key for cloud-init.ssh-keys.
+// This should take the format {user}:{key}, and neither part can be empty.
+func IsUserSSHKey(value string) error {
+	user, key, _ := strings.Cut(value, ":")
+
+	if key == "" {
+		return errors.New("Key part must not be empty")
+	}
+
+	if user == "" {
+		return errors.New("User part must not be empty")
+	}
+
 	return nil
 }
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -436,6 +436,7 @@ var APIExtensions = []string{
 	"profiles_all_projects",
 	"storage_driver_powerflex",
 	"storage_driver_pure",
+	"cloud_init_ssh_keys",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds supports for addition of SSH keys on instances in such a way that neither `cloud-init.vendor-data` and `cloud-init.user-data` are not overwritten.

This is done through the addition of the config key `cloud-init.ssh-keys.KEYNAME`, where KEYNAME can be any arbitrary name for the added key. The content of this key is merged into any pre-existing `cloud-config` defined in either `cloud-init.vendor-data` or `cloud-init.user-data`.

LXD CI tests in https://github.com/canonical/lxd-ci/pull/412