### PR TITLE
Network: Fix another regression from moving away from fmt.Sprintf

### DIFF
--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1997,7 +1997,7 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 			}
 
 			if r.ListenPort > 0 {
-				targetArgs = append(targetArgs, ipToString(target.Address)+":"+fmt.Sprint(target.Port))
+				targetArgs = append(targetArgs, ipToString(target.Address)+":"+strconv.FormatUint(target.Port, 10))
 			} else {
 				targetArgs = append(targetArgs, ipToString(target.Address))
 			}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -2005,7 +2005,7 @@ func (o *OVN) LoadBalancerApply(loadBalancerName OVNLoadBalancer, routers []OVNR
 
 		if r.ListenPort > 0 {
 			args = append(args,
-				ipToString(r.ListenAddress)+fmt.Sprint(r.ListenPort),
+				ipToString(r.ListenAddress)+":"+strconv.FormatUint(r.ListenPort, 10),
 				strings.Join(targetArgs, ","),
 				r.Protocol,
 			)


### PR DESCRIPTION
Fixes missing colon from https://github.com/canonical/lxd/pull/14991