### PR TITLE
AppArmor-related cherry-picks due to core20 update (stable-4.0)

### DIFF
--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -480,8 +480,13 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Configuration: unprivileged containers
   pivot_root,
 
+  # We need to allow all these filesystems because they were allowed
+  # for years as a result of a https://bugs.launchpad.net/apparmor/+bug/1597017
+  # Now, when AppArmor is fixed, we start to get complaints that things which
+  # were working before stopped to work now.
   mount fstype=devpts,
   mount fstype=proc,
+  mount fstype=sysfs,
 
   # Allow modifying mount propagation
   mount options=(rw,slave) -> **,

--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -480,6 +480,8 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   ### Configuration: unprivileged containers
   pivot_root,
 
+  mount fstype=devpts,
+
   # Allow modifying mount propagation
   mount options=(rw,slave) -> **,
   mount options=(rw,rslave) -> **,

--- a/lxd/apparmor/instance_lxc.go
+++ b/lxd/apparmor/instance_lxc.go
@@ -481,6 +481,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   pivot_root,
 
   mount fstype=devpts,
+  mount fstype=proc,
 
   # Allow modifying mount propagation
   mount options=(rw,slave) -> **,


### PR DESCRIPTION
- core20 is updated
- core20 update contains a fixed AppArmor user space utilities version which contains a fix for an old bug https://bugs.launchpad.net/apparmor/+bug/1597017
- this makes AppArmor to be more strict than before
- and... we have a problem with devpts mount after.