### PR TITLE
Storage: Include required Pure Storage API token role in description

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -6034,9 +6034,9 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-powerflex-volume-conf end -->
 <!-- config group storage-pure-pool-conf start -->
 ```{config:option} pure.api.token storage-pure-pool-conf
-:shortdesc: "API token for Pure Storage gateway authentication"
+:shortdesc: "API authorization token for Pure Storage gateway"
 :type: "string"
-
+API authorization token for Pure Storage gateway. Must have array_admin role to give LXD full control over managed storage pools (Pure Storage pods).
 ```
 
 ```{config:option} pure.gateway storage-pure-pool-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6731,8 +6731,8 @@
 				"keys": [
 					{
 						"pure.api.token": {
-							"longdesc": "",
-							"shortdesc": "API token for Pure Storage gateway authentication",
+							"longdesc": "API authorization token for Pure Storage gateway. Must have array_admin role to give LXD full control over managed storage pools (Pure Storage pods).",
+							"shortdesc": "API authorization token for Pure Storage gateway",
 							"type": "string"
 						}
 					},

--- a/lxd/storage/drivers/driver_pure.go
+++ b/lxd/storage/drivers/driver_pure.go
@@ -128,10 +128,10 @@ func (d *pure) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		"size": validate.Optional(validate.IsSize),
 		// lxdmeta:generate(entities=storage-pure; group=pool-conf; key=pure.api.token)
-		//
+		// API authorization token for Pure Storage gateway. Must have array_admin role to give LXD full control over managed storage pools (Pure Storage pods).
 		// ---
 		//  type: string
-		//  shortdesc: API token for Pure Storage gateway authentication
+		//  shortdesc: API authorization token for Pure Storage gateway
 		"pure.api.token": validate.Optional(),
 		// lxdmeta:generate(entities=storage-pure; group=pool-conf; key=pure.gateway)
 		//


### PR DESCRIPTION
Adds required API token role in `pure.api.token` field description.
The required role is `array_admin` to allow LXD full control over managed storage pools (Pure Storage pods). One example of this requirement is removal of default protection rules when storage pool is created.