### PR TITLE
OIDC: Cluster-wide key and salt for cookie encryption

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2630,3 +2630,18 @@ Adds the field `client_certificate` to `GET /1.0` to indicate if the current req
 
 This API extension adds a `used_by` field to the API response for a {ref}`cluster group <cluster-groups>`.
 Deletion of a cluster group is disallowed if the cluster group is referenced by project configuration (see {config:option}`project-restricted:restricted.cluster.groups`).
+
+## `secret_lifetime`
+
+Cookie encryption keys used for OIDC authentication are derived from a secret key using a salt.
+This API extension enables setting the {config:option}`server-core:core.secret_key_lifetime` and {config:option}`server-core:core.salt_lifetime` configuration keys.
+
+When the key or salt is required, LXD will check if it has expired.
+If either have expired, a new salt or key will be created with the given lifetime.
+
+The salt lifetime should be shorter than the key lifetime.
+To reflect this, the key lifetime is specified in days and the salt lifetime is specified in minutes.
+
+When the key rotates, all OIDC users will be logged out of LXD.
+If they are still logged into the identity provider, this will cause a brief redirection.
+Otherwise, they will need to log back in to the identity provider.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4614,6 +4614,35 @@ If this option is not specified, LXD falls back to the `NO_PROXY` environment va
 
 ```
 
+```{config:option} core.salt_lifetime server-core
+:defaultdesc: "`60`"
+:scope: "global"
+:shortdesc: "The lifetime in minutes of the cluster salt."
+:type: "integer"
+The cluster salt is used to encrypt cookies that are used to verify the integrity of the OpenID Connect (OIDC) browser login flow.
+This configuration specifies the number of minutes a given salt is valid for.
+
+The default value is 60 minutes.
+```
+
+```{config:option} core.secret_key_lifetime server-core
+:defaultdesc: "`30`"
+:scope: "global"
+:shortdesc: "The lifetime in days of the cluster secret key."
+:type: "integer"
+The cluster secret key is used to encrypt cookies that are used to verify the integrity of the OpenID Connect (OIDC) browser login flow.
+It is also used to encrypt cookies used for maintaining login information for OIDC authenticated users.
+This configuration specifies the number of days a given key is valid for.
+When a key is required, LXD checks if the current key has expired.
+If the key has expired, a new key is generated with the given lifetime in days.
+The default value is 30 days.
+
+Note that this key is used in combination with a salt for obfuscation.
+
+When this key rotates, all users that are logged in via OIDC will need to re-authenticate with the identity provider (IdP).
+If they are still logged in with the IdP, they will be automatically logged back into LXD.
+```
+
 ```{config:option} core.shutdown_timeout server-core
 :defaultdesc: "`5`"
 :scope: "global"

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -28,6 +28,7 @@ import (
 	clusterRequest "github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/lxd/db/cluster/secret"
 	"github.com/canonical/lxd/lxd/db/operationtype"
 	"github.com/canonical/lxd/lxd/db/warningtype"
 	"github.com/canonical/lxd/lxd/instance"
@@ -832,6 +833,9 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		if err != nil {
 			return err
 		}
+
+		// Reset the cluster secret. A new one will be fetched when next required.
+		d.clusterSecretInternal = &secret.Secret{}
 
 		d.globalConfigMu.Lock()
 		d.localConfig = nodeConfig

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -848,7 +848,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 			changes[k], _ = v.(string)
 		}
 
-		err = doAPI10UpdateTriggers(d, nil, changes, nodeConfig, currentClusterConfig)
+		err = doAPI10UpdateTriggers(r, d, nil, changes, nodeConfig, currentClusterConfig)
 		if err != nil {
 			return err
 		}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -669,6 +669,8 @@ func extractKeys(s secret.Secret, salt []byte) (hash []byte, block []byte, err e
 // Opts contains optional configurable fields for the Verifier.
 type Opts struct {
 	GroupsClaim string
+	Host        string
+	Ctx         context.Context
 }
 
 // NewVerifier returns a Verifier.
@@ -688,6 +690,18 @@ func NewVerifier(issuer string, clientID string, scopes []string, audience strin
 		groupsClaim:    opts.GroupsClaim,
 		clusterSecret:  clusterSecret,
 		httpClientFunc: httpClientFunc,
+	}
+
+	if options != nil && options.Host != "" {
+		ctx := context.Background()
+		if opts.Ctx != nil {
+			ctx = opts.Ctx
+		}
+
+		err := verifier.ensureConfig(ctx, opts.Host)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to configure OIDC verifier: %w", err)
+		}
 	}
 
 	return verifier, nil

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -248,6 +248,13 @@ func (c *Config) ClusterHealingThreshold() time.Duration {
 	return healingThreshold
 }
 
+// KeyAndSaltLifetimes returns the lifetimes of the cluster-wide secret key and salt.
+func (c *Config) KeyAndSaltLifetimes() (keyLifetime time.Duration, saltLifetime time.Duration) {
+	keyLifetimeDays := c.m.GetInt64("core.secret_key_lifetime")
+	saltLifetimeMinutes := c.m.GetInt64("core.salt_lifetime")
+	return time.Duration(keyLifetimeDays) * 24 * time.Hour, time.Duration(saltLifetimeMinutes) * time.Minute
+}
+
 // Dump current configuration keys and their values. Keys with values matching
 // their defaults are omitted.
 func (c *Config) Dump() map[string]any {

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -500,6 +500,37 @@ var ConfigSchema = config.Schema{
 	//  shortdesc: Whether to automatically trust clients signed by the CA
 	"core.trust_ca_certificates": {Type: config.Bool, Default: "false"},
 
+	// lxdmeta:generate(entities=server; group=core; key=core.secret_key_lifetime)
+	// The cluster secret key is used to encrypt cookies that are used to verify the integrity of the OpenID Connect (OIDC) browser login flow.
+	// It is also used to encrypt cookies used for maintaining login information for OIDC authenticated users.
+	// This configuration specifies the number of days a given key is valid for.
+	// When a key is required, LXD checks if the current key has expired.
+	// If the key has expired, a new key is generated with the given lifetime in days.
+	// The default value is 30 days.
+	//
+	// Note that this key is used in combination with a salt for obfuscation.
+	//
+	// When this key rotates, all users that are logged in via OIDC will need to re-authenticate with the identity provider (IdP).
+	// If they are still logged in with the IdP, they will be automatically logged back into LXD.
+	// ---
+	//  type: integer
+	//  scope: global
+	//  defaultdesc: `30`
+	//  shortdesc: The lifetime in days of the cluster secret key.
+	"core.secret_key_lifetime": {Type: config.Int64, Default: "30"},
+
+	// lxdmeta:generate(entities=server; group=core; key=core.salt_lifetime)
+	// The cluster salt is used to encrypt cookies that are used to verify the integrity of the OpenID Connect (OIDC) browser login flow.
+	// This configuration specifies the number of minutes a given salt is valid for.
+	//
+	// The default value is 60 minutes.
+	// ---
+	//  type: integer
+	//  scope: global
+	//  defaultdesc: `60`
+	//  shortdesc: The lifetime in minutes of the cluster salt.
+	"core.salt_lifetime": {Type: config.Int64, Default: "60"},
+
 	// lxdmeta:generate(entities=server; group=images; key=images.auto_update_cached)
 	//
 	// ---

--- a/lxd/config/map.go
+++ b/lxd/config/map.go
@@ -217,6 +217,11 @@ func (m *Map) set(name string, value string, initial bool) (bool, error) {
 		return true, nil
 	}
 
+	// Bypass schema for volatile.secret keys and don't insert them into the config map.
+	if strings.HasPrefix(name, "volatile.secret.") {
+		return false, nil
+	}
+
 	key, ok := m.schema[name]
 	if !ok {
 		return false, fmt.Errorf("Unknown key")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1706,7 +1706,7 @@ func (d *Daemon) init() error {
 			return util.HTTPClient("", d.proxy)
 		}
 
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScopes, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcScopes, oidcAudience, d.getClusterSecret, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 		if err != nil {
 			return err
 		}

--- a/lxd/db/cluster/secret/secret.go
+++ b/lxd/db/cluster/secret/secret.go
@@ -1,0 +1,334 @@
+package secret
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// Secret encapsulates a cluster-wide secret allowing all members to share and rotate salts and keys.
+// The caller should check if the current secret IsValid and use it if it is valid. Otherwise, they must call Update.
+type Secret struct {
+	key  key
+	salt salt
+}
+
+// IsValid returns true if both the key and salt are set and have not expired.
+func (s Secret) IsValid() bool {
+	return s.key.isValid() && s.salt.isValid()
+}
+
+// KeyAndSalt returns the current key and salt.
+func (s Secret) KeyAndSalt() (key []byte, salt []byte, err error) {
+	if !s.key.isValid() {
+		return nil, nil, errors.New("Invalid key")
+	}
+
+	if !s.salt.isValid() {
+		return nil, nil, errors.New("Invalid salt")
+	}
+
+	return s.key.bytes, s.salt.u[:], nil
+}
+
+// UnsetKey should be called when `core.salt_lifetime` is changed so that the current key is invalidated.
+func (s *Secret) UnsetKey(ctx context.Context, tx *sql.Tx) error {
+	return s.key.unset(ctx, tx)
+}
+
+// UnsetSalt should be called when `core.salt_lifetime` is changed so that the current salt is invalidated.
+func (s *Secret) UnsetSalt(ctx context.Context, tx *sql.Tx) error {
+	return s.salt.unset(ctx, tx)
+}
+
+// Update updates the secret. This should only be called when the current secret is invalid. In both cases, it queries
+// the database to check if any other members have updated the value first. If the key and salt in the database are valid,
+// they are used. Otherwise, the key/salt is overwritten with a new valid one.
+func (s *Secret) Update(ctx context.Context, tx *sql.Tx, keyLifetime time.Duration, saltLifetime time.Duration) error {
+	if s == nil {
+		return errors.New("Cannot update nil secret")
+	}
+
+	keyIsValid := s.key.isValid()
+	saltIsValid := s.salt.isValid()
+	if keyIsValid && saltIsValid {
+		return nil
+	}
+
+	if !keyIsValid {
+		key, err := getKey(ctx, tx, keyLifetime)
+		if err != nil {
+			return err
+		}
+
+		s.key = *key
+	}
+
+	if !saltIsValid {
+		salt, err := getSalt(ctx, tx, saltLifetime)
+		if err != nil {
+			return err
+		}
+
+		s.salt = *salt
+	}
+
+	return nil
+}
+
+// getKey gets a secret key from the database or sets a new one with the given lifetime.
+func getKey(ctx context.Context, tx *sql.Tx, lifetime time.Duration) (*key, error) {
+	// Check if another cluster member has already updated the salt.
+	r := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE key = 'volatile.secret.key'")
+	err := r.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	var dbSecretKey key
+	err = r.Scan(&dbSecretKey)
+	if err == nil && dbSecretKey.isValid() {
+		// Another member updated the key, and it is in date, so use that.
+		return &dbSecretKey, nil
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	updatedSecret, err := newKey(lifetime)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := tx.ExecContext(ctx, "INSERT OR REPLACE INTO config (key, value) VALUES ('volatile.secret.key', ?)", updatedSecret)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to set new shared secret: %w", err)
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to check key was correctly stored: %w", err)
+	}
+
+	if rowsAffected != 1 {
+		return nil, fmt.Errorf("Failed to set new secret key - no rows affected")
+	}
+
+	return updatedSecret, nil
+}
+
+// newKey returns a key with the expiry set to the current UTC time, plus the lifetime in milliseconds.
+func newKey(lifetime time.Duration) (*key, error) {
+	buf := make([]byte, 512)
+	n, err := rand.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+
+	if n != 512 {
+		return nil, errors.New("Not enough bytes to read")
+	}
+
+	return &key{
+		expiry: time.Now().UTC().Add(lifetime).UnixMilli(),
+		bytes:  buf,
+	}, nil
+}
+
+// key is a combination of a timestamp (UTC Unix milliseconds) and 512 random bytes.
+type key struct {
+	expiry int64
+	bytes  []byte
+}
+
+func (s key) unset(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "DELETE FROM config WHERE key = 'volatile.secret.key'")
+	return err
+}
+
+// String implements fmt.Stringer for key.
+func (s key) String() string {
+	if s.expiry == 0 || len(s.bytes) == 0 {
+		return ""
+	}
+
+	return strconv.FormatInt(s.expiry, 10) + "." + base64.StdEncoding.EncodeToString(s.bytes)
+}
+
+// isValid returns true if the key is set and has not expired.
+func (s key) isValid() bool {
+	return len(s.bytes) == 512 && s.expiry > time.Now().UTC().UnixMilli()
+}
+
+// Scan implements sql.Scanner for key.
+func (s *key) Scan(value any) error {
+	if s == nil {
+		return errors.New("Cannot scan secret key into nil value")
+	}
+
+	if value == nil {
+		return nil
+	}
+
+	stringValue, err := driver.String.ConvertValue(value)
+	if err != nil {
+		return fmt.Errorf("Invalid secret key type: %w", err)
+	}
+
+	secretStr, ok := stringValue.(string)
+	if !ok {
+		return fmt.Errorf("key should be a string, got `%v` (%T)", stringValue, stringValue)
+	}
+
+	tStr, secretStr, ok := strings.Cut(secretStr, ".")
+	if !ok {
+		return fmt.Errorf("Invalid cluster secret: Timestamp and secret must be separated by a '.'")
+	}
+
+	expiry, err := strconv.ParseInt(tStr, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	secret, err := base64.StdEncoding.DecodeString(secretStr)
+	if err != nil {
+		return err
+	}
+
+	s.expiry = expiry
+	s.bytes = secret
+
+	return nil
+}
+
+// Value implements driver.Valuer for key.
+func (s key) Value() (driver.Value, error) {
+	if !s.isValid() {
+		return nil, errors.New("Cannot write invalid secret to database")
+	}
+
+	return s.String(), nil
+}
+
+// getSalt gets a Salt from the database or sets a new one with the given lifetime.
+func getSalt(ctx context.Context, tx *sql.Tx, lifetime time.Duration) (*salt, error) {
+	// Check if another cluster member has already updated the salt.
+	r := tx.QueryRowContext(ctx, "SELECT value FROM config WHERE key = 'volatile.secret.salt'")
+	err := r.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	var dbSalt salt
+	err = r.Scan(&dbSalt)
+	if err == nil && dbSalt.isValid() {
+		// Another member updated the salt, and it is in date, so use that.
+		return &dbSalt, nil
+	} else if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+
+	updatedSalt, err := newSalt(lifetime)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := tx.ExecContext(ctx, "INSERT OR REPLACE INTO config (key, value) VALUES ('volatile.secret.salt', ?)", updatedSalt)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to set new shared salt: %w", err)
+	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to check salt was correctly stored: %w", err)
+	}
+
+	if rowsAffected != 1 {
+		return nil, fmt.Errorf("Failed to set new salt - no rows affected")
+	}
+
+	return updatedSalt, nil
+}
+
+// newSalt returns a salt with the expiry set to the current UTC time, plus the lifetime in milliseconds.
+func newSalt(lifetime time.Duration) (*salt, error) {
+	u, err := ulid.New(uint64(time.Now().UTC().UnixMilli()+lifetime.Milliseconds()), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create time embedded salt: %w", err)
+	}
+
+	return &salt{
+		u: &u,
+	}, nil
+}
+
+// salt is a wrapper for ulid.ULID for use as a random salt with a built-in expiry.
+type salt struct {
+	u *ulid.ULID
+}
+
+func (s salt) unset(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, "DELETE FROM config WHERE key = 'volatile.secret.salt'")
+	return err
+}
+
+// String implements fmt.Stringer for salt.
+func (s salt) String() string {
+	if s.u == nil {
+		return ""
+	}
+
+	return s.u.String()
+}
+
+// isValid returns true if the salt is set and has not expired.
+func (s salt) isValid() bool {
+	return s.u != nil && time.Now().UTC().UnixMilli() < ulid.Time(s.u.Time()).UTC().UnixMilli()
+}
+
+// Scan implements sql.Scanner for salt.
+func (s *salt) Scan(value any) error {
+	if s == nil {
+		return errors.New("Cannot scan salt into nil value")
+	}
+
+	if value == nil {
+		return nil
+	}
+
+	stringValue, err := driver.String.ConvertValue(value)
+	if err != nil {
+		return fmt.Errorf("Invalid salt type: %w", err)
+	}
+
+	saltStr, ok := stringValue.(string)
+	if !ok {
+		return fmt.Errorf("salt should be a string, got `%v` (%T)", stringValue, stringValue)
+	}
+
+	u, err := ulid.Parse(saltStr)
+	if err != nil {
+		return fmt.Errorf("salt should be a ULID: %w", err)
+	}
+
+	s.u = &u
+
+	return nil
+}
+
+// Value implements driver.Valuer for salt.
+func (s salt) Value() (driver.Value, error) {
+	if !s.isValid() {
+		return nil, errors.New("Cannot write invalid salt to database")
+	}
+
+	return s.u.String(), nil
+}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5190,6 +5190,24 @@
 						}
 					},
 					{
+						"core.salt_lifetime": {
+							"defaultdesc": "`60`",
+							"longdesc": "The cluster salt is used to encrypt cookies that are used to verify the integrity of the OpenID Connect (OIDC) browser login flow.\nThis configuration specifies the number of minutes a given salt is valid for.\n\nThe default value is 60 minutes.",
+							"scope": "global",
+							"shortdesc": "The lifetime in minutes of the cluster salt.",
+							"type": "integer"
+						}
+					},
+					{
+						"core.secret_key_lifetime": {
+							"defaultdesc": "`30`",
+							"longdesc": "The cluster secret key is used to encrypt cookies that are used to verify the integrity of the OpenID Connect (OIDC) browser login flow.\nIt is also used to encrypt cookies used for maintaining login information for OIDC authenticated users.\nThis configuration specifies the number of days a given key is valid for.\nWhen a key is required, LXD checks if the current key has expired.\nIf the key has expired, a new key is generated with the given lifetime in days.\nThe default value is 30 days.\n\nNote that this key is used in combination with a salt for obfuscation.\n\nWhen this key rotates, all users that are logged in via OIDC will need to re-authenticate with the identity provider (IdP).\nIf they are still logged in with the IdP, they will be automatically logged back into LXD.",
+							"scope": "global",
+							"shortdesc": "The lifetime in days of the cluster secret key.",
+							"type": "integer"
+						}
+					},
+					{
 						"core.shutdown_timeout": {
 							"defaultdesc": "`5`",
 							"longdesc": "Specify the number of minutes to wait for running operations to complete before the LXD server shuts down.",

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -442,6 +442,7 @@ var APIExtensions = []string{
 	"project_default_network_and_storage",
 	"client_cert_presence",
 	"clustering_groups_used_by",
+	"secret_lifetime",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -12,10 +12,14 @@ test_oidc() {
   lxc config set oidc.scopes "my-scope email openid" # Valid
   lxc config unset oidc.scopes # Should reset to include profile and offline access claims
 
+  lxc config set "oidc.client.id=device"
+
+  # Cannot set issuer to a URL that cannot perform discovery.
+  ! lxc config set "oidc.issuer=http://127.0.0.1:$(local_tcp_port)/" || false
+
   # Setup OIDC
   spawn_oidc
   lxc config set "oidc.issuer=http://127.0.0.1:$(cat "${TEST_DIR}/oidc.port")/"
-  lxc config set "oidc.client.id=device"
 
   # Expect this to fail. No user set.
   ! BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc || false


### PR DESCRIPTION
When performing the [authorization code flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow) two cookies are encrypted and stored on the client. After authentication, when the client is redirected to LXDs `/oidc/callback` endpoint, the receiving LXD cluster member must be able to decrypt these cookies to complete the PKCE part of the authentication flow.

It is possible that, if LXD is deployed behind a load-balancer or DNS SRV records are used, the redirection to `/oidc/callback` will reach a different cluster member to the one that started the login flow. Currently, the encryption keys used for these cookies are cluster member specific. If the call to `/oidc/login` starts on one cluster member, but the call to `/oidc/callback` reaches another cluster member, then decryption of these cookies fails and the authentication flow must be restarted.

This is documented in #13644

This PR adds the concept of a cluster wide secret key and salt. Both the key and the salt are stored in the `config` table but are hidden from the server configuration. 

The key and salt have the following formats:
- salt: a [ULID](https://github.com/ulid/spec) with the time set to the time of expiry and with `(crypto/rand).Reader` as the source of entropy (rather than the default monotonic reader).
- key: a 512 bytes read from `(crypto/rand).Reader`. In the database, this is base64 encoded and prepended with the expiry time in unix milliseconds (UTC) (delimited by a `.`, which base64 cannot contain).

Note that the key is not a private TLS key. It's only use is as a source for HKDF derivation of hash and block keys for cookie encryption.

Whenever the salt or key are used, the caller should check if they are still valid. If they are not valid, the caller should check if another cluster member has created a valid key/salt and stored it in the database. If the key/salt in the database is not valid, the caller should set a new one. The `lxd/db/secret` package has been added to handle this.

Two new configuration keys are added to manage the lifetime of the secret key (`core.secret_key_lifetime` default 30 (days)) and salt (`core.salt_lifetime` default 60 (minutes)). When the key or salt lifetime is updated, the existing key and salt are invalidated. Additionally, when a daemon joins a cluster, any secrets it is holding in memory are invalidated.

To preserve the authorization code flow in case of salt or key rotation occurring while a user is logging in, the OIDC verifier keeps old relying party configuration available in memory for 5 minutes. The verifier determines which RP to use to complete the flow by checking that it is able to decode the `state` cookie (which is set as part of the flow).

This PR removes dependence on the cluster private key for derivation of unique cookie encryption keys for OIDC ID and access tokens. Instead we use the cluster-wide secret key, plus the session ID, to derive unique keys per user session.

Lastly, options for instantiating a new OIDC verifier have been expanded to pass in a "host" and a context. This means that the verifier will attempt to perform discovery when the configuration is set. 

Closes #13644.

Marking as draft because this is really a collection of ideas and there is no spec. If we like the approach and decide to merge, beware that this will log out all OIDC users (though if they're still logged in at the IdP, the be re-logged into LXD after a brief redirect).