### PR TITLE
github: Rework documentation tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -465,7 +465,7 @@ jobs:
   ui-e2e-tests:
     name: UI e2e tests
     runs-on: ubuntu-latest
-    needs: [code-tests, documentation-build]
+    needs: [code-tests, documentation]
     if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' ) && github.ref_name == 'main' && github.repository == 'canonical/lxd' }}
     env:
       LD_LIBRARY_PATH: "/home/runner/go/bin/dqlite/libs/"
@@ -616,8 +616,8 @@ jobs:
           path: ${{env.GOCOVERDIR}}
         if: env.GOCOVERDIR != ''
 
-  documentation-build:
-    name: Documentation build
+  documentation:
+    name: Documentation
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -651,6 +651,12 @@ jobs:
           set -eux
           make doc-spellcheck
 
+      - name: Run inclusive naming checker
+        uses: get-woke/woke-action@b2ec032c4a2c912142b38a6a453ad62017813ed0 # v0
+        with:
+          fail-on-error: true
+          woke-args: "*.md **/*.md -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml"
+
       - name: Upload documentation artifacts
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
@@ -658,10 +664,12 @@ jobs:
           name: documentation
           path: doc/_build
 
-  documentation-tests:
-    name: Documentation tests
+  documentation-linkcheck:
+    name: Documentation link check
     runs-on: ubuntu-24.04
-    needs: documentation-build
+    needs: documentation
+    # Run link checker during scheduled CI runs only
+    if: ${{ github.event_name == 'schedule' }}
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -681,15 +689,7 @@ jobs:
           merge-multiple: true
           path: doc/_build
 
-      - name: Run inclusive naming checker
-        uses: get-woke/woke-action@b2ec032c4a2c912142b38a6a453ad62017813ed0 # v0
-        with:
-          fail-on-error: true
-          woke-args: "*.md **/*.md -c https://github.com/canonical/Inclusive-naming/raw/main/config.yml"
-
       - name: Run link checker
-        # Run link checker during scheduled CI runs only
-        if: ${{ github.event_name == 'schedule' }}
         shell: 'script -q -e -c "export TERM=xterm-256color; bash {0}"'
         run: |
           set -eux
@@ -698,7 +698,7 @@ jobs:
   snap:
     name: Trigger snap edge build
     runs-on: ubuntu-24.04
-    needs: [code-tests, system-tests, client, documentation-tests]
+    needs: [code-tests, system-tests, client, documentation]
     if: ${{ github.repository == 'canonical/lxd' && github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     env:
       SSH_AUTH_SOCK: /tmp/ssh_agent.sock


### PR DESCRIPTION
 - Move inclusive name checker into main documentation build and test workflow.
 - Separate out the link checker workflow from rest of documentation workflow as unreliable - this avoids unnecessary checkout and download of documentation build just to run inclusive name check on normal PRs.