### PR TITLE
doc: update forward API docstrings

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -3355,6 +3355,7 @@ definitions:
                     type: string
                 description: Forward configuration map (refer to doc/network-forwards.md)
                 example:
+                    target_address: 198.51.100.99
                     user.mykey: foo
                 type: object
                 x-go-name: Config
@@ -3420,6 +3421,7 @@ definitions:
                     type: string
                 description: Forward configuration map (refer to doc/network-forwards.md)
                 example:
+                    target_address: 198.51.100.99
                     user.mykey: foo
                 type: object
                 x-go-name: Config
@@ -3444,6 +3446,7 @@ definitions:
                     type: string
                 description: Forward configuration map (refer to doc/network-forwards.md)
                 example:
+                    target_address: 198.51.100.99
                     user.mykey: foo
                 type: object
                 x-go-name: Config
@@ -3453,7 +3456,12 @@ definitions:
                 type: string
                 x-go-name: Description
             listen_address:
-                description: The listen address of the forward
+                description: |-
+                    The listen address of the forward
+                    For OVN networks only, you can dynamically allocate the listen address from a pre-defined range.
+                    To do so for an IPv4 address, provide a listen_address of `0.0.0.0`.
+                    For an IPv6 address, provide a listen_address of `::`.
+                    These are equivalent to the `allocate=ipv{4|6}` flag used to create a network forward via the CLI.
                 example: 192.0.2.1
                 type: string
                 x-go-name: ListenAddress

--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -159,7 +159,7 @@ type NetworkForwardPut struct {
 	//  shortdesc: User-provided free-form key/value pairs
 
 	// Forward configuration map (refer to doc/network-forwards.md)
-	// Example: {"user.mykey": "foo"}
+	// Example: {"user.mykey": "foo","target_address": "198.51.100.99"}
 	Config map[string]string `json:"config" yaml:"config"`
 
 	// lxdmeta:generate(entities=network-forward; group=forward-properties; key=ports)
@@ -206,7 +206,7 @@ type NetworkForward struct {
 	Description string `json:"description" yaml:"description"`
 
 	// Forward configuration map (refer to doc/network-forwards.md)
-	// Example: {"user.mykey": "foo"}
+	// Example: {"user.mykey": "foo","target_address": "198.51.100.99"}
 	Config map[string]string `json:"config" yaml:"config"`
 
 	// Port forwards (optional)

--- a/shared/api/network_forward.go
+++ b/shared/api/network_forward.go
@@ -113,6 +113,10 @@ type NetworkForwardsPost struct {
 	//  shortdesc: IP address to listen on
 
 	// The listen address of the forward
+	// For OVN networks only, you can dynamically allocate the listen address from a pre-defined range.
+	// To do so for an IPv4 address, provide a listen_address of `0.0.0.0`.
+	// For an IPv6 address, provide a listen_address of `::`.
+	// These are equivalent to the `allocate=ipv{4|6}` flag used to create a network forward via the CLI.
 	// Example: 192.0.2.1
 	ListenAddress string `json:"listen_address" yaml:"listen_address"`
 }


### PR DESCRIPTION
- Adds information about how to dynamically allocate listen addresses via API
- Adds missing `target_address` in network forward config map docstrings
- Updates `rest-api.yaml` for API specification