### PR TITLE
doc: Code of Conduct replacement and minor fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Review the following guidelines before contributing to the project.
 
 ## Code of Conduct
 
-All contributors must adhere to the [Contributor Covenant Code of Conduct](https://github.com/canonical/lxd/blob/main/CODE_OF_CONDUCT.md).
+All contributors must adhere to the [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
 
 ## License and copyright
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 <!-- Include start contributing -->
 
 The LXD team welcomes contributions through pull requests, issue reports, and discussions.
-- Contribute to the code or documentation, report bugs, or request features in the [GitHub repository](https://github.com/canonical/lxd/issues)
+- Contribute to the code or documentation, report bugs, or request features in the [GitHub repository](https://github.com/canonical/lxd)
 - Ask questions or join discussions in the [LXD forum](https://discourse.ubuntu.com/c/lxd/126).
 
 Review the following guidelines before contributing to the project.
@@ -136,4 +136,4 @@ If you add or update configuration options, regenerate and commit the documentat
 
 ## More information
 
-For more information, including details about contributing to the code as well as the documentation for LXD, see [Contributing](https://documentation.ubuntu.com/lxd/en/latest/contributing/) in the documentation.
+For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://documentation.ubuntu.com/lxd/en/latest/contributing/) in the documentation.

--- a/doc/README.md
+++ b/doc/README.md
@@ -10,7 +10,7 @@ GitHub provides a basic rendering of the documentation as well, but important fe
 
 ### Documentation framework
 
-LXD's documentation is built with [Sphinx](https://www.sphinx-doc.org/en/master/index.html) and hosted on [Read the Docs](https://about.readthedocs.com/). <!-- wokeignore:rule=master -->
+LXD's documentation is built with [Sphinx](https://www.sphinx-doc.org) and hosted on [Read the Docs](https://about.readthedocs.com/).
 
 It is written in [Markdown](https://commonmark.org/) with [MyST](https://myst-parser.readthedocs.io/) extensions.
 For syntax help and guidelines, see the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) and the [documentation cheat sheet](https://documentation.ubuntu.com/lxd/en/latest/doc-cheat-sheet-myst/) ([source](https://raw.githubusercontent.com/canonical/lxd/main/doc/doc-cheat-sheet-myst.md)).

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -74,7 +74,7 @@ Clarify concepts or common questions based on your own experience.
 Report documentation issues by opening an issue on [GitHub](https://github.com/canonical/lxd/issues).
 : - We will evaluate and update the documentation as needed.
 
-Ask questions or suggest improvements in the [LXD forum](https://discourse.ubuntu.com/c/lxd/126).
+Ask questions or suggest improvements in the [LXD forum](https://discourse.ubuntu.com/c/lxd).
 : - We monitor discussions and update the documentation when necessary.
 
 Join discussions in the `#lxd` channel on IRC via [Libera Chat](https://web.libera.chat/#lxd).


### PR DESCRIPTION
- replaces the Contributor Covenant Code of Conduct with the Ubuntu Code of Conduct 
- a few minor fixes