### PR TITLE
github: require code tests to pass before running client ones

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,6 +384,7 @@ jobs:
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.os }}
+    needs: code-tests
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
The code test job fails ~18% of the time according to https://github.com/canonical/lxd/actions/metrics/performance?tab=jobs
Since the client tests are super quick to run and are not gating anything, it's best to run them only once the code tests have passed.