### PR TITLE
cloud-init: Include `user.*` keys in `meta-data` file

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -2600,7 +2600,7 @@ func (d *disk) generateVMConfigDrive() (string, error) {
 	var metaDataBuilder strings.Builder
 
 	// Append strings to the builder
-	metaDataBuilder.WriteString("instance-id: " + d.inst.Name() + "\n")
+	metaDataBuilder.WriteString("instance-id: " + d.inst.CloudInitID() + "\n")
 	metaDataBuilder.WriteString("local-hostname: " + d.inst.Name() + "\n")
 
 	// These keys shouldn't be appended to the meta as it would be redundant as their values are already available


### PR DESCRIPTION
We can't add make these values available through `ds.config` as we do when using the LXD datastore, so this is the next best thing.

This does raise the risk of adding duplicate keys since `user.meta-data` could include the same key as some `user.*`. Similarly to what is reported in https://github.com/canonical/lxd/issues/13853. But this won't be a concern after `user.meta-data` is removed.

Closes https://github.com/canonical/lxd/issues/14803