### PR TITLE
Backport docs (stable-5.21)

### DIFF
--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -33,27 +33,32 @@ To see state and usage information for a cluster member, run the following comma
 
 ## Configure your cluster
 
-To configure your cluster, use [`lxc config`](lxc_config.md).
-For example:
+To configure your cluster, use [`lxc config`](lxc_config.md):
+
+    lxc config set <server-config-option> <value>
+
+Example:
 
     lxc config set cluster.max_voters 5
 
 Keep in mind that some {ref}`server configuration options <server>` are global and others are local.
-You can configure the global options on any cluster member, and the changes are propagated to the other cluster members through the distributed database.
-The local options are set only on the server where you configure them (or alternatively on the server that you target with `--target`).
+In addition to the server configuration, there are {ref}`cluster member configuration options <cluster-member-config>` that are specific to each cluster member. To set these configuration values, use [`lxc cluster set`](lxc_cluster_set.md):
 
-In addition to the server configuration, there are a few cluster configurations that are specific to each cluster member.
-See {ref}`cluster-member-config` for all available configurations.
+    lxc cluster set <member-name> <member-config-option> <value>
 
-To set these configuration options, use [`lxc cluster set`](lxc_cluster_set.md) or [`lxc cluster edit`](lxc_cluster_edit.md).
-For example:
+Example:
 
     lxc cluster set server1 scheduler.instance manual
 
+Alternatively, you can use the {ref}`use the edit command <cluster-edit>`.
+
 ### Assign member roles
 
-To add or remove a {ref}`member role <clustering-member-roles>` for a cluster member, use the [`lxc cluster role`](lxc_cluster_role.md) command.
-For example:
+To add or remove a {ref}`member role <clustering-member-roles>` for a cluster member, use the [`lxc cluster role`](lxc_cluster_role.md) command:
+
+    lxc cluster role add <member-name> <role>
+
+Example:
 
     lxc cluster role add server1 event-hub
 
@@ -61,9 +66,14 @@ For example:
 You can add or remove only those roles that are not assigned automatically by LXD.
 ```
 
+(cluster-edit)=
 ### Edit the cluster member configuration
 
-To edit all properties of a cluster member, including the member-specific configuration, the member roles, the failure domain and the cluster groups, use the [`lxc cluster edit`](lxc_cluster_edit.md) command.
+To edit all properties of a cluster member, including the member-specific configuration, the member roles, the failure domain and the cluster groups, use the following command:
+
+    lxc cluster edit
+
+For more information, see: [`lxc cluster edit`](lxc_cluster_edit.md).
 
 (cluster-evacuate-restore)=
 ## Evacuate and restore cluster members
@@ -162,6 +172,10 @@ In a LXD cluster, the API on all servers responds with the same shared certifica
 
 The certificate is stored at `/var/snap/lxd/common/lxd/cluster.crt` (if you use the snap) or `/var/lib/lxd/cluster.crt` (otherwise) and is the same on all cluster members.
 
-You can replace the standard certificate with another one, for example, a valid certificate obtained through ACME services (see {ref}`authentication-server-certificate` for more information).
-To do so, use the [`lxc cluster update-certificate`](lxc_cluster_update-certificate.md) command.
-This command replaces the certificate on all servers in your cluster.
+You can replace the standard certificate with another one, such as a valid certificate obtained through ACME services (see {ref}`authentication-server-certificate` for more information).
+To do so, run the following command on any cluster member:
+
+    lxc cluster update-certificate
+
+This command replaces the certificate on all cluster members. For more information, see: [`lxc cluster update-certificate`](lxc_cluster_update-certificate.md).
+

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -41,7 +41,10 @@ Example:
 
     lxc config set cluster.max_voters 5
 
-Keep in mind that some {ref}`server configuration options <server>` are global and others are local.
+All LXD {ref}`server configuration options <server>` can be applied to cluster members. 
+
+Keep in mind that some options are global in scope, and others are local. When you configure an option with global scope on any cluster member, the changes are propagated to the other cluster members through the distributed database. The locally scoped options are set only on the cluster member where you configure them, unless you use the `--target` flag to specify a different cluster member.
+
 In addition to the server configuration, there are {ref}`cluster member configuration options <cluster-member-config>` that are specific to each cluster member. To set these configuration values, use [`lxc cluster set`](lxc_cluster_set.md):
 
     lxc cluster set <member-name> <member-config-option> <value>

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -41,7 +41,7 @@ Example:
 
     lxc config set cluster.max_voters 5
 
-All LXD {ref}`server configuration options <server>` can be applied to cluster members. 
+All LXD {ref}`server configuration options <server>` can be applied to cluster members.
 
 Keep in mind that some options are global in scope, and others are local. When you configure an option with global scope on any cluster member, the changes are propagated to the other cluster members through the distributed database. The locally scoped options are set only on the cluster member where you configure them, unless you use the `--target` flag to specify a different cluster member.
 
@@ -66,7 +66,7 @@ Example:
     lxc cluster role add server1 event-hub
 
 ```{note}
-You can add or remove only those roles that are not assigned automatically by LXD.
+You can add or remove only those roles that are not assigned automatically by LXD. To find out which roles are automatically assigned, see: {ref}`clustering-member-roles`.
 ```
 
 (cluster-edit)=
@@ -99,7 +99,7 @@ When the evacuated cluster member is available again, use the [`lxc cluster rest
 
     lxc cluster restore <member_name>
 
-This command removes the cluster member's "evacuated" state, migrates the evacuated instances back from the cluster members that were temporarily holding them (using live migration if applicable), then restarts any instances that were shut down. 
+This command removes the cluster member's "evacuated" state, migrates the evacuated instances back from the cluster members that were temporarily holding them (using live migration if applicable), then restarts any instances that were shut down.
 
 (cluster-evacuation-mode)=
 ### Evacuation mode and live migration
@@ -109,7 +109,7 @@ You can control how each instance is migrated, via the {config:option}`instance-
 If an instance is not suitable for live migration, it will be shut down cleanly before evacuation, respecting the {config:option}`instance-boot:boot.host_shutdown_timeout` configuration key.
 
 ```{note}
-Any instance that you plan to live-migrate must have its {config:option}`instance-migration:migration.stateful` configuration option set to `true`. Be aware that this option can only be set while the instance is stopped. Thus, for any instance to have the ability to be live-migrated in the future, this option must be set to `true` ahead of time. 
+Any instance that you plan to live-migrate must have its {config:option}`instance-migration:migration.stateful` configuration option set to `true`. Be aware that this option can only be set while the instance is stopped. Thus, for any instance to have the ability to be live-migrated in the future, this option must be set to `true` ahead of time.
 ```
 
 (cluster-automatic-evacuation)=
@@ -181,4 +181,3 @@ To do so, run the following command on any cluster member:
     lxc cluster update-certificate
 
 This command replaces the certificate on all cluster members. For more information, see: [`lxc cluster update-certificate`](lxc_cluster_update-certificate.md).
-


### PR DESCRIPTION
This backports https://github.com/canonical/lxd/pull/14870 into `stable-5.21` to get the doc reference labels `cluster-restore` and `cluster-evacuate-restore` into the stable branch to unblock the MicroCloud [`v2-edge` backports](https://github.com/canonical/microcloud/pull/681) which reference those labels using the docs from `stable-5.21`.