### PR TITLE
Prevent cluster groups from being deleted when referenced by a projects' configuration

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2625,3 +2625,8 @@ Adds flags --network and --storage. The --network flag adds a network device con
 ## `client_cert_presence`
 
 Adds the field `client_certificate` to `GET /1.0` to indicate if the current request has a client certificate in it. This is for informational purposes only and does not affect the behavior of the API.
+
+## `clustering_groups_used_by`
+
+This API extension adds a `used_by` field to the API response for a {ref}`cluster group <cluster-groups>`.
+Deletion of a cluster group is disallowed if the cluster group is referenced by project configuration (see {config:option}`project-restricted:restricted.cluster.groups`).

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -327,6 +327,15 @@ definitions:
                 example: group1
                 type: string
                 x-go-name: Name
+            used_by:
+                description: |-
+                    UsedBy is a list or LXD entity URLs that reference the cluster group.
+
+                    API extension: clustering_groups_used_by
+                items:
+                    type: string
+                type: array
+                x-go-name: UsedBy
         title: ClusterGroup represents a cluster group.
         type: object
         x-go-package: github.com/canonical/lxd/shared/api

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	dqlite "github.com/canonical/go-dqlite/v3/client"
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/client"
@@ -774,11 +775,15 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		s.UpdateIdentityCache()
 
 		// Update local setup and possibly join the raft dqlite cluster.
-		nodes := make([]db.RaftNode, len(info.RaftNodes))
-		for i, node := range info.RaftNodes {
-			nodes[i].ID = node.ID
-			nodes[i].Address = node.Address
-			nodes[i].Role = db.RaftRole(node.Role)
+		nodes := make([]db.RaftNode, 0, len(info.RaftNodes))
+		for _, node := range info.RaftNodes {
+			nodes = append(nodes, db.RaftNode{
+				NodeInfo: dqlite.NodeInfo{
+					ID:      node.ID,
+					Address: node.Address,
+					Role:    db.RaftRole(node.Role),
+				},
+			})
 		}
 
 		err = cluster.Join(s, d.gateway, networkCert, serverCert, req.ServerName, nodes)
@@ -1378,6 +1383,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Filter to online members.
+		onlineNodeAddresses = make([]any, 0, len(members))
 		for _, member := range members {
 			if member.State == db.ClusterMemberStateEvacuated || member.IsOffline(s.GlobalConfig.OfflineThreshold()) {
 				continue
@@ -2481,14 +2487,16 @@ func internalClusterPostAccept(d *Daemon, r *http.Request) response.Response {
 	}
 
 	accepted := internalClusterPostAcceptResponse{
-		RaftNodes:  make([]internalRaftNode, len(nodes)),
+		RaftNodes:  make([]internalRaftNode, 0, len(nodes)),
 		PrivateKey: s.Endpoints.NetworkPrivateKey(),
 	}
 
-	for i, node := range nodes {
-		accepted.RaftNodes[i].ID = node.ID
-		accepted.RaftNodes[i].Address = node.Address
-		accepted.RaftNodes[i].Role = int(node.Role)
+	for _, node := range nodes {
+		accepted.RaftNodes = append(accepted.RaftNodes, internalRaftNode{
+			ID:      node.ID,
+			Address: node.Address,
+			Role:    int(node.Role),
+		})
 	}
 
 	return response.SyncResponse(true, accepted)
@@ -2718,12 +2726,16 @@ func internalClusterPostAssign(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("No raft members provided"))
 	}
 
-	nodes := make([]db.RaftNode, len(req.RaftNodes))
-	for i, node := range req.RaftNodes {
-		nodes[i].ID = node.ID
-		nodes[i].Address = node.Address
-		nodes[i].Role = db.RaftRole(node.Role)
-		nodes[i].Name = node.Name
+	nodes := make([]db.RaftNode, 0, len(req.RaftNodes))
+	for _, node := range req.RaftNodes {
+		nodes = append(nodes, db.RaftNode{
+			NodeInfo: dqlite.NodeInfo{
+				ID:      node.ID,
+				Address: node.Address,
+				Role:    db.RaftRole(node.Role),
+			},
+			Name: node.Name,
+		})
 	}
 
 	err = cluster.Assign(s, d.gateway, nodes)
@@ -3249,15 +3261,15 @@ func evacuateClusterMember(s *state.State, gateway *cluster.Gateway, r *http.Req
 		return response.SmartError(err)
 	}
 
-	instances := make([]instance.Instance, len(dbInstances))
+	instances := make([]instance.Instance, 0, len(dbInstances))
 
-	for i, dbInst := range dbInstances {
+	for _, dbInst := range dbInstances {
 		inst, err := instance.LoadByProjectAndName(s, dbInst.Project, dbInst.Name)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to load instance: %w", err))
 		}
 
-		instances[i] = inst
+		instances = append(instances, inst)
 	}
 
 	run := func(op *operations.Operation) error {
@@ -3426,8 +3438,8 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	instances := make([]instance.Instance, 0)
-	localInstances := make([]instance.Instance, 0)
+	instances := make([]instance.Instance, 0, len(dbInstances))
+	localInstances := make([]instance.Instance, 0, len(dbInstances))
 
 	for _, dbInst := range dbInstances {
 		inst, err := instance.LoadByProjectAndName(s, dbInst.Project, dbInst.Name)
@@ -3829,14 +3841,14 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-			apiClusterGroups := make([]*api.ClusterGroup, len(clusterGroups))
-			for i, clusterGroup := range clusterGroups {
+			apiClusterGroups := make([]*api.ClusterGroup, 0, len(clusterGroups))
+			for _, clusterGroup := range clusterGroups {
 				members, err := tx.GetClusterGroupNodes(ctx, clusterGroup.Name)
 				if err != nil {
 					return err
 				}
 
-				apiClusterGroups[i] = db.ClusterGroupToAPI(&clusterGroup, members)
+				apiClusterGroups = append(apiClusterGroups, db.ClusterGroupToAPI(&clusterGroup, members))
 			}
 
 			result = apiClusterGroups

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4359,7 +4359,16 @@ func clusterGroupDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if len(members) > 0 {
-			return fmt.Errorf("Only empty cluster groups can be removed")
+			return api.StatusErrorf(http.StatusBadRequest, "Only empty cluster groups can be removed")
+		}
+
+		usedBy, err := dbCluster.GetClusterGroupUsedBy(ctx, tx.Tx(), name)
+		if err != nil {
+			return err
+		}
+
+		if len(usedBy) > 0 {
+			return api.StatusErrorf(http.StatusBadRequest, "Cluster group is currently in use")
 		}
 
 		return dbCluster.DeleteClusterGroup(ctx, tx.Tx(), name)

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -12,18 +12,6 @@ import (
 	"github.com/canonical/lxd/shared/version"
 )
 
-// ClusterGroupToAPI is a convenience to convert a ClusterGroup db struct into
-// an API cluster group struct.
-func ClusterGroupToAPI(clusterGroup *cluster.ClusterGroup, nodes []string) *api.ClusterGroup {
-	c := &api.ClusterGroup{
-		Name:        clusterGroup.Name,
-		Description: clusterGroup.Description,
-		Members:     nodes,
-	}
-
-	return c
-}
-
 // GetClusterGroupNodes returns a list of nodes of the given cluster group.
 func (c *ClusterTx) GetClusterGroupNodes(ctx context.Context, groupName string) ([]string, error) {
 	q := `SELECT nodes.name FROM nodes_cluster_groups

--- a/lxd/db/cluster/cluster_groups.go
+++ b/lxd/db/cluster/cluster_groups.go
@@ -48,11 +48,17 @@ type ClusterGroupFilter struct {
 }
 
 // ToAPI returns a LXD API entry.
-func (c *ClusterGroup) ToAPI() (*api.ClusterGroup, error) {
+func (c *ClusterGroup) ToAPI(ctx context.Context, tx *sql.Tx) (*api.ClusterGroup, error) {
+	usedBy, err := GetClusterGroupUsedBy(ctx, tx, c.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	result := api.ClusterGroup{
 		Name:        c.Name,
 		Description: c.Description,
 		Members:     c.Nodes,
+		UsedBy:      usedBy,
 	}
 
 	return &result, nil

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -321,6 +321,11 @@ type ClusterGroup struct {
 	// List of members in this group
 	// Example: ["node1", "node3"]
 	Members []string `json:"members" yaml:"members"`
+
+	// UsedBy is a list or LXD entity URLs that reference the cluster group.
+	//
+	// API extension: clustering_groups_used_by
+	UsedBy []string `json:"used_by" yaml:"used_by"`
 }
 
 // ClusterGroupPost represents the fields required to rename a cluster group.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -441,6 +441,7 @@ var APIExtensions = []string{
 	"oidc_scopes",
 	"project_default_network_and_storage",
 	"client_cert_presence",
+	"clustering_groups_used_by",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3810,7 +3810,22 @@ EOF
   # Clean up
   lxc rm -f c1 c2 c3 c4 c5
 
-  # Restricted project tests
+  ## Restricted project tests
+
+  # Create an empty cluster group and reference it from project config
+  lxc cluster group create cluster:fizz
+  lxc project create cluster:buzz -c restricted=true -c restricted.cluster.groups=fizz
+
+  # Cannot launch an instance because fizz has no members
+  ! lxc init testimage cluster:c1 --project buzz || false
+
+  # Group fizz has no members, but it cannot be deleted because it is referenced by project buzz.
+  ! lxc cluster group delete cluster:fizz || false
+
+  # Clean up.
+  lxc project delete cluster:buzz
+  lxc cluster group delete cluster:fizz
+
   lxc project create foo -c features.images=false -c restricted=true -c restricted.cluster.groups=blah
   lxc profile show default | lxc profile edit default --project foo
 


### PR DESCRIPTION
Adds an API extension `clustering_groups_used_by` and adds a `UsedBy` field to `api.ClusterGroup`. On GET requests, the `UsedBy` URLs are projects that contain the cluster group in `restricted.cluster.groups`. DELETE requests will fail if the cluster group is used by a project.

Closes #15118 