### PR TITLE
lxd/device/disk: Consider `readonly` for other volume types

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1052,6 +1052,10 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 		opts = append(opts, "cache="+d.config["io.cache"])
 	}
 
+	if shared.IsTrue(d.config["readonly"]) || d.config["source.snapshot"] != "" {
+		opts = append(opts, "ro")
+	}
+
 	// Add I/O limits if set.
 	var diskLimits *deviceConfig.DiskLimits
 	if d.config["limits.read"] != "" || d.config["limits.write"] != "" || d.config["limits.max"] != "" {
@@ -1226,10 +1230,6 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				revert.Add(revertFunc)
 
 				mount.Opts = append(mount.Opts, d.detectVMPoolMountOpts()...)
-			}
-
-			if shared.IsTrue(d.config["readonly"]) || d.config["source.snapshot"] != "" {
-				mount.Opts = append(mount.Opts, "ro")
 			}
 
 			// If the source being added is a directory or cephfs share, then we will use the lxd-agent


### PR DESCRIPTION
Prior to this change, the following disk types could have `readonly: true` in their device config and still be mounted rw in VMs:
- root disks (not likely to work very well but the disk device config semantics should be consistent)
- cloud-init config drive (unknown to me if a CD image would be writable)
- `source: ceph:...` disks
- Delegated ceph block volumes (all ceph block volumes are delegated)

I alluded in #14930 to a regression introduced by this change; that was a mistake on my part. This is good to go, tests at https://github.com/canonical/lxd-ci/pull/422.