### PR TITLE
lxd/instance/drivers/lxc: tiny improvements

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1071,14 +1071,12 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		nvidiaDriver := d.expandedConfig["nvidia.driver.capabilities"]
 		if nvidiaDriver == "" {
 			err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_DRIVER_CAPABILITIES=compute,utility")
-			if err != nil {
-				return nil, err
-			}
 		} else {
 			err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_DRIVER_CAPABILITIES="+nvidiaDriver)
-			if err != nil {
-				return nil, err
-			}
+		}
+
+		if err != nil {
+			return nil, err
 		}
 
 		nvidiaRequireCuda := d.expandedConfig["nvidia.require.cuda"]

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1080,7 +1080,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		}
 
 		nvidiaRequireCuda := d.expandedConfig["nvidia.require.cuda"]
-		if nvidiaRequireCuda == "" {
+		if nvidiaRequireCuda != "" {
 			err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_REQUIRE_CUDA="+nvidiaRequireCuda)
 			if err != nil {
 				return nil, err
@@ -1088,7 +1088,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		}
 
 		nvidiaRequireDriver := d.expandedConfig["nvidia.require.driver"]
-		if nvidiaRequireDriver == "" {
+		if nvidiaRequireDriver != "" {
 			err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_REQUIRE_DRIVER="+nvidiaRequireDriver)
 			if err != nil {
 				return nil, err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1250,10 +1250,9 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 
 	// Setup process limits
 	for k, v := range d.expandedConfig {
-		if strings.HasPrefix(k, "limits.kernel.") {
-			prlimitSuffix := strings.TrimPrefix(k, "limits.kernel.")
-			prlimitKey := fmt.Sprintf("lxc.prlimit.%s", prlimitSuffix)
-			err = lxcSetConfigItem(cc, prlimitKey, v)
+		prlimitSuffix, found := strings.CutPrefix(k, "limits.kernel.")
+		if found {
+			err = lxcSetConfigItem(cc, "lxc.prlimit."+prlimitSuffix, v)
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1269,9 +1269,7 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		//  condition: container
 		//  shortdesc: Override for the corresponding `sysctl` setting in the container
 		if strings.HasPrefix(k, "linux.sysctl.") {
-			sysctlSuffix := strings.TrimPrefix(k, "linux.sysctl.")
-			sysctlKey := fmt.Sprintf("lxc.sysctl.%s", sysctlSuffix)
-			err = lxcSetConfigItem(cc, sysctlKey, v)
+			err = lxcSetConfigItem(cc, k, v)
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1007,8 +1007,9 @@ func (d *lxc) initLXC(config bool) (*liblxc.Container, error) {
 		//  type: string
 		//  liveupdate: yes (exec)
 		//  shortdesc: Environment variables to export
-		if strings.HasPrefix(k, "environment.") {
-			err = lxcSetConfigItem(cc, "lxc.environment", fmt.Sprintf("%s=%s", strings.TrimPrefix(k, "environment."), v))
+		environmentKey, found := strings.CutPrefix(k, "environment.")
+		if found {
+			err = lxcSetConfigItem(cc, "lxc.environment", environmentKey+"="+v)
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8120,9 +8120,6 @@ func (d *lxc) CGroup() (*cgroup.CGroup, error) {
 
 // SetAffinity sets affinity in the container according with a set provided.
 func (d *lxc) SetAffinity(set []string) error {
-	sort.Strings(set)
-	affinitySet := strings.Join(set, ",")
-
 	// Confirm the container didn't just stop
 	if d.InitPID() <= 0 {
 		return nil
@@ -8132,6 +8129,9 @@ func (d *lxc) SetAffinity(set []string) error {
 	if err != nil {
 		return fmt.Errorf("Unable to get cgroup struct: %w", err)
 	}
+
+	sort.Strings(set)
+	affinitySet := strings.Join(set, ",")
 
 	err = cg.SetCpuset(affinitySet)
 	if err != nil {


### PR DESCRIPTION
The handling of `NVIDIA_REQUIRE_CUDA` and `NVIDIA_REQUIRE_DRIVER` env variables seem to have been backward causing empty variables to be exported when the respective configuration keys were empty and not defined when actually populated.