### PR TITLE
LXD: Proxy device fixes

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -654,12 +654,12 @@ func (d *proxy) killProxyProc(pidPath string) error {
 	if shared.PathExists(pidPath) {
 		p, err := subprocess.ImportProcess(pidPath)
 		if err != nil {
-			return fmt.Errorf("Could not read pid file: %s", err)
+			return fmt.Errorf("Could not read pid file %q: %w", pidPath, err)
 		}
 
 		err = p.Stop()
 		if err != nil && err != subprocess.ErrNotRunning {
-			return fmt.Errorf("Unable to kill forkproxy: %s", err)
+			return fmt.Errorf("Unable to kill forkproxy: %w", err)
 		}
 
 		err = os.Remove(pidPath)

--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -349,7 +349,12 @@ container_devices_proxy_unix() {
     false
   fi
 
-  rm -f "${HOST_SOCK}"
+  # Ensure host socket removed upon device removal.
+  lxc config device remove proxyTester proxyDev
+  if [ -e "${HOST_SOCK}" ]; then
+    echo "Host socket was not removed upon device removal"
+    false
+  fi
 
   # Cleanup
   lxc delete -f proxyTester


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/14972 and https://github.com/canonical/lxd/issues/15023.
Co-authored by @simondeziel.

This pull request includes changes to `lxd/device/proxy.go` to improve error handling and cleanup processes, as well as a test update in `test/suites/container_devices_proxy.sh` to ensure proper socket removal.

Changes to `lxd/device/proxy.go`:

* Updated `killProxyProc` to also perform any necessary cleanup (removing the created unix socket) and improved error message formatting.
* Modified `checkProxyStarted` function to to prioritize the 'Failed to listen on...' error message.
 

Test update in `test/suites/container_devices_proxy.sh`:

* Added a check to the `container_devices_proxy_unix` function to ensure that the host socket is removed upon proxy device removal.