### PR TITLE
cloud-init: Follow up on SSH key injection

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -303,7 +303,7 @@ To inject SSH keys into LXD instances for an arbitrary user, use the configurati
 
 Use the format `<user>:<key>` for its value, where `<user>` is a Linux username and `<key>` can be either a pure SSH public key or an import ID for a key hosted elsewhere. For example, `root:gh:githubUser` and `myUser:ssh-keyAlg publicKeyHash` are valid values.
 
-`cloud-init.ssh-keys.<keyName>` cannot be applied if LXD is unable to parse both the existing `cloud-config.vendor-data` and `cloud-config.user-data` for that instance. This could happen, for example, if those keys contain badly formatted YAML.
+The content of `cloud-init.ssh-keys.<keyName>` is merged into the contents of both `cloud-config.vendor-data` and `cloud-config.user-data` before presenting their content to the guest. This is done according to the [`cloud-config` specification](https://cloudinit.readthedocs.io/en/latest/explanation/about-cloud-config.html). Therefore, keys defined via `cloud-init.ssh-keys.<keyName>` cannot be applied if LXD is unable to parse both the existing `cloud-config.vendor-data` and `cloud-config.user-data` for that instance. This could happen, for example, if those keys contain badly formatted YAML.
 
 You can define SSH keys via `cloud-init.vendor-data` or `cloud-init.user-data` directly. Keys defined using `cloud-init.ssh-keys.<keyName>` do not conflict with those defined with either `cloud-init.vendor-data` or `cloud-init.user-data` in any way. For more information on how to use `cloud-config` to define SSH keys, see [the cloud-init docs for SSH configuration](https://cloudinit.readthedocs.io/en/latest/reference/yaml_examples/ssh.html).
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -2554,7 +2554,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 	// Merge additional SSH keys present on the instance config into vendorData.
 	vendorData, err = util.MergeSSHKeyCloudConfig(instanceConfig, vendorData)
 	if err != nil {
-		logger.Warn("Failed merging SSH keys into cloud-init seed data, abstain from injecting additional keys", logger.Ctx{"err": err, "project": d.inst.Project(), "instance": d.inst.Name(), "dataConfigKey": vendorDataKey})
+		logger.Warn("Failed merging SSH keys into cloud-init seed data, abstain from injecting additional keys", logger.Ctx{"err": err, "project": d.inst.Project().Name, "instance": d.inst.Name(), "dataConfigKey": vendorDataKey})
 	}
 
 	err = os.WriteFile(filepath.Join(scratchDir, "vendor-data"), []byte(vendorData), 0400)
@@ -2576,7 +2576,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 	// Merge additional SSH keys present on the instance config into userData.
 	userData, err = util.MergeSSHKeyCloudConfig(instanceConfig, userData)
 	if err != nil {
-		logger.Warn("Failed merging SSH keys into cloud-init seed data, abstain from injecting additional keys", logger.Ctx{"err": err, "project": d.inst.Project(), "instance": d.inst.Name(), "dataConfigKey": userDataKey})
+		logger.Warn("Failed merging SSH keys into cloud-init seed data, abstain from injecting additional keys", logger.Ctx{"err": err, "project": d.inst.Project().Name, "instance": d.inst.Name(), "dataConfigKey": userDataKey})
 	}
 
 	err = os.WriteFile(filepath.Join(scratchDir, "user-data"), []byte(userData), 0400)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -122,7 +122,7 @@ func devlxdConfigKeyGetHandler(d *Daemon, c instance.Instance, w http.ResponseWr
 	if strings.HasSuffix(key, ".vendor-data") || strings.HasSuffix(key, ".user-data") {
 		value, err = util.MergeSSHKeyCloudConfig(c.ExpandedConfig(), value)
 		if err != nil {
-			logger.Warn("Failed merging SSH keys into cloud-init seed data, abstain from injecting additional keys", logger.Ctx{"err": err, "project": c.Project(), "instance": c.Name(), "requestedKey": key})
+			logger.Warn("Failed merging SSH keys into cloud-init seed data, abstain from injecting additional keys", logger.Ctx{"err": err, "project": c.Project().Name, "instance": c.Name(), "requestedKey": key})
 		}
 	}
 

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -73,8 +73,10 @@ func devlxdConfigGetHandler(d *Daemon, c instance.Instance, w http.ResponseWrite
 	hasSSHKeys := false
 	hasCustomConfig := false
 	for k := range c.ExpandedConfig() {
-		// cloud-init.ssh-keys keys should not be retireved by cloud-init directly but instead should be merged into
-		// cloud-init.vendor-data and/or cloud-init.user-data.
+		// cloud-init.ssh-keys keys are not to be retrieved by cloud-init directly, but instead LXD converts them
+		// into cloud-init config and merges it into cloud-init.[vendor|user]-data.
+		// This way we can make use of the full array of options proivded by cloud-config for injecting keys
+		// and not compromise any cloud-init config defined on the instance's expanded config.
 		if strings.HasPrefix(k, "cloud-init.ssh-keys.") {
 			hasSSHKeys = true
 		} else if strings.HasPrefix(k, "user.") || strings.HasPrefix(k, "cloud-init.") {


### PR DESCRIPTION
Addressing some left over comments from https://github.com/canonical/lxd/pull/14959