### PR TITLE
Daemon: Allow shutdown during startup

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1460,7 +1460,7 @@ func (d *Daemon) init() error {
 			options = append(options, driver.WithTracing(dqliteClient.LogDebug))
 		}
 
-		d.db.Cluster, err = db.OpenCluster(context.Background(), "db.bin", store, localClusterAddress, dir, d.config.DqliteSetupTimeout, nil, options...)
+		d.db.Cluster, err = db.OpenCluster(d.shutdownCtx, "db.bin", store, localClusterAddress, dir, d.config.DqliteSetupTimeout, nil, options...)
 		if err == nil {
 			logger.Info("Initialized global database")
 			break


### PR DESCRIPTION
Fixes #14628 

Launch `d.Init()` in a goroutine so that a shutdown signal will immediately cancel the `shutdownCtx` and trigger `d.Stop()`. This allows shutting down LXD while it is still starting; it's likely that this introduces some nasty races (including nil pointer derefs :cry: ) if `Stop()` is called on a partially initialized daemon.

However, responding to shutdown signals right away lets the admin bail on Dqlite startup if a clustered LXD server isn't able to achieve quorum. Without this patch, a user who needs to run `lxd recover` will sit and wait forever for LXD to shut down gracefully.

I'm opening this PR mostly to run the test suite against it; still thinking about an appropriate approach for stopping a partially initialized daemon.