### PR TITLE
github: split documentation job into build and test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -465,7 +465,7 @@ jobs:
   ui-e2e-tests:
     name: UI e2e tests
     runs-on: ubuntu-latest
-    needs: [code-tests, documentation]
+    needs: [code-tests, documentation-build]
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' ) && github.ref_name == 'main' && github.repository == 'canonical/lxd' }}
     env:
       LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
@@ -616,8 +616,8 @@ jobs:
           path: ${{env.GOCOVERDIR}}
         if: env.GOCOVERDIR != ''
 
-  documentation:
-    name: Documentation
+  documentation-build:
+    name: Documentation build
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -651,6 +651,36 @@ jobs:
           set -eux
           make doc-spellcheck
 
+      - name: Upload documentation artifacts
+        if: always()
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: documentation
+          path: doc/_build
+
+  documentation-tests:
+    name: Documentation tests
+    runs-on: ubuntu-24.04
+    needs: documentation-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build LXD client
+        run: make client
+
+      - name: Download built docs
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: documentation
+          merge-multiple: true
+          path: doc/_build
+
       - name: Run inclusive naming checker
         uses: get-woke/woke-action@b2ec032c4a2c912142b38a6a453ad62017813ed0 # v0
         with:
@@ -665,17 +695,10 @@ jobs:
           set -eux
           make doc-linkcheck
 
-      - name: Upload documentation artifacts
-        if: always()
-        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: documentation
-          path: doc/_build
-
   snap:
     name: Trigger snap edge build
     runs-on: ubuntu-24.04
-    needs: [code-tests, system-tests, client, documentation]
+    needs: [code-tests, system-tests, client, documentation-tests]
     if: ${{ github.repository == 'canonical/lxd' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock


### PR DESCRIPTION
## Done
- Separated a portion of the documentation job from the test workflow into its own job. This prevents the UI E2E tests from depending on unrelated parts of the documentation job.

NOTE: On my fork [run](https://github.com/mas-who/lxd/actions/runs/13309237496/job/37167572965), the documentation test job was executed successfully, but it seems like the doc link checker is failing at the same spot