### PR TITLE
cloud-init: Reset Instance ID when SSH keys are defined

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1255,6 +1255,13 @@ func (d *common) needsNewInstanceID(changedConfig []string, oldExpandedDevices d
 		}
 	}
 
+	// Additional SSH keys should also trigger an ID reset.
+	for _, key := range changedConfig {
+		if strings.HasPrefix(key, "cloud-init.ssh-keys.") {
+			return true
+		}
+	}
+
 	// Look for changes in network interface names.
 	getNICNames := func(devs deviceConfig.Devices) []string {
 		names := make([]string, 0, len(devs))


### PR DESCRIPTION
Setting a new instance ID prompts `cloud-init` to get and apply configuration from LXD. So we update the instance ID if an instance restarts after changing configuration that is relevant for `cloud-init` to make sure it is applied. This PR does this with `cloud-init.ssh-keys` so they are applied even after the first boot.