### PR TITLE
lxd/device/cdi/spec: use config search paths option for Ubuntu Core

### DIFF
--- a/lxd/device/cdi/spec.go
+++ b/lxd/device/cdi/spec.go
@@ -64,6 +64,7 @@ func generateNvidiaSpec(s *state.State, cdiID ID, inst instance.Instance) (*spec
 
 	rootPath := ""
 	devRootPath := ""
+	configSearchPaths := []string{}
 	if s.OS.InUbuntuCore() {
 		devRootPath = "/"
 
@@ -97,6 +98,7 @@ func generateNvidiaSpec(s *state.State, cdiID ID, inst instance.Instance) (*spec
 		}
 
 		rootPath = strings.TrimSuffix(rootPath, "\n")
+		configSearchPaths = []string{rootPath + "/usr/share"}
 
 		// Let's ensure that user did:
 		// snap connect mesa-2404:kernel-gpu-2404 pc-kernel
@@ -116,6 +118,7 @@ func generateNvidiaSpec(s *state.State, cdiID ID, inst instance.Instance) (*spec
 		nvcdi.WithNVIDIACDIHookPath(nvidiaCTKPath),
 		nvcdi.WithMode(mode),
 		nvcdi.WithCSVFiles(defaultNvidiaTegraCSVFiles(rootPath)),
+		nvcdi.WithConfigSearchPaths(configSearchPaths),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create CDI library: %w", err)

--- a/lxd/device/cdi/spec.go
+++ b/lxd/device/cdi/spec.go
@@ -3,6 +3,7 @@
 package cdi
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -92,7 +93,7 @@ func generateNvidiaSpec(s *state.State, cdiID ID, inst instance.Instance) (*spec
 			"NVIDIA_DRIVER_ROOT",
 		}
 
-		rootPath, err = shared.RunCommand(cmd[0], cmd[1:]...)
+		rootPath, err = shared.RunCommandContext(context.TODO(), cmd[0], cmd[1:]...)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to determine NVIDIA driver root path: %w", err)
 		}


### PR DESCRIPTION
After we've got https://github.com/NVIDIA/nvidia-container-toolkit/pull/847 merged we can use WithConfigSearchPaths() nvcdi option to specify where NVIDIA configuration files are located and revert our previous hacky fix from https://github.com/canonical/lxd-pkg-snap/pull/679

No behavior change for non-Ubuntu Core environment intended.

Please, merge with https://github.com/canonical/lxd-pkg-snap/pull/739