### PR TITLE
Replace `source-type` with `source.type`

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -186,7 +186,7 @@ See {ref}`devices-disk-types` for details.
 
 ```
 
-```{config:option} source-type device-disk-device-conf
+```{config:option} source.type device-disk-device-conf
 :defaultdesc: "`custom`"
 :required: "no"
 :shortdesc: "Type of the backing storage volume"

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -265,7 +265,7 @@ func (c *cmdStorageVolumeAttach) run(cmd *cobra.Command, args []string) error {
 
 	// Only specify sourcetype when not the default
 	if volType != "custom" {
-		device["source-type"] = volType
+		device["source.type"] = volType
 	}
 
 	// Add the device to the instance
@@ -373,7 +373,7 @@ func (c *cmdStorageVolumeAttachProfile) run(cmd *cobra.Command, args []string) e
 
 	// Only specify sourcetype when not the default
 	if volType != "custom" {
-		device["source-type"] = volType
+		device["source.type"] = volType
 	}
 
 	// Add the device to the instance
@@ -880,8 +880,8 @@ func (c *cmdStorageVolumeDetach) run(cmd *cobra.Command, args []string) error {
 	if devName == "" {
 		for n, d := range inst.Devices {
 			sourceType := "custom"
-			if d["source-type"] != "" {
-				sourceType = d["source-type"]
+			if d["source.type"] != "" {
+				sourceType = d["source.type"]
 			}
 
 			if d["type"] == "disk" && d["pool"] == resource.name && volType == sourceType && volName == d["source"] {
@@ -984,8 +984,8 @@ func (c *cmdStorageVolumeDetachProfile) run(cmd *cobra.Command, args []string) e
 	if devName == "" {
 		for n, d := range profile.Devices {
 			sourceType := "custom"
-			if d["source-type"] != "" {
-				sourceType = d["source-type"]
+			if d["source.type"] != "" {
+				sourceType = d["source.type"]
 			}
 
 			if d["type"] == "disk" && d["pool"] == resource.name && volType == sourceType && volName == d["source"] {

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -152,8 +152,8 @@ func (d *disk) sourceVolumeFields() (volumeName string, volumeType storageDriver
 	volumeName = d.config["source"]
 
 	volumeTypeName = cluster.StoragePoolVolumeTypeNameCustom
-	if d.config["source-type"] != "" {
-		volumeTypeName = d.config["source-type"]
+	if d.config["source.type"] != "" {
+		volumeTypeName = d.config["source.type"]
 	}
 
 	dbVolumeType, err = storagePools.VolumeTypeNameToDBType(volumeTypeName)
@@ -272,7 +272,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		//  required: yes
 		//  shortdesc: Source of a file system or block device
 		"source": validate.IsAny,
-		// lxdmeta:generate(entities=device-disk; group=device-conf; key=source-type)
+		// lxdmeta:generate(entities=device-disk; group=device-conf; key=source.type)
 		// Possible values are `custom` (the default) or `virtual-machine`. This
 		// key is only valid when `source` is the name of a storage volume.
 		// ---
@@ -280,7 +280,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		//  defaultdesc: `custom`
 		//  required: no
 		//  shortdesc: Type of the backing storage volume
-		"source-type": validate.Optional(validate.IsOneOf(cluster.StoragePoolVolumeTypeNameCustom, cluster.StoragePoolVolumeTypeNameVM)),
+		"source.type": validate.Optional(validate.IsOneOf(cluster.StoragePoolVolumeTypeNameCustom, cluster.StoragePoolVolumeTypeNameVM)),
 		// lxdmeta:generate(entities=device-disk; group=device-conf; key=limits.read)
 		// You can specify a value in byte/s (various suffixes supported, see {ref}`instances-limit-units`) or in IOPS (must be suffixed with `iops`).
 		// See also {ref}`storage-configure-io`.
@@ -420,8 +420,8 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 		return fmt.Errorf(`Cannot use both "required" and deprecated "optional" properties at the same time`)
 	}
 
-	if d.config["source-type"] != "" && d.config["pool"] == "" {
-		return fmt.Errorf(`"source-type" can only be used on storage volume disk devices`)
+	if d.config["source.type"] != "" && d.config["pool"] == "" {
+		return fmt.Errorf(`"source.type" can only be used on storage volume disk devices`)
 	}
 
 	if d.config["source"] == "" && d.config["path"] != "/" {
@@ -1623,7 +1623,7 @@ func (w *cgroupWriter) Set(version cgroup.Backend, controller string, key string
 // mountPoolVolume mounts storage volumes created via the storage api. Config keys:
 //   - d.config["pool"] : pool name
 //   - d.config["source"] : volume name
-//   - d.config["source-type"] : volume type
+//   - d.config["source.type"] : volume type
 //
 // Returns the mount path and MountInfo struct. If d.inst type is container the
 // volume will be shifted if needed.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -201,7 +201,7 @@
 						}
 					},
 					{
-						"source-type": {
+						"source.type": {
 							"defaultdesc": "`custom`",
 							"longdesc": "Possible values are `custom` (the default) or `virtual-machine`. This\nkey is only valid when `source` is the name of a storage volume.",
 							"required": "no",

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -1316,7 +1316,7 @@ type ComparableSnapshot struct {
 // creation date is different to the source.
 // A snapshot will be added to the "to delete from target" slice if it doesn't exist in the source or its ID or
 // creation date is different to the source.
-func CompareSnapshots(sourceSnapshots []ComparableSnapshot, targetSnapshots []ComparableSnapshot) ([]int, []int) {
+func CompareSnapshots(sourceSnapshots []ComparableSnapshot, targetSnapshots []ComparableSnapshot) (syncSourceSnapshots []int, deleteTargetSnapshots []int) {
 	// Compare source and target.
 	sourceSnapshotsByName := make(map[string]*ComparableSnapshot, len(sourceSnapshots))
 	targetSnapshotsByName := make(map[string]*ComparableSnapshot, len(targetSnapshots))

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -970,8 +970,8 @@ func volumeIsUsedByDevice(vol api.StorageVolume, inst *db.InstanceArgs, dev map[
 	}
 
 	volumeTypeName := cluster.StoragePoolVolumeTypeNameCustom
-	if dev["source-type"] != "" {
-		volumeTypeName = dev["source-type"]
+	if dev["source.type"] != "" {
+		volumeTypeName = dev["source.type"]
 	}
 
 	if volumeTypeName == vol.Type && dev["source"] == vol.Name {


### PR DESCRIPTION
This is the kind of thing that makes people wonder "what the heck were they thinking" (see [docs](https://documentation.ubuntu.com/lxd/en/latest/reference/devices_disk/#device-disk-device-conf:size)):
![Screenshot from 2025-02-13 16-30-00](https://github.com/user-attachments/assets/1d2260d0-1ca8-4d87-8873-d33a870e9022)

I couldn't unsee it. Namespacing these keys under `source` just seems like a really good idea. I will use `source.snapshot` for snapshots.

There shouldn't be any changes needed for the lxd-ci tests; I ran them on this locally and they pass.