### PR TITLE
lxd/instance_backup: Save the implicitly validated instance name

### DIFF
--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -528,7 +528,7 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Validate the name.
+	// Validate the new backup name.
 	newBackupName, err := backup.ValidateBackupName(req.Name)
 	if err != nil {
 		return response.BadRequest(err)

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -540,6 +540,9 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	// Save the instance name that was implicitly validated when looking up the backup.
+	name = backup.Instance().Name()
+
 	newName := name + shared.SnapshotDelimiter + newBackupName
 
 	rename := func(op *operations.Operation) error {


### PR DESCRIPTION
Help CodeQL understand the instance name was validated. Should address the following warnings:

* https://github.com/canonical/lxd/security/code-scanning/64
* https://github.com/canonical/lxd/security/code-scanning/287