### PR TITLE
doc: update broken link in howto/initialize

### DIFF
--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -26,7 +26,7 @@ Clustering (see {ref}`exp-clusters` and {ref}`cluster-form`)
   The default answer is `no`, which means clustering is not enabled.
   If you answer `yes`, you can either connect to an existing cluster or create one.
 
-MAAS support (see [`maas.io`](https://maas.io/) and [MAAS - Setting up LXD for VMs](https://maas.io/docs/how-to-use-lxd-vms))
+MAAS support (see [`maas.io`](https://maas.io/) and [MAAS - Setting up LXD for VMs](https://maas.io/docs/how-to-manage-machines#p-9078-add-lxd-for-vm-hosts))
 : MAAS is an open-source tool that lets you build a data center from bare-metal servers.
 
   The default answer is `no`, which means MAAS support is not enabled.


### PR DESCRIPTION
- Fixed broken link to MAAS documentation in doc/howto/initialize.md.