### PR TITLE
Auth: Fix `idFromURLQuery` for fine-grained TLS identities

### DIFF
--- a/lxd/db/cluster/entity_type_identity.go
+++ b/lxd/db/cluster/entity_type_identity.go
@@ -56,10 +56,10 @@ WHERE '' = ?
 		WHEN %d THEN '%s' 
 	END = ? 
 	AND identities.identifier = ?
-	AND identities.type IN (%d)
+	AND identities.type IN (%d, %d, %d)
 `, authMethodTLS, api.AuthenticationMethodTLS,
 		authMethodOIDC, api.AuthenticationMethodOIDC,
-		identityTypeOIDCClient,
+		identityTypeOIDCClient, identityTypeCertificateClient, identityTypeCertificateClientPending,
 	)
 }
 

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -174,6 +174,19 @@ fine_grained: true"
   lxc auth group permission remove test-group identity oidc/test-user@example.com can_view
   ! lxc auth group permission remove test-group identity oidc/test-user@example.com can_view || false # Already removed
 
+  ! lxc auth group permission add test-group identity "${tls_identity_fingerprint}" can_view || false # Missing authentication method
+  lxc auth group permission add test-group identity "tls/${tls_identity_fingerprint}" can_view # Valid
+  lxc auth group permission remove test-group identity "tls/${tls_identity_fingerprint}" can_view
+  ! lxc auth group permission remove test-group identity "tls/${tls_identity_fingerprint}" can_view || false # Already removed
+
+  lxc auth identity create tls/tmp
+  pending_identity_id="$(lxc auth identity list --format csv | grep -F 'Client certificate (pending)' | cut -d, -f4)"
+  ! lxc auth group permission add test-group identity "${pending_identity_id}" can_view || false # Missing authentication method
+  lxc auth group permission add test-group identity "tls/${pending_identity_id}" can_view # Valid
+  lxc auth group permission remove test-group identity "tls/${pending_identity_id}" can_view
+  ! lxc auth group permission remove test-group identity "tls/${pending_identity_id}" can_view || false # Already removed
+  lxc auth identity delete tls/tmp
+
   ### IDENTITY PROVIDER GROUP MANAGEMENT ###
   lxc auth identity-provider-group create test-idp-group
   ! lxc auth identity-provider-group group add test-idp-group not-found || false # Group not found


### PR DESCRIPTION
The database queries for certificate and identity entity types were
changed in #14173 so that they don't overlap. This included restricting
the ID from URL query for identities to only include OIDC identities
(which were the only fine-grained identities at the time).

When fine-grained TLS identities were added in #14207, the new identity
types were not added to the ID from URL query. This prevents permission
subsystems from resolving the URL of a pending or activated fine-grained
TLS identity, and therefore prevents permissions from being granted against
identities of this type.

Reported by @mas-who:
```
mason@BlackMumba:~/Desktop/work/forks/lxd-ui/keys$ lxc auth group show tls-group
name: tls-group
description: ""
permissions:
- entity_type: server
  url: /1.0
  entitlement: admin
- entity_type: identity
  url: /1.0/auth/identities/oidc/lxd-ui-e2e-tests@example.org
  entitlement: can_delete
identities: {}
identity_provider_groups: []
mason@BlackMumba:~/Desktop/work/forks/lxd-ui/keys$ lxc auth identity list
+-----------------------+-----------------------------------+------------------------------+------------------------------------------------------------------+-------------+
| AUTHENTICATION METHOD |               TYPE                |             NAME             |                            IDENTIFIER                            |   GROUPS    |
+-----------------------+-----------------------------------+------------------------------+------------------------------------------------------------------+-------------+
| oidc                  | OIDC client                       | lxd-ui-e2e-tests@example.org | lxd-ui-e2e-tests@example.org                                     | asdf        |
|                       |                                   |                              |                                                                  | asdfasdfasd |
|                       |                                   |                              |                                                                  | test        |
+-----------------------+-----------------------------------+------------------------------+------------------------------------------------------------------+-------------+
| tls                   | Client certificate                | tls-identity                 | f934c18045449d44a427a492553312b40b3d4dba887b1da62fe2cdd96c8de08d |             |
+-----------------------+-----------------------------------+------------------------------+------------------------------------------------------------------+-------------+
| tls                   | Client certificate (pending)      | tls-identity                 | 5d724a56-60cd-45f9-9f83-57d2adf38585                             |             |
+-----------------------+-----------------------------------+------------------------------+------------------------------------------------------------------+-------------+
| tls                   | Client certificate (unrestricted) | lxd-ui                       | fd74e84407f3614b166f9870bc268517741db2039629888974bb17c957a1f83b |             |
+-----------------------+-----------------------------------+------------------------------+------------------------------------------------------------------+-------------+
mason@BlackMumba:~/Desktop/work/forks/lxd-ui/keys$ lxc auth group permission add tls-group identity tls/f934c18045449d44a427a492553312b40b3d4dba887b1da62fe2cdd96c8de08d can_edit
Error: Failed to find entity ID for URL "/1.0/auth/identities/tls/f934c18045449d44a427a492553312b40b3d4dba887b1da62fe2cdd96c8de08d"
mason@BlackMumba:~/Desktop/work/forks/lxd-ui/keys$ lxc auth group permission add tls-group identity tls/tls-identity can_edit
Error: Failed to find entity ID for URL "/1.0/auth/identities/tls/tls-identity"
```