### PR TITLE
Network: Don't ask OVN to allocate dynamic addresses when DHCP is disabled

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3819,8 +3819,8 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			// IPv4 addresses have been added, then add an EUI64 static IPv6 address so that the switch
 			// port has an IPv6 address that will be used to generate a DNS record. This works around a
 			// limitation in OVN that prevents us requesting dynamic IPv6 address allocation when
-			// static IPv4 allocation is used.
-			if len(staticIPs) > 0 {
+			// static IPv4 allocation is used or when we don't want to have dynamic IPv4 allocation.
+			if len(staticIPs) > 0 || dhcpv4Subnet == nil {
 				hasIPv6 := false
 				for _, ip := range staticIPs {
 					if ip.To4() == nil {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1997,7 +1997,7 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 			}
 
 			if r.ListenPort > 0 {
-				targetArgs = append(targetArgs, ipToString(target.Address)+":"+fmt.Sprint(target.Port))
+				targetArgs = append(targetArgs, ipToString(target.Address)+":"+strconv.FormatUint(target.Port, 10))
 			} else {
 				targetArgs = append(targetArgs, ipToString(target.Address))
 			}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1239,21 +1239,26 @@ func (o *OVN) LogicalSwitchPortAdd(switchName OVNSwitch, portName OVNSwitchPort,
 			args = append(args, string(opts.Parent), fmt.Sprint(opts.VLAN))
 		}
 
-		ipStr := make([]string, 0, len(opts.IPs))
-		for _, ip := range opts.IPs {
-			ipStr = append(ipStr, ip.String())
+		var addresses []string
+
+		if opts.MAC != nil {
+			addresses = append(addresses, opts.MAC.String())
 		}
 
-		var addresses string
-		if opts.MAC != nil && len(ipStr) > 0 {
-			addresses = opts.MAC.String() + " " + strings.Join(ipStr, " ")
-		} else if opts.MAC != nil && len(ipStr) <= 0 {
-			addresses = opts.MAC.String() + " dynamic"
-		} else {
-			addresses = "dynamic"
+		if len(opts.IPs) > 0 {
+			// If static IPs are requested then use these.
+			for _, ip := range opts.IPs {
+				addresses = append(addresses, ip.String())
+			}
+		} else if opts.DHCPv4OptsID != "" || opts.DHCPv6OptsID != "" {
+			// Or if either DHCPv4 or DHCPv6 is enabled then request dynamic IPs for both protocols.
+			// OVN currently doesn't allow us to request protocol specific dynamic IPs.
+			addresses = append(addresses, "dynamic")
 		}
 
-		args = append(args, "--", "lsp-set-addresses", string(portName), addresses)
+		if len(addresses) > 0 {
+			args = append(args, "--", "lsp-set-addresses", string(portName), strings.Join(addresses, " "))
+		}
 
 		if opts.DHCPv4OptsID != "" {
 			args = append(args, "--", "lsp-set-dhcpv4-options", string(portName), string(opts.DHCPv4OptsID))

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -2005,7 +2005,7 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 
 		if r.ListenPort > 0 {
 			args = append(args,
-				ipToString(r.ListenAddress)+fmt.Sprint(r.ListenPort),
+				ipToString(r.ListenAddress)+":"+strconv.FormatUint(r.ListenPort, 10),
 				strings.Join(targetArgs, ","),
 				r.Protocol,
 			)


### PR DESCRIPTION
This PR changes the way LXD configures OVN's logical switch ports so that it doesn't request `dynamic` IPs for the switch port when `ipv4.dhcp` **and** `ipv6.dhcp` are disabled on the network.

Because OVN doesn't currently allow us to request protocol specific dynamic allocation, LXD has a workaround where if `ipv4.dhcp` is disabled, but `ipv6.dhcp` is enabled, LXD will generate an EUI64 address from the MAC address and set that as a static address in OVN. This avoids OVN needing to also allocate an IPv4 address. It also means that no DNS A records will be created for that port.

However in the case where `ipv4.dhcp` is enabled and `ipv6.dhcp` is false, we need to ask OVN to assign `dynamic` addresses, and so the logical switch port will get both an IPv4 and IPv6 address (and DNS entries for both by extension).

Also fixes a regression from https://github.com/canonical/lxd/pull/14991