### PR TITLE
Tweaks for backup tests

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -415,7 +415,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_backup_volume_export "backup volume export"
     run_test test_backup_export_import_instance_only "backup export and import instance only"
     run_test test_backup_volume_rename_delete "backup volume rename and delete"
-    run_test test_backup_different_instance_uuid "backup instance and check instance UUIDs"
+    run_test test_backup_instance_uuid "backup instance and check instance UUIDs"
     run_test test_backup_volume_expiry "backup volume expiry"
     run_test test_backup_export_import_recover "backup export, import, and recovery"
     run_test test_container_local_cross_pool_handling "container local cross pool handling"

--- a/test/main.sh
+++ b/test/main.sh
@@ -172,6 +172,10 @@ export LXD_SKIP_TESTS
 LXD_REQUIRED_TESTS="${LXD_REQUIRED_TESTS:-}"
 export LXD_REQUIRED_TESTS
 
+# This must be enough to accomodate the busybox testimage
+SMALL_ROOT_DISK="${SMALL_ROOT_DISK:-"root,size=32MiB"}"
+export SMALL_ROOT_DISK
+
 run_test() {
   TEST_CURRENT=${1}
   TEST_CURRENT_DESCRIPTION=${2:-${1}}

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -665,7 +665,7 @@ test_backup_rename() {
   lxc query -X POST --wait -d '{\"name\":\"foo\"}' /1.0/instances/c1/backups
 
   # All backups should be listed
-  lxc query /1.0/instances/c1/backups | jq .'[0]' | grep instances/c1/backups/foo
+  [ "$(lxc query /1.0/instances/c1/backups | jq -r '.[]')" = "/1.0/instances/c1/backups/foo" ]
 
   # The specific backup should exist
   lxc query /1.0/instances/c1/backups/foo
@@ -674,7 +674,7 @@ test_backup_rename() {
   lxc mv c1 c2
 
   # All backups should be listed
-  lxc query /1.0/instances/c2/backups | jq .'[0]' | grep instances/c2/backups/foo
+  [ "$(lxc query /1.0/instances/c2/backups | jq -r '.[]')" = "/1.0/instances/c2/backups/foo" ]
 
   # The specific backup should exist
   lxc query /1.0/instances/c2/backups/foo

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1034,7 +1034,7 @@ test_backup_export_import_recover() {
     ensure_has_localhost_remote "${LXD_ADDR}"
 
     # Create and export an instance.
-    lxc launch testimage c1 -d "${SMALL_ROOT_DISK}"
+    lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
     lxc export c1 "${LXD_DIR}/c1.tar.gz"
     lxc delete -f c1
 

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -964,16 +964,16 @@ test_backup_volume_rename_delete() {
   ! stat "${LXD_DIR}"/backups/custom/"${pool}"/default_vol2 || false
 }
 
-test_backup_different_instance_uuid() {
+test_backup_instance_uuid() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  echo "==> Checking instances UUID during backup operation"
+  echo "==> Checking instance UUIDs during backup operation"
   lxc launch testimage c1 -d "${SMALL_ROOT_DISK}"
   initialUUID=$(lxc config get c1 volatile.uuid)
   initialGenerationID=$(lxc config get c1 volatile.uuid.generation)
 
-  # export and import to trigger new UUID generation
+  # export and import should preserve the UUID and generation UUID
   lxc export c1 "${LXD_DIR}/c1.tar.gz"
   lxc delete -f c1
   lxc import "${LXD_DIR}/c1.tar.gz"
@@ -982,7 +982,7 @@ test_backup_different_instance_uuid() {
   newGenerationID=$(lxc config get c1 volatile.uuid.generation)
 
   if [ "${initialGenerationID}" != "${newGenerationID}" ] || [ "${initialUUID}" != "${newUUID}" ]; then
-    echo "==> UUID of the instance should remain the same after importing the backup file"
+    echo "==> UUID and generation UUID of the instance should remain the same after importing the backup file"
     false
   fi
 

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -12,7 +12,7 @@ test_storage_volume_recover() {
   fi
 
   # Create custom block volume.
-  lxc storage volume create "${poolName}" vol1 --type=block
+  lxc storage volume create "${poolName}" vol1 --type=block size=32MiB
 
   # Import ISO.
   truncate -s 8MiB foo.iso
@@ -28,7 +28,7 @@ test_storage_volume_recover() {
 
   if [ "$poolDriver" = "zfs" ]; then
     # Create filesystem volume.
-    lxc storage volume create "${poolName}" vol3
+    lxc storage volume create "${poolName}" vol3 size=32MiB
 
     # Create block_mode enabled volume.
     lxc storage volume create "${poolName}" vol4 zfs.block_mode=true size=200MiB
@@ -106,7 +106,7 @@ EOF
 
     # Recover container and custom volume that isn't mounted.
     lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
-    lxc storage volume create "${poolName}" vol1_test
+    lxc storage volume create "${poolName}" vol1_test size=32MiB
     lxc storage volume attach "${poolName}" vol1_test c1 /mnt
     lxc start c1
     lxc exec c1 --project test -- mount | grep /mnt
@@ -728,7 +728,7 @@ _backup_volume_export_with_project() {
   lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
 
   # Create custom storage volume.
-  lxc storage volume create "${custom_vol_pool}" testvol
+  lxc storage volume create "${custom_vol_pool}" testvol size=32MiB
 
   # Attach storage volume to the test container and start.
   lxc storage volume attach "${custom_vol_pool}" testvol c1 /mnt
@@ -911,7 +911,7 @@ test_backup_volume_rename_delete() {
   pool="lxdtest-$(basename "${LXD_DIR}")"
 
   # Create test volume.
-  lxc storage volume create "${pool}" vol1
+  lxc storage volume create "${pool}" vol1 size=32MiB
 
   if ! lxc query -X POST /1.0/storage-pools/"${pool}"/volumes/custom/vol1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Storage volume backup not found" ; then
     echo "invalid rename response for missing storage volume"
@@ -996,7 +996,7 @@ test_backup_volume_expiry() {
   poolName=$(lxc profile device get default root pool)
 
   # Create custom volume.
-  lxc storage volume create "${poolName}" vol1
+  lxc storage volume create "${poolName}" vol1 size=32MiB
 
   # Create storage volume backups using the API directly.
   # The first one is created with an expiry date, the second one never expires.

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1065,7 +1065,7 @@ test_backup_export_import_instance_only() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   # Create an instance with snapshot.
-  lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
+  lxc init --empty c1 -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1
 
   # Verify the original instance has snapshots.

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1068,6 +1068,9 @@ test_backup_export_import_instance_only() {
   lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1
 
+  # Verify the original instance has snapshots.
+  [ "$(lxc query "/1.0/storage-pools/${poolName}/volumes/container/c1/snapshots" | jq -r 'length')" = "1" ]
+
   # Export the instance and remove it.
   lxc export c1 "${LXD_DIR}/c1.tar.gz" --instance-only
   lxc delete -f c1
@@ -1076,7 +1079,7 @@ test_backup_export_import_instance_only() {
   lxc import "${LXD_DIR}/c1.tar.gz"
 
   # Verify imported instance has no snapshots.
-  [ "$(lxc query "/1.0/storage-pools/${poolName}/volumes/container/c1/snapshots" | jq "length == 0")" = "true" ]
+  [ "$(lxc query "/1.0/storage-pools/${poolName}/volumes/container/c1/snapshots" | jq -r 'length')" = "0" ]
 
   rm "${LXD_DIR}/c1.tar.gz"
   lxc delete -f c1

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -105,7 +105,7 @@ yes
 EOF
 
     # Recover container and custom volume that isn't mounted.
-    lxc init testimage c1
+    lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
     lxc storage volume create "${poolName}" vol1_test
     lxc storage volume attach "${poolName}" vol1_test c1 /mnt
     lxc start c1
@@ -378,8 +378,8 @@ _backup_import_with_project() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  lxc launch testimage c1
-  lxc launch testimage c2
+  lxc launch testimage c1 -d "${SMALL_ROOT_DISK}"
+  lxc launch testimage c2 -d "${SMALL_ROOT_DISK}"
 
   # Check invalid snapshot names
   ! lxc snapshot c2 ".." || false
@@ -486,7 +486,7 @@ _backup_import_with_project() {
   # Also check that the container storage volume config is correctly captured and restored.
   default_pool="$(lxc profile device get default root pool)"
 
-  lxc launch testimage c1-foo
+  lxc launch testimage c1-foo -d "${SMALL_ROOT_DISK}"
   lxc storage volume set "${default_pool}" container/c1-foo user.foo=c1-foo-snap0
   lxc snapshot c1-foo c1-foo-snap0
   lxc storage volume set "${default_pool}" container/c1-foo user.foo=c1-foo-snap1
@@ -508,7 +508,7 @@ _backup_import_with_project() {
   lxc storage create pool_2 dir
 
   # Export created container
-  lxc init testimage c3 -s pool_1
+  lxc init testimage c3 -d "${SMALL_ROOT_DISK}" -s pool_1
   lxc export c3 "${LXD_DIR}/c3.tar.gz"
 
   # Remove container and storage pool
@@ -575,7 +575,7 @@ _backup_export_with_project() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  lxc launch testimage c1
+  lxc launch testimage c1 -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1
 
   mkdir "${LXD_DIR}/optimized" "${LXD_DIR}/non-optimized"
@@ -628,7 +628,7 @@ _backup_export_with_project() {
   rm -rf "${LXD_DIR}/optimized" "${LXD_DIR}/non-optimized"
 
   # Check if hyphens cause issues when creating backups
-  lxc launch testimage c1-foo
+  lxc launch testimage c1-foo -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1-foo
 
   lxc export c1-foo "${LXD_DIR}/c1-foo.tar.gz"
@@ -654,7 +654,7 @@ test_backup_rename() {
     false
   fi
 
-  lxc init testimage c1
+  lxc init --empty c1 -d "${SMALL_ROOT_DISK}"
 
   if ! lxc query -X POST /1.0/containers/c1/backups/backupmissing -d '{\"name\": \"backupnewname\"}' --wait 2>&1 | grep -q "Error: Instance backup not found" ; then
     echo "invalid rename response for missing backup"
@@ -725,7 +725,7 @@ _backup_volume_export_with_project() {
   lxd_backend=$(storage_backend "$LXD_DIR")
 
   # Create test container.
-  lxc init testimage c1
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
 
   # Create custom storage volume.
   lxc storage volume create "${custom_vol_pool}" testvol
@@ -969,7 +969,7 @@ test_backup_different_instance_uuid() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   echo "==> Checking instances UUID during backup operation"
-  lxc launch testimage c1
+  lxc launch testimage c1 -d "${SMALL_ROOT_DISK}"
   initialUUID=$(lxc config get c1 volatile.uuid)
   initialGenerationID=$(lxc config get c1 volatile.uuid.generation)
 
@@ -1034,7 +1034,7 @@ test_backup_export_import_recover() {
     ensure_has_localhost_remote "${LXD_ADDR}"
 
     # Create and export an instance.
-    lxc launch testimage c1
+    lxc launch testimage c1 -d "${SMALL_ROOT_DISK}"
     lxc export c1 "${LXD_DIR}/c1.tar.gz"
     lxc delete -f c1
 
@@ -1065,7 +1065,7 @@ test_backup_export_import_instance_only() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   # Create an instance with snapshot.
-  lxc init testimage c1
+  lxc init testimage c1 -d "${SMALL_ROOT_DISK}"
   lxc snapshot c1
 
   # Export the instance and remove it.


### PR DESCRIPTION
This mostly aims at being faster by using smaller instances/volumes.

It also renames the `backup_different_instance_uuid` test to `backup_instance_uuid` to avoid any confusion. As explained in cb5bb787dbf, the UUIDs should be preserved through `export`/`import`.