### PR TITLE
Fix Snapshot Root attachment for RBD Volumes

### DIFF
--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -19,10 +19,16 @@ type RunConfigItem struct {
 	Value string
 }
 
+// DevSource is either:
+// - A path on the LXD host.
+// - A file descriptor held by the LXD process.
+// - A Ceph RBD Image description.
+type DevSource any
+
 // MountEntryItem represents a single mount entry item.
 type MountEntryItem struct {
 	DevName    string      // The internal name for the device.
-	DevPath    string      // Describes the block special device or remote filesystem to be mounted.
+	DevSource  DevSource   // Describes the block special device or remote filesystem to be mounted.
 	TargetPath string      // Describes the mount point (target) for the filesystem.
 	FSType     string      // Describes the type of the filesystem.
 	Opts       []string    // Describes the mount options associated with the filesystem.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -47,6 +47,7 @@ type DevSourceRBD struct {
 	UserName    string
 	PoolName    string
 	ImageName   string
+	Snapshot    string
 }
 
 // BlockFsDetect detects the type of block device.

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -338,7 +338,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 
 	// Instruct LXD to perform the mount.
 	runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
-		DevPath:    d.HostPath,
+		DevSource:  DevSourcePath{Path: d.HostPath},
 		TargetPath: d.RelativePath,
 		FSType:     "none",
 		Opts:       []string{"bind", "create=file"},

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1207,7 +1207,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					projectStorageVolumeName := project.StorageVolume(d.inst.Project().Name, volumeName)
 
 					vol := d.pool.GetVolume(volumeType, contentType, projectStorageVolumeName, dbVolume.Config)
-					rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
+					rbdImageName, snapName := storageDrivers.CephGetRBDImageName(vol, false)
 
 					mount := deviceConfig.MountEntryItem{
 						DevSource: DevSourceRBD{
@@ -1215,6 +1215,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 							UserName:    userName,
 							PoolName:    poolName,
 							ImageName:   rbdImageName,
+							Snapshot:    snapName,
 						},
 						DevName: d.name,
 						Opts:    opts,

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -979,7 +979,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		// Instruct LXD to perform the mount.
 		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
 			DevName:    d.name,
-			DevPath:    sourceDevPath,
+			DevSource:  DevSourcePath{Path: sourceDevPath},
 			TargetPath: relativeDestPath,
 			FSType:     "none",
 			Opts:       options,
@@ -1112,10 +1112,10 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 		// Encode the file descriptor and original isoPath into the DevPath field.
 		runConf.Mounts = []deviceConfig.MountEntryItem{
 			{
-				DevPath: fmt.Sprintf("%s:%d:%s", DiskFileDescriptorMountPrefix, f.Fd(), isoPath),
-				DevName: d.name,
-				FSType:  "iso9660",
-				Opts:    opts,
+				DevSource: DevSourceFD{FD: f.Fd(), Path: isoPath},
+				DevName:   d.name,
+				FSType:    "iso9660",
+				Opts:      opts,
 			},
 		}
 
@@ -1129,21 +1129,24 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 			clusterName, userName := d.cephCreds()
 			runConf.Mounts = []deviceConfig.MountEntryItem{
 				{
-					DevPath: DiskGetRBDFormat(clusterName, userName, fields[0], fields[1]),
+					DevSource: DevSourceRBD{
+						ClusterName: clusterName,
+						UserName:    userName,
+						PoolName:    fields[0],
+						ImageName:   fields[1],
+					},
 					DevName: d.name,
 					Opts:    opts,
 					Limits:  diskLimits,
 				},
 			}
 		} else {
-			var err error
-
 			// Default to block device or image file passthrough first.
 			mount := deviceConfig.MountEntryItem{
-				DevPath: shared.HostPath(d.config["source"]),
-				DevName: d.name,
-				Opts:    opts,
-				Limits:  diskLimits,
+				DevSource: DevSourcePath{Path: shared.HostPath(d.config["source"])},
+				DevName:   d.name,
+				Opts:      opts,
+				Limits:    diskLimits,
 			}
 
 			// Mount the pool volume and update srcPath to mount path so it can be recognised as dir
@@ -1207,7 +1210,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
 
 					mount := deviceConfig.MountEntryItem{
-						DevPath: DiskGetRBDFormat(clusterName, userName, poolName, rbdImageName),
+						DevSource: DevSourceRBD{
+							ClusterName: clusterName,
+							UserName:    userName,
+							PoolName:    poolName,
+							ImageName:   rbdImageName,
+						},
 						DevName: d.name,
 						Opts:    opts,
 						Limits:  diskLimits,
@@ -1222,10 +1230,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					return &runConf, nil
 				}
 
-				revertFunc, mount.DevPath, _, err = d.mountPoolVolume()
+				revertFunc, mountedPath, _, err := d.mountPoolVolume()
 				if err != nil {
 					return nil, diskSourceNotFoundError{msg: "Failed mounting volume", err: err}
 				}
+
+				mount.DevSource = DevSourcePath{Path: mountedPath}
 
 				revert.Add(revertFunc)
 
@@ -1235,7 +1245,8 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 			// If the source being added is a directory or cephfs share, then we will use the lxd-agent
 			// directory sharing feature to mount the directory inside the VM, and as such we need to
 			// indicate to the VM the target path to mount to.
-			if shared.IsDir(mount.DevPath) || d.sourceIsCephFs() {
+			pathSource, isPath := mount.DevSource.(DevSourcePath)
+			if (isPath && shared.IsDir(pathSource.Path)) || d.sourceIsCephFs() {
 				if d.config["path"] == "" {
 					return nil, fmt.Errorf(`Missing mount "path" setting`)
 				}
@@ -1245,10 +1256,12 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				// takes effect event if using virtio-fs (which doesn't support read only mode) by
 				// having the underlying mount setup as readonly.
 				var revertFunc func()
-				revertFunc, mount.DevPath, _, err = d.createDevice(mount.DevPath)
+				revertFunc, mountedPath, _, err := d.createDevice(pathSource.Path)
 				if err != nil {
 					return nil, err
 				}
+
+				mount.DevSource = DevSourcePath{Path: mountedPath}
 
 				revert.Add(revertFunc)
 
@@ -1276,7 +1289,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					logPath := filepath.Join(d.inst.LogPath(), "disk."+filesystem.PathNameEncode(d.name)+".log")
 					_ = os.Remove(logPath) // Remove old log if needed.
 
-					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.state.OS.KernelVersion, d.inst, sockPath, pidPath, logPath, mount.DevPath, rawIDMaps)
+					revertFunc, unixListener, err := DiskVMVirtiofsdStart(d.state.OS.KernelVersion, d.inst, sockPath, pidPath, logPath, mountedPath, rawIDMaps)
 					if err != nil {
 						var errUnsupported UnsupportedError
 						if errors.As(err, &errUnsupported) {
@@ -1326,7 +1339,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					// Start virtfs-proxy-helper for 9p share (this will rewrite mount.DevPath with
 					// socket FD number so must come after starting virtiofsd).
 					err = func() error {
-						unixListener, cleanup, err := DiskVMVirtfsProxyStart(d.state.OS.ExecPath, d.vmVirtfsProxyHelperPaths(), mount.DevPath, rawIDMaps)
+						unixListener, cleanup, err := DiskVMVirtfsProxyStart(d.state.OS.ExecPath, d.vmVirtfsProxyHelperPaths(), mountedPath, rawIDMaps)
 						if err != nil {
 							return err
 						}
@@ -1339,7 +1352,7 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						runConf.PostHooks = append(runConf.PostHooks, unixListener.Close)
 
 						// Use 9p socket FD number as dev path so qemu can connect to the proxy.
-						mount.DevPath = fmt.Sprint(unixListener.Fd())
+						mount.DevSource = DevSourceFD{FD: unixListener.Fd()}
 
 						return nil
 					}()
@@ -1347,8 +1360,8 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 						return nil, fmt.Errorf("Failed to setup virtfs-proxy-helper for device %q: %w", d.name, err)
 					}
 				}
-			} else {
-				f, err := d.localSourceOpen(mount.DevPath)
+			} else if isPath {
+				f, err := d.localSourceOpen(pathSource.Path)
 				if err != nil {
 					return nil, err
 				}
@@ -1357,14 +1370,15 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 				runConf.PostHooks = append(runConf.PostHooks, f.Close)
 				runConf.Revert = func() { _ = f.Close() } // Close file on VM start failure.
 
-				// Detect ISO files to set correct FSType before DevPath is encoded below.
+				// Detect ISO files to set correct FSType.
 				// This is very important to support Windows ISO images (amongst other).
-				if strings.HasSuffix(mount.DevPath, ".iso") {
+				if strings.HasSuffix(pathSource.Path, ".iso") {
 					mount.FSType = "iso9660"
 				}
 
-				// Encode the file descriptor and original srcPath into the DevPath field.
-				mount.DevPath = fmt.Sprintf("%s:%d:%s", DiskFileDescriptorMountPrefix, f.Fd(), mount.DevPath)
+				mount.DevSource = DevSourceFD{FD: f.Fd(), Path: pathSource.Path}
+			} else {
+				return nil, fmt.Errorf("Unexpected DevSource for runConf.Mount; expected %T, got %T", DevSourcePath{}, mount.DevSource)
 			}
 
 			// Add successfully setup mount config to runConf.

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -281,7 +281,7 @@ func (d *gpuPhysical) startCDIDevices(configDevices cdi.ConfigDevices, runConf *
 
 		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
 			DevName:    deviceName,
-			DevPath:    devPath,
+			DevSource:  DevSourcePath{Path: devPath},
 			TargetPath: relativeDestPath,
 			FSType:     "none",
 			Opts:       options,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3752,13 +3752,14 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]string, mountInfo *storageP
 				clusterName = storageDrivers.CephDefaultUser
 			}
 
-			rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
+			rbdImageName, snapName := storageDrivers.CephGetRBDImageName(vol, false)
 
 			driveConf.DevSource = device.DevSourceRBD{
 				ClusterName: clusterName,
 				UserName:    userName,
 				PoolName:    config["ceph.osd.pool_name"],
 				ImageName:   rbdImageName,
+				Snapshot:    snapName,
 			}
 		}
 	}
@@ -4018,6 +4019,10 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		blockDev["user"] = rbdSource.UserName
 		blockDev["server"] = []map[string]string{}
 		blockDev["conf"] = "/etc/ceph/" + rbdSource.ClusterName + ".conf"
+
+		if rbdSource.Snapshot != "" {
+			blockDev["snapshot"] = rbdSource.Snapshot
+		}
 
 		// Setup the Ceph cluster config (monitors and keyring).
 		monitors, err := storageDrivers.CephMonitors(rbdSource.ClusterName)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -3730,7 +3730,7 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]string, mountInfo *storageP
 	// Generate a new device config with the root device path expanded.
 	driveConf := deviceConfig.MountEntryItem{
 		DevName:    rootDriveConf.DevName,
-		DevPath:    mountInfo.DiskPath,
+		DevSource:  device.DevSourcePath{Path: mountInfo.DiskPath},
 		Opts:       rootDriveConf.Opts,
 		TargetPath: rootDriveConf.TargetPath,
 		Limits:     rootDriveConf.Limits,
@@ -3754,7 +3754,12 @@ func (d *qemu) addRootDriveConfig(qemuDev map[string]string, mountInfo *storageP
 
 			rbdImageName := storageDrivers.CephGetRBDImageName(vol, "", false)
 
-			driveConf.DevPath = device.DiskGetRBDFormat(clusterName, userName, config["ceph.osd.pool_name"], rbdImageName)
+			driveConf.DevSource = device.DevSourceRBD{
+				ClusterName: clusterName,
+				UserName:    userName,
+				PoolName:    config["ceph.osd.pool_name"],
+				ImageName:   rbdImageName,
+			}
 		}
 	}
 
@@ -3829,12 +3834,12 @@ func (d *qemu) addDriveDirConfig(cfg *[]cfgSection, bus *qemuBus, fdFiles *[]*os
 	// Add 9p share config.
 	devBus, devAddr, multi := bus.allocate(busFunctionGroup9p)
 
-	fd, err := strconv.Atoi(driveConf.DevPath)
-	if err != nil {
-		return fmt.Errorf("Invalid file descriptor %q for drive %q: %w", driveConf.DevPath, driveConf.DevName, err)
+	fdSource, ok := driveConf.DevSource.(device.DevSourceFD)
+	if !ok {
+		return fmt.Errorf("Drive config for %q was not a file descriptor", driveConf.DevName)
 	}
 
-	proxyFD := d.addFileDescriptor(fdFiles, os.NewFile(uintptr(fd), driveConf.DevName))
+	proxyFD := d.addFileDescriptor(fdFiles, os.NewFile(fdSource.FD, driveConf.DevName))
 
 	driveDir9pOpts := qemuDriveDirOpts{
 		dev: qemuDevOpts{
@@ -3859,7 +3864,9 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 	aioMode := "native" // Use native kernel async IO and O_DIRECT by default.
 	cacheMode := "none" // Bypass host cache, use O_DIRECT semantics by default.
 	media := "disk"
-	isRBDImage := strings.HasPrefix(driveConf.DevPath, device.RBDFormatPrefix)
+	rbdSource, isRBDImage := driveConf.DevSource.(device.DevSourceRBD)
+	fdSource, isFd := driveConf.DevSource.(device.DevSourceFD)
+	pathSource, _ := driveConf.DevSource.(device.DevSourcePath)
 
 	// Check supported features.
 	// Use io_uring over native for added performance (if supported by QEMU and kernel is recent enough).
@@ -3878,32 +3885,17 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		// For RBD, we want writeback to allow for the system-configured "rbd cache" to take effect if present.
 		cacheMode = "writeback"
 	} else {
-		srcDevPath := driveConf.DevPath // This should not be used for passing to QEMU, only for probing.
+		// This should not be used for passing to QEMU, only for probing.
+		srcDevPath := pathSource.Path
 
-		// Detect if existing file descriptor format is being supplied.
-		if strings.HasPrefix(driveConf.DevPath, device.DiskFileDescriptorMountPrefix+":") {
-			// Expect devPath in format "fd:<fdNum>:<devPath>".
-			devPathParts := strings.SplitN(driveConf.DevPath, ":", 3)
-			if len(devPathParts) != 3 || !strings.HasPrefix(driveConf.DevPath, device.DiskFileDescriptorMountPrefix+":") {
-				return nil, fmt.Errorf("Unexpected devPath file descriptor format %q", driveConf.DevPath)
-			}
-
-			// Map the file descriptor to the file descriptor path it will be in the QEMU process.
-			fd, err := strconv.Atoi(devPathParts[1])
-			if err != nil {
-				return nil, fmt.Errorf("Invalid file descriptor %q: %w", devPathParts[1], err)
-			}
-
+		if isFd {
 			// Extract original dev path for additional probing below.
-			srcDevPath = devPathParts[2]
-			if srcDevPath == "" {
-				return nil, fmt.Errorf("Device source path is empty")
-			}
+			srcDevPath = fdSource.Path
 
-			driveConf.DevPath = fmt.Sprintf("/proc/self/fd/%d", fd)
+			pathSource.Path = fmt.Sprintf("/proc/self/fd/%d", fdSource.FD)
 		} else if driveConf.TargetPath != "/" {
 			// Only the root disk device is allowed to pass local devices to us without using an FD.
-			return nil, fmt.Errorf("Invalid device path format %q", driveConf.DevPath)
+			return nil, fmt.Errorf("Disk device %q was not a file descriptor", driveConf.DevName)
 		}
 
 		srcDevPathInfo, err := os.Stat(srcDevPath)
@@ -4007,46 +3999,28 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 	} else if isRBDImage {
 		blockDev["driver"] = "rbd"
 
-		_, rbdImageName, opts, err := device.DiskParseRBDFormat(driveConf.DevPath)
-		if err != nil {
-			return nil, fmt.Errorf("Failed parsing rbd string: %w", err)
+		if rbdSource.UserName == "" {
+			rbdSource.UserName = storageDrivers.CephDefaultUser
 		}
 
-		// Parse the options (ceph credentials).
-		userName := storageDrivers.CephDefaultUser
-		clusterName := storageDrivers.CephDefaultCluster
-		poolName := ""
-
-		for _, option := range opts {
-			fields := strings.Split(option, "=")
-			if len(fields) != 2 {
-				return nil, fmt.Errorf("Unexpected volume rbd option %q", option)
-			}
-
-			if fields[0] == "id" {
-				userName = fields[1]
-			} else if fields[0] == "pool" {
-				poolName = fields[1]
-			} else if fields[0] == "conf" {
-				baseName := filepath.Base(fields[1])
-				clusterName = strings.TrimSuffix(baseName, ".conf")
-			}
+		if rbdSource.ClusterName == "" {
+			rbdSource.ClusterName = storageDrivers.CephDefaultCluster
 		}
 
-		if poolName == "" {
+		if rbdSource.PoolName == "" {
 			return nil, fmt.Errorf("Missing pool name")
 		}
 
 		// The aio option isn't available when using the rbd driver.
 		delete(blockDev, "aio")
-		blockDev["pool"] = poolName
-		blockDev["image"] = rbdImageName
-		blockDev["user"] = userName
+		blockDev["pool"] = rbdSource.PoolName
+		blockDev["image"] = rbdSource.ImageName
+		blockDev["user"] = rbdSource.UserName
 		blockDev["server"] = []map[string]string{}
-		blockDev["conf"] = "/etc/ceph/" + clusterName + ".conf"
+		blockDev["conf"] = "/etc/ceph/" + rbdSource.ClusterName + ".conf"
 
 		// Setup the Ceph cluster config (monitors and keyring).
-		monitors, err := storageDrivers.CephMonitors(clusterName)
+		monitors, err := storageDrivers.CephMonitors(rbdSource.ClusterName)
 		if err != nil {
 			return nil, err
 		}
@@ -4062,7 +4036,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 			})
 		}
 
-		rbdSecret, err = storageDrivers.CephKeyring(clusterName, userName)
+		rbdSecret, err = storageDrivers.CephKeyring(rbdSource.ClusterName, rbdSource.UserName)
 		if err != nil {
 			return nil, err
 		}
@@ -4154,7 +4128,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 				permissions = unix.O_RDONLY
 			}
 
-			f, err := os.OpenFile(driveConf.DevPath, permissions, 0)
+			f, err := os.OpenFile(pathSource.Path, permissions, 0)
 			if err != nil {
 				return fmt.Errorf("Failed opening file descriptor for disk device %q: %w", driveConf.DevName, err)
 			}

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -1131,15 +1131,22 @@ func (d *ceph) generateUUID(fsType string, devPath string) error {
 }
 
 func (d *ceph) getRBDVolumeName(vol Volume, snapName string, zombie bool, withPoolName bool) string {
-	out := CephGetRBDImageName(vol, snapName, zombie)
+	imageName, volSnapName := CephGetRBDImageName(vol, zombie)
+
+	// see `man 8 rbd` for "snap-spec"
+	if snapName != "" {
+		imageName += "@" + snapName
+	} else if volSnapName != "" {
+		imageName += "@" + volSnapName
+	}
 
 	// If needed, the output will be prefixed with the pool name, e.g.
 	// <pool>/<type>_<volname>@<snapname>.
 	if withPoolName {
-		out = fmt.Sprintf("%s/%s", d.config["ceph.osd.pool_name"], out)
+		imageName = d.config["ceph.osd.pool_name"] + "/" + imageName
 	}
 
-	return out
+	return imageName
 }
 
 // Let's say we want to send the a container "a" including snapshots "snap0" and

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -47,7 +48,8 @@ var cephVolTypePrefixes = map[VolumeType]string{
 
 // osdPoolExists checks whether a given OSD pool exists.
 func (d *ceph) osdPoolExists() (bool, error) {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"ceph",
 		"--name", "client."+d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -81,7 +83,8 @@ func (d *ceph) osdPoolExists() (bool, error) {
 //     that this call actually deleted an OSD pool it needs to check for the
 //     existence of the pool first.
 func (d *ceph) osdDeletePool() error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"ceph",
 		"--name", "client."+d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -133,7 +136,7 @@ func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
 		"create",
 		d.getRBDVolumeName(vol, "", false, false))
 
-	_, err = shared.RunCommand("rbd", cmd...)
+	_, err = shared.RunCommandContext(context.TODO(), "rbd", cmd...)
 	return err
 }
 
@@ -143,7 +146,8 @@ func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
 //     to be sure that this call actually deleted an RBD storage volume it needs
 //     to check for the existence of the pool first.
 func (d *ceph) rbdDeleteVolume(vol Volume) error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -162,7 +166,8 @@ func (d *ceph) rbdDeleteVolume(vol Volume) error {
 // in the /dev directory and is therefore necessary in order to mount it.
 func (d *ceph) rbdMapVolume(vol Volume) (string, error) {
 	rbdName := d.getRBDVolumeName(vol, "", false, false)
-	devPath, err := shared.RunCommand(
+	devPath, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -193,7 +198,8 @@ func (d *ceph) rbdUnmapVolume(vol Volume, unmapUntilEINVAL bool) error {
 	ourDeactivate := false
 
 again:
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -245,7 +251,8 @@ again:
 // This is a precondition in order to delete an RBD snapshot can.
 func (d *ceph) rbdUnmapVolumeSnapshot(vol Volume, snapshotName string, unmapUntilEINVAL bool) error {
 again:
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -276,7 +283,8 @@ again:
 
 // rbdCreateVolumeSnapshot creates a read-write snapshot of a given RBD storage volume.
 func (d *ceph) rbdCreateVolumeSnapshot(vol Volume, snapshotName string) error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -295,7 +303,8 @@ func (d *ceph) rbdCreateVolumeSnapshot(vol Volume, snapshotName string) error {
 // rbdProtectVolumeSnapshot protects a given snapshot from being deleted.
 // This is a precondition to be able to create RBD clones from a given snapshot.
 func (d *ceph) rbdProtectVolumeSnapshot(vol Volume, snapshotName string) error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -326,7 +335,8 @@ func (d *ceph) rbdProtectVolumeSnapshot(vol Volume, snapshotName string) error {
 // - This is a precondition to be able to delete an RBD snapshot.
 // - This command will only succeed if the snapshot does not have any clones.
 func (d *ceph) rbdUnprotectVolumeSnapshot(vol Volume, snapshotName string) error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -377,7 +387,7 @@ func (d *ceph) rbdCreateClone(sourceVol Volume, sourceSnapshotName string, targe
 		d.getRBDVolumeName(sourceVol, sourceSnapshotName, false, true),
 		d.getRBDVolumeName(targetVol, "", false, true))
 
-	_, err := shared.RunCommand("rbd", cmd...)
+	_, err := shared.RunCommandContext(context.TODO(), "rbd", cmd...)
 	if err != nil {
 		return err
 	}
@@ -387,7 +397,8 @@ func (d *ceph) rbdCreateClone(sourceVol Volume, sourceSnapshotName string, targe
 
 // rbdListSnapshotClones list all clones of an RBD snapshot.
 func (d *ceph) rbdListSnapshotClones(vol Volume, snapshotName string) ([]string, error) {
-	msg, err := shared.RunCommand(
+	msg, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -421,7 +432,8 @@ func (d *ceph) rbdMarkVolumeDeleted(vol Volume, newVolumeName string) error {
 	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, newVolumeName, vol.config, vol.poolConfig)
 	deletedName := d.getRBDVolumeName(newVol, "", true, true)
 
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -446,7 +458,8 @@ func (d *ceph) rbdRenameVolume(vol Volume, newVolumeName string) error {
 	// new volume name generated in getRBDVolumeName.
 	newVol := NewVolume(d, d.name, vol.volType, vol.contentType, newVolumeName, vol.config, vol.poolConfig)
 
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -468,7 +481,8 @@ func (d *ceph) rbdRenameVolume(vol Volume, newVolumeName string) error {
 // original name and the caller maps it under its new name the snapshot will be
 // mapped twice. This will prevent it from being deleted.
 func (d *ceph) rbdRenameVolumeSnapshot(vol Volume, oldSnapshotName string, newSnapshotName string) error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -491,7 +505,8 @@ func (d *ceph) rbdRenameVolumeSnapshot(vol Volume, oldSnapshotName string, newSn
 //     The caller will usually want to parse this according to its needs. This
 //     helper library provides two small functions to do this but see below.
 func (d *ceph) rbdGetVolumeParent(vol Volume) (string, error) {
-	msg, err := shared.RunCommand(
+	msg, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -525,7 +540,8 @@ func (d *ceph) rbdGetVolumeParent(vol Volume) (string, error) {
 // This requires that the snapshot does not have any clones and is unmapped and
 // unprotected.
 func (d *ceph) rbdDeleteVolumeSnapshot(vol Volume, snapshotName string) error {
-	_, err := shared.RunCommand(
+	_, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],
@@ -547,7 +563,8 @@ func (d *ceph) rbdDeleteVolumeSnapshot(vol Volume, snapshotName string) error {
 // this will only return
 // <rbd-snapshot-name>.
 func (d *ceph) rbdListVolumeSnapshots(vol Volume) ([]string, error) {
-	msg, err := shared.RunCommand(
+	msg, err := shared.RunCommandContext(
+		context.TODO(),
 		"rbd",
 		"--id", d.config["ceph.user.name"],
 		"--cluster", d.config["ceph.cluster_name"],


### PR DESCRIPTION
`DiskGetRBDFormat` and `DiskParseRBDFormat` have been the gifts that keep on giving... bugs! Instead of trying to hack yet another field into these functions, I went ahead and refactored `MountEntryItem`'s `DevPath` field to use `any` instead of `string`.

Beyond being more comprehensible and less error-prone, it also makes adding fields to delegated RBD disk devices pretty trivial.

The second piece of this PR makes attaching RBD volume snapshots work (@tomponline was correct, this never worked and somehow slipped through my local tests). LXD uses Ceph in two ways:
- The `rbd` cli utility (`man 8 rbd`)
- Via Qemu QMP ([docs](https://www.qemu.org/docs/master/interop/qemu-qmp-ref.html))

The rbd utility requires the snapshot's name to be appended to the volume name with an `@`.

QMP expects a snapshot name to be passed as a separate parameter (see [docs](https://www.qemu.org/docs/master/interop/qemu-storage-daemon-qmp-ref.html#qapidoc-708)).

LXD has been conflating these things; `CephGetRBDImageName` was trying to provide image names for both `rbd` (used in the Ceph driver) and QMP for delegated block volumes (including a confusing reference to [these docs](https://docs.ceph.com/en/squid/rbd/qemu-rbd/#usage)). `CephGetRBDImageName` now separates the snapshot component in its return value so that it can be used correctly in both contexts.