### PR TITLE
Storage: Prevent using remote storage pools for `(images|backups)_volume`

### DIFF
--- a/lxd/daemon_storage.go
+++ b/lxd/daemon_storage.go
@@ -167,6 +167,10 @@ func daemonStorageValidate(s *state.State, target string) (validatedTarget strin
 		return "", fmt.Errorf("Storage pool %q cannot be used when in %q status", poolName, poolState)
 	}
 
+	if pool.Driver().Info().Remote {
+		return "", fmt.Errorf("Remote storage pool %q cannot be used", pool)
+	}
+
 	var snapshots []db.StorageVolumeArgs
 	var dbVol *db.StorageVolume
 

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -25,6 +25,10 @@ _server_config_storage() {
 
   lxd_backend=$(storage_backend "$LXD_DIR")
   if [ "$lxd_backend" = "ceph" ]; then
+    # The volume doesn't have to be present as the check errors after testing for the remote storage pool.
+    ! lxc config set storage.backups_volume "${pool}/foo" | grep -q "Error: Failed validation of \"storage.backups_volume\": Remote storage pool \"${pool}\" cannot be used"
+    ! lxc config set storage.images_volume "${pool}/foo" | grep -q "Error: Failed validation of \"storage.images_volume\": Remote storage pool \"${pool}\" cannot be used"
+
     return
   fi
 


### PR DESCRIPTION
This prevents using FS vols from unsupported remote storage drivers for the `storage.(images|backups)_volume` config keys.
It prevents concurrent reads/writes from multiple hosts when used inside a cluster.

Just checking for remote drivers is not sufficient as CephFS volumes can be used.