### PR TITLE
lxd/operations: don't log whole operation on failure

### DIFF
--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -97,7 +97,7 @@ func waitForOperations(ctx context.Context, cluster *db.Cluster, consoleShutdown
 
 			_, opAPI, err := op.Render()
 			if err != nil {
-				logger.Warn("Failed to render operation", logger.Ctx{"operation": op, "err": err})
+				logger.Warn("Failed to render operation", logger.Ctx{"operation ID": op.ID(), "operation class": op.Class().String(), "operation status": op.Status().String(), "err": err})
 			} else if opAPI.MayCancel {
 				_, _ = op.Cancel()
 			}


### PR DESCRIPTION
If the operation fails to render, we should not log the whole operation as it can contain sensitive information (tokens, passwords, etc).

Addresses https://github.com/canonical/lxd/security/code-scanning/307

Co-developed-by: Mark Laing <mark.laing@canonical.com>