### PR TITLE
Client cert presence check in GET /1.0

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2621,3 +2621,7 @@ Note that the `openid` and `email` scopes are always required.
 ## `project_default_network_and_storage`
 
 Adds flags --network and --storage. The --network flag adds a network device connected to the specified network to the default profile. The --storage flag adds a root disk device using the specified storage pool to the default profile.
+
+## `client_cert_presence`
+
+Adds the field `client_certificate` to `GET /1.0` to indicate if the current request has a client certificate in it. This is for informational purposes only and does not affect the behavior of the API.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -5948,6 +5948,12 @@ definitions:
                 readOnly: true
                 type: string
                 x-go-name: AuthUserName
+            client_certificate:
+                description: Whether the requester sent a client certificate with the request
+                example: false
+                readOnly: true
+                type: boolean
+                x-go-name: ClientCertificate
             config:
                 additionalProperties: {}
                 description: Server configuration map (refer to doc/server.md)
@@ -6196,6 +6202,12 @@ definitions:
                 readOnly: true
                 type: array
                 x-go-name: AuthMethods
+            client_certificate:
+                description: Whether the requester sent a client certificate with the request
+                example: false
+                readOnly: true
+                type: boolean
+                x-go-name: ClientCertificate
             public:
                 description: Whether the server is public-only (only public endpoints are implemented)
                 example: false

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -236,12 +236,13 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	}
 
 	srv := api.ServerUntrusted{
-		APIExtensions: version.APIExtensions,
-		APIStatus:     "stable",
-		APIVersion:    version.APIVersion,
-		Public:        false,
-		Auth:          "untrusted",
-		AuthMethods:   authMethods,
+		APIExtensions:     version.APIExtensions,
+		APIStatus:         "stable",
+		APIVersion:        version.APIVersion,
+		Public:            false,
+		Auth:              "untrusted",
+		AuthMethods:       authMethods,
+		ClientCertificate: r.TLS != nil && len(r.TLS.PeerCertificates) > 0,
 	}
 
 	// If not authenticated, return now.

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -196,6 +196,13 @@ type ServerUntrusted struct {
 	//
 	// API extension: oidc
 	AuthMethods []string `json:"auth_methods" yaml:"auth_methods"`
+
+	// Whether the requester sent a client certificate with the request
+	// Read only: true
+	// Example: false
+	//
+	// API extension: client_cert_presence
+	ClientCertificate bool `json:"client_certificate" yaml:"client_certificate"`
 }
 
 // Server represents a LXD server

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -440,6 +440,7 @@ var APIExtensions = []string{
 	"cloud_init_ssh_keys",
 	"oidc_scopes",
 	"project_default_network_and_storage",
+	"client_cert_presence",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
# Done

* show if client cert was present for an unauthenticated request to GET /1.0
* this is for the UI to use, as it can't know if a cert is present otherwise
* following a suggesting from @markylaing 