### PR TITLE
Storage: Document Powerflex user minimum require role

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -276,6 +276,7 @@ syscall
 syscalls
 sysfs
 syslog
+SystemAdmin
 Tbit
 TCP
 TensorRT

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5869,7 +5869,7 @@ If you want to specify the storage pool via its name, also set {config:option}`s
 :scope: "global"
 :shortdesc: "User for PowerFlex Gateway authentication"
 :type: "string"
-
+Must have at least SystemAdmin role to give LXD full control over managed storage pools.
 ```
 
 ```{config:option} powerflex.user.password storage-powerflex-pool-conf

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -6555,7 +6555,7 @@
 					{
 						"powerflex.user.name": {
 							"defaultdesc": "`admin`",
-							"longdesc": "",
+							"longdesc": "Must have at least SystemAdmin role to give LXD full control over managed storage pools.",
 							"scope": "global",
 							"shortdesc": "User for PowerFlex Gateway authentication",
 							"type": "string"

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -216,7 +216,7 @@ func (d *powerflex) Delete(op *operations.Operation) error {
 func (d *powerflex) Validate(config map[string]string) error {
 	rules := map[string]func(value string) error{
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.user.name)
-		//
+		// Must have at least SystemAdmin role to give LXD full control over managed storage pools.
 		// ---
 		//  type: string
 		//  defaultdesc: `admin`


### PR DESCRIPTION
Adds a short note about the minimum required role the PowerFlex user needs to have set.