### PR TITLE
API: Avoid premature load of instance DB record in log endpoints

### DIFF
--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -519,12 +519,6 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid instance name"))
 	}
 
-	// Ensure instance exists.
-	inst, err := instance.LoadByProjectAndName(s, projectName, name)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 	if err != nil {
@@ -535,14 +529,15 @@ func instanceExecOutputGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	file, err := url.PathUnescape(mux.Vars(r)["file"])
+	// Ensure instance exists.
+	inst, err := instance.LoadByProjectAndName(s, projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = instancetype.ValidName(name, false)
+	file, err := url.PathUnescape(mux.Vars(r)["file"])
 	if err != nil {
-		return response.BadRequest(err)
+		return response.SmartError(err)
 	}
 
 	if !validExecOutputFileName(file) {

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/instance"
-	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/lxd/lifecycle"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
@@ -614,12 +613,6 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid instance name"))
 	}
 
-	// Ensure instance exists.
-	inst, err := instance.LoadByProjectAndName(s, projectName, name)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 	if err != nil {
@@ -630,14 +623,15 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	file, err := url.PathUnescape(mux.Vars(r)["file"])
+	// Ensure instance exists.
+	inst, err := instance.LoadByProjectAndName(s, projectName, name)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = instancetype.ValidName(name, false)
+	file, err := url.PathUnescape(mux.Vars(r)["file"])
 	if err != nil {
-		return response.BadRequest(err)
+		return response.SmartError(err)
 	}
 
 	if !validExecOutputFileName(file) {

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -662,6 +662,10 @@ func instanceExecOutputDelete(d *Daemon, r *http.Request) response.Response {
 }
 
 func validLogFileName(fname string) bool {
+	if strings.Contains(fname, "/") || strings.Contains(fname, "\\") || strings.Contains(fname, "..") {
+		return false
+	}
+
 	/* Let's just require that the paths be relative, so that we don't have
 	 * to deal with any escaping or whatever.
 	 */
@@ -674,6 +678,10 @@ func validLogFileName(fname string) bool {
 }
 
 func validExecOutputFileName(fName string) bool {
+	if strings.Contains(fName, "/") || strings.Contains(fName, "\\") || strings.Contains(fName, "..") {
+		return false
+	}
+
 	return (strings.HasSuffix(fName, ".stdout") || strings.HasSuffix(fName, ".stderr")) &&
 		strings.HasPrefix(fName, "exec_")
 }

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -419,12 +419,6 @@ func instanceExecOutputsGet(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid instance name"))
 	}
 
-	// Ensure instance exists.
-	inst, err := instance.LoadByProjectAndName(s, projectName, name)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
@@ -435,9 +429,10 @@ func instanceExecOutputsGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	err = instancetype.ValidName(name, false)
+	// Ensure instance exists.
+	inst, err := instance.LoadByProjectAndName(s, projectName, name)
 	if err != nil {
-		return response.BadRequest(err)
+		return response.SmartError(err)
 	}
 
 	// Mount the instance's root volume


### PR DESCRIPTION
- Don't load full record until after internal redirect to correct cluster member has occurred, otherwise the instance is potentially loaded twice.
- Also always use instance name from DB when constructing paths.
- Improve file name checks to appease codeql.