### PR TITLE
Storage: Revert PowerFlex client API token lock

### DIFF
--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -271,7 +271,7 @@ func (p *powerFlexClient) requestAuthenticated(method string, path string, body 
 		if body != nil {
 			bodyReader, err = p.createBodyReader(body)
 			if err != nil {
-				return fmt.Errorf("Failed to create reader from requets body: %w", err)
+				return fmt.Errorf("Failed to create reader from request's body: %w", err)
 			}
 		}
 


### PR DESCRIPTION
This reverts commit d298a4487cce36cf9230855f062b8c5b119f643e.

Whilst reviewing https://github.com/canonical/lxd/pull/14968 I realized that the lock on the token is not required as there isn't any case with multiple callers on the same instance of the storage driver struct.
See [comment](https://github.com/canonical/lxd/pull/14968#discussion_r1952783018) for reference.