### PR TITLE
Storage: Improve volume metadata

### DIFF
--- a/.github/actions/install-lxd-runtimedeps/action.yml
+++ b/.github/actions/install-lxd-runtimedeps/action.yml
@@ -47,5 +47,7 @@ runs:
           zfsutils-linux \
           openvswitch-switch
 
+        sudo snap install yq
+
         # reclaim some space
         sudo apt-get clean

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2642,3 +2642,17 @@ This adds a request option to set snapshot's target profile on instance copy to 
 ## `resources_device_fs_uuid`
 
 Adds the field `device_fs_uuid` including the respective UUID to each disk and partition indicating whether or not a filesystem is located on the device.
+
+## `backup_metadata_version`
+
+Adds the field `version` when exporting instances and custom storage volumes to define the backup file format.
+In case the field is omitted, the server's default version is used.
+This maintains backwards compatibility with older clients.
+
+When exporting an instance, the specific version can be provided using the `--export-version` flag:
+
+`lxc export v1 --export-version 2`
+
+The same applies when exporting a custom storage volume:
+
+`lxc storage volume export pool1 vol1 --export-version 2`

--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -139,6 +139,11 @@ You can add any of the following flags to the command:
 
   Exporting a volume in optimized mode is usually quicker than exporting the individual files.
   Snapshots are exported as differences from the main volume, which decreases their size (quota) and makes them easily accessible.
+
+`--export-version`
+: If you intend to import the backup to an older version of LXD, set the version to `1` which will use the original (old) backup metadata format.
+Backups using the old format can always be imported on newer versions of LXD.
+If the flag is not specified and the server has support for the `backup_metadata_version` API extension, version `2` is used by default.
 <!-- Include end export info -->
 
 `--volume-only`

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -1859,6 +1859,11 @@ definitions:
         x-go-package: github.com/canonical/lxd/shared/api
     InstanceBackupsPost:
         properties:
+            Version:
+                description: What backup format version to use
+                example: 1
+                format: uint32
+                type: integer
             compression_algorithm:
                 description: What compression algorithm to use
                 example: gzip
@@ -6019,6 +6024,16 @@ definitions:
                     type: string
                 type: array
                 x-go-name: Architectures
+            backup_metadata_version_range:
+                description: Range of supported backup metadata versions
+                example:
+                    - 1
+                    - 2
+                items:
+                    format: uint32
+                    type: integer
+                type: array
+                x-go-name: BackupMetadataVersionRange
             certificate:
                 description: Server certificate as PEM encoded X509
                 example: X509 PEM certificate
@@ -6555,6 +6570,11 @@ definitions:
     StoragePoolVolumeBackupsPost:
         description: StoragePoolVolumeBackupsPost represents the fields available for a new LXD volume backup
         properties:
+            Version:
+                description: What backup format version to use
+                example: 1
+                format: uint32
+                type: integer
             compression_algorithm:
                 description: What compression algorithm to use
                 example: gzip

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -23,6 +25,7 @@ type cmdExport struct {
 	flagInstanceOnly         bool
 	flagOptimizedStorage     bool
 	flagCompressionAlgorithm string
+	flagExportVersion        string
 }
 
 func (c *cmdExport) command() *cobra.Command {
@@ -41,6 +44,8 @@ func (c *cmdExport) command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagOptimizedStorage, "optimized-storage", false,
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Compression algorithm to use (none for uncompressed)")+"``")
+	cmd.Flags().StringVar(&c.flagExportVersion, "export-version", "",
+		i18n.G("Use a different metadata format version than the latest one supported by the server")+"``")
 
 	return cmd
 }
@@ -74,6 +79,37 @@ func (c *cmdExport) run(cmd *cobra.Command, args []string) error {
 		InstanceOnly:         instanceOnly,
 		OptimizedStorage:     c.flagOptimizedStorage,
 		CompressionAlgorithm: c.flagCompressionAlgorithm,
+	}
+
+	backupVersionSupported := d.HasExtension("backup_metadata_version")
+
+	// Don't allow explicitly setting 0 as it will implicitly create a backup using version 1.
+	if c.flagExportVersion == "0" {
+		return fmt.Errorf(i18n.G("Invalid export version %q"), "0")
+	}
+
+	// In case no version is set, default to 0 so we can convert it to an uint32.
+	if c.flagExportVersion == "" {
+		c.flagExportVersion = "0"
+	}
+
+	versionUint, err := strconv.ParseUint(c.flagExportVersion, 10, 32)
+	if err != nil {
+		return fmt.Errorf(i18n.G("Invalid export version %q: %w"), c.flagExportVersion, err)
+	}
+
+	versionUint32 := uint32(versionUint)
+
+	// If the server supports setting the backup version, set the selected version.
+	// If supported but the version is not set, the server picks its default version.
+	// If unsupported but the version is set to 1, the field isn't set so its up to the server to pick the old version.
+	if backupVersionSupported {
+		if versionUint32 != 0 {
+			req.Version = versionUint32
+		}
+	} else if !backupVersionSupported && versionUint32 > api.BackupMetadataVersion1 {
+		// Any version beyond 1 isn't supported by an older server without the backup_metadata_version extension.
+		return errors.New(i18n.G("The server doesn't support setting the metadata format version"))
 	}
 
 	op, err := d.CreateInstanceBackup(name, req)

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -45,7 +45,7 @@ func (c *cmdExport) command() *cobra.Command {
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Compression algorithm to use (none for uncompressed)")+"``")
 	cmd.Flags().StringVar(&c.flagExportVersion, "export-version", "",
-		i18n.G("Use a different metadata format version than the latest one supported by the server")+"``")
+		i18n.G("Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)")+"``")
 
 	return cmd
 }

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2639,6 +2639,7 @@ type cmdStorageVolumeExport struct {
 	flagVolumeOnly           bool
 	flagOptimizedStorage     bool
 	flagCompressionAlgorithm string
+	flagExportVersion        string
 }
 
 func (c *cmdStorageVolumeExport) command() *cobra.Command {
@@ -2652,6 +2653,8 @@ func (c *cmdStorageVolumeExport) command() *cobra.Command {
 	cmd.Flags().BoolVar(&c.flagOptimizedStorage, "optimized-storage", false,
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Define a compression algorithm: for backup or none")+"``")
+	cmd.Flags().StringVar(&c.flagExportVersion, "export-version", "",
+		i18n.G("Use a different metadata format version than the latest one supported by the server")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.run
 
@@ -2708,6 +2711,37 @@ func (c *cmdStorageVolumeExport) run(cmd *cobra.Command, args []string) error {
 		VolumeOnly:           volumeOnly,
 		OptimizedStorage:     c.flagOptimizedStorage,
 		CompressionAlgorithm: c.flagCompressionAlgorithm,
+	}
+
+	backupVersionSupported := d.HasExtension("backup_metadata_version")
+
+	// Don't allow explicitly setting 0 as it will implicitly create a backup using version 1.
+	if c.flagExportVersion == "0" {
+		return fmt.Errorf(i18n.G("Invalid export version %q"), "0")
+	}
+
+	// In case no version is set, default to 0 so we can convert it to an uint32.
+	if c.flagExportVersion == "" {
+		c.flagExportVersion = "0"
+	}
+
+	versionUint, err := strconv.ParseUint(c.flagExportVersion, 10, 32)
+	if err != nil {
+		return fmt.Errorf(i18n.G("Invalid export version %q: %w"), c.flagExportVersion, err)
+	}
+
+	versionUint32 := uint32(versionUint)
+
+	// If the server supports setting the backup version, set the selected version.
+	// If supported but the version is not set, the server picks its default version.
+	// If unsupported but the version is set to 1, the field isn't set so its up to the server to pick the old version.
+	if backupVersionSupported {
+		if versionUint32 != 0 {
+			req.Version = versionUint32
+		}
+	} else if !backupVersionSupported && versionUint32 > api.BackupMetadataVersion1 {
+		// Any version beyond 1 isn't supported by an older server without the backup_metadata_version extension.
+		return errors.New(i18n.G("The server doesn't support setting the metadata format version"))
 	}
 
 	op, err := d.CreateStoragePoolVolumeBackup(name, volName, req)

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2654,7 +2654,7 @@ func (c *cmdStorageVolumeExport) command() *cobra.Command {
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Define a compression algorithm: for backup or none")+"``")
 	cmd.Flags().StringVar(&c.flagExportVersion, "export-version", "",
-		i18n.G("Use a different metadata format version than the latest one supported by the server")+"``")
+		i18n.G("Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)")+"``")
 	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.run
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/lxd/auth"
 	"github.com/canonical/lxd/lxd/auth/oidc"
+	backupConfig "github.com/canonical/lxd/lxd/backup/config"
 	"github.com/canonical/lxd/lxd/cluster"
 	clusterConfig "github.com/canonical/lxd/lxd/cluster/config"
 	"github.com/canonical/lxd/lxd/config"
@@ -309,24 +310,25 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	}
 
 	env := api.ServerEnvironment{
-		Addresses:              addresses,
-		Architectures:          architectures,
-		Certificate:            certificate,
-		CertificateFingerprint: certificateFingerprint,
-		Kernel:                 s.OS.Uname.Sysname,
-		KernelArchitecture:     s.OS.Uname.Machine,
-		KernelVersion:          s.OS.Uname.Release,
-		OSName:                 s.OS.ReleaseInfo["NAME"],
-		OSVersion:              s.OS.ReleaseInfo["VERSION_ID"],
-		Project:                projectName,
-		Server:                 "lxd",
-		ServerPid:              os.Getpid(),
-		ServerVersion:          version.Version,
-		ServerLTS:              version.IsLTSVersion,
-		ServerClustered:        s.ServerClustered,
-		ServerEventMode:        string(cluster.ServerEventMode()),
-		ServerName:             serverName,
-		Firewall:               s.Firewall.String(),
+		Addresses:                  addresses,
+		Architectures:              architectures,
+		BackupMetadataVersionRange: []uint32{api.BackupMetadataVersion1, backupConfig.MaxMetadataVersion},
+		Certificate:                certificate,
+		CertificateFingerprint:     certificateFingerprint,
+		Kernel:                     s.OS.Uname.Sysname,
+		KernelArchitecture:         s.OS.Uname.Machine,
+		KernelVersion:              s.OS.Uname.Release,
+		OSName:                     s.OS.ReleaseInfo["NAME"],
+		OSVersion:                  s.OS.ReleaseInfo["VERSION_ID"],
+		Project:                    projectName,
+		Server:                     "lxd",
+		ServerPid:                  os.Getpid(),
+		ServerVersion:              version.Version,
+		ServerLTS:                  version.IsLTSVersion,
+		ServerClustered:            s.ServerClustered,
+		ServerEventMode:            string(cluster.ServerEventMode()),
+		ServerName:                 serverName,
+		Firewall:                   s.Firewall.String(),
 	}
 
 	env.KernelFeatures = map[string]string{

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -722,7 +722,7 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 	}
 
 	if instName != backupConf.Instance.Name {
-		return fmt.Errorf("Instance name requested %q doesn't match instance name in backup config %q", instName, backupConf.Instance.Name)
+		return fmt.Errorf("Requested instance name %q doesn't match instance name %q in backup config", instName, backupConf.Instance.Name)
 	}
 
 	if len(backupConf.Pools) == 0 {
@@ -809,11 +809,11 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		}
 
 		if dbVolume.Name != rootVol.Name {
-			return fmt.Errorf(`The name %q of the storage volume is not identical to the instance's name "%s"`, dbVolume.Name, backupConf.Instance.Name)
+			return fmt.Errorf(`The storage volume name %q does not match the instance's name %q`, dbVolume.Name, backupConf.Instance.Name)
 		}
 
 		if dbVolume.Type != rootVol.Type {
-			return fmt.Errorf(`The type %q of the storage volume is not identical to the instance's type %q`, dbVolume.Type, rootVol.Type)
+			return fmt.Errorf(`The storage volume type %q does not match the instance's type %q`, dbVolume.Type, rootVol.Type)
 		}
 
 		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -543,8 +543,13 @@ func volumeBackupWriteIndex(s *state.State, projectName string, volumeName strin
 		return fmt.Errorf("Failed generating volume backup config: %w", err)
 	}
 
+	customVol, err := config.CustomVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the custom volume: %w", err)
+	}
+
 	indexInfo := backup.Info{
-		Name:             config.Volume.Name,
+		Name:             customVol.Name,
 		Pool:             pool.Name(),
 		Backend:          pool.Driver().Info().Name,
 		OptimizedStorage: &optimized,
@@ -554,8 +559,8 @@ func volumeBackupWriteIndex(s *state.State, projectName string, volumeName strin
 	}
 
 	if snapshots {
-		indexInfo.Snapshots = make([]string, 0, len(config.VolumeSnapshots))
-		for _, s := range config.VolumeSnapshots {
+		indexInfo.Snapshots = make([]string, 0, len(customVol.Snapshots))
+		for _, s := range customVol.Snapshots {
 			indexInfo.Snapshots = append(indexInfo.Snapshots, s.Name)
 		}
 	}

--- a/lxd/backup/backup_info.go
+++ b/lxd/backup/backup_info.go
@@ -130,5 +130,11 @@ func GetInfo(r io.ReadSeeker, sysOS *sys.OS, outputPath string) (*Info, error) {
 		return nil, fmt.Errorf("Backup is missing at %q", backupIndexPath)
 	}
 
+	// Upgrade the config file in any case to the new format.
+	result.Config, err = ConvertFormat(result.Config, api.BackupMetadataVersion2)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to convert backup config to version %d: %w", api.BackupMetadataVersion2, err)
+	}
+
 	return &result, nil
 }

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -11,13 +11,29 @@ const DefaultMetadataVersion = api.BackupMetadataVersion1
 // MaxMetadataVersion represents the latest supported metadata version.
 const MaxMetadataVersion = api.BackupMetadataVersion2
 
+// Volume represents the config of a volume including its snapshots.
+type Volume struct {
+	// Make sure to have the embedded structs fields inline to avoid nesting.
+	api.StorageVolume `yaml:",inline"`
+
+	Snapshots []*api.StorageVolumeSnapshot `yaml:"snapshots,omitempty"`
+}
+
 // Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
 type Config struct {
-	Container       *api.Instance                `yaml:"container,omitempty"` // Used by VM backups too.
-	Snapshots       []*api.InstanceSnapshot      `yaml:"snapshots,omitempty"`
-	Pool            *api.StoragePool             `yaml:"pool,omitempty"`
-	Profiles        []*api.Profile               `yaml:"profiles,omitempty"`
-	Volume          *api.StorageVolume           `yaml:"volume,omitempty"`
+	Version   uint32                  `yaml:"version,omitempty"`
+	Instance  *api.Instance           `yaml:"instance,omitempty"`
+	Snapshots []*api.InstanceSnapshot `yaml:"snapshots,omitempty"`
+	Pools     []*api.StoragePool      `yaml:"pools,omitempty"`
+	Profiles  []*api.Profile          `yaml:"profiles,omitempty"`
+	Volumes   []*Volume               `yaml:"volumes,omitempty"`
+	Bucket    *api.StorageBucket      `yaml:"bucket,omitempty"`
+	// Deprecated: Use Instance instead.
+	Container *api.Instance `yaml:"container,omitempty"`
+	// Deprecated: Use Pools instead.
+	Pool *api.StoragePool `yaml:"pool,omitempty"`
+	// Deprecated: Use Volumes instead.
+	Volume *api.StorageVolume `yaml:"volume,omitempty"`
+	// Deprecated: Use the list of Snapshots under Volumes.
 	VolumeSnapshots []*api.StorageVolumeSnapshot `yaml:"volume_snapshots,omitempty"`
-	Bucket          *api.StorageBucket           `yaml:"bucket,omitempty"`
 }

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -4,6 +4,10 @@ import (
 	"github.com/canonical/lxd/shared/api"
 )
 
+// DefaultMetadataVersion represents the current default version of the format used when writing a backup's metadata.
+// The metadata is used both for exporting backups and for migration.
+const DefaultMetadataVersion = api.BackupMetadataVersion1
+
 // Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
 type Config struct {
 	Container       *api.Instance                `yaml:"container,omitempty"` // Used by VM backups too.

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+
+	"github.com/canonical/lxd/lxd/instance/instancetype"
 	"github.com/canonical/lxd/shared/api"
 )
 
@@ -36,4 +39,131 @@ type Config struct {
 	Volume *api.StorageVolume `yaml:"volume,omitempty"`
 	// Deprecated: Use the list of Snapshots under Volumes.
 	VolumeSnapshots []*api.StorageVolumeSnapshot `yaml:"volume_snapshots,omitempty"`
+}
+
+// rootVolPoolName returns the pool name of an instance's root volume.
+// The name is derived from the instance's expanded devices.
+func (c *Config) rootVolPoolName() (string, error) {
+	if c.Instance == nil {
+		return "", fmt.Errorf("Instance config is missing")
+	}
+
+	_, deviceConfig, err := instancetype.GetRootDiskDevice(c.Instance.ExpandedDevices)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get root disk device: %w", err)
+	}
+
+	poolName, ok := deviceConfig["pool"]
+	if ok {
+		return poolName, nil
+	}
+
+	return "", fmt.Errorf("Root volume pool does not exist")
+}
+
+// primaryVolume can be used to retrieve both custom storage volumes and the volume of instance snapshots.
+// In both cases the backup config contains only a single volume.
+func (c *Config) primaryVolume() (*Volume, error) {
+	if len(c.Volumes) == 0 {
+		return nil, fmt.Errorf("No primary volume is defined in backup config")
+	}
+
+	if len(c.Volumes) > 1 {
+		return nil, fmt.Errorf("More than one primary volume is defined in backup config")
+	}
+
+	if c.Volumes[0] == nil {
+		return nil, fmt.Errorf("Primary volume config does not exist")
+	}
+
+	return c.Volumes[0], nil
+}
+
+// RootVolumePool returns the pool of the root volume.
+// The pool is derived from the volume whose name matches the one of the instance.
+func (c *Config) RootVolumePool() (*api.StoragePool, error) {
+	rootVolPoolName, err := c.rootVolPoolName()
+	if err != nil {
+		return nil, err
+	}
+
+	var rootVolPool *api.StoragePool
+	for _, pool := range c.Pools {
+		if pool.Name == rootVolPoolName {
+			rootVolPool = pool
+			break
+		}
+	}
+
+	if rootVolPool == nil {
+		return nil, fmt.Errorf("Pool config of the root volume does not exist")
+	}
+
+	return rootVolPool, nil
+}
+
+// UpdateRootVolumePool updates the root volume's storage pool.
+func (c *Config) UpdateRootVolumePool(pool *api.StoragePool) error {
+	rootVolPoolName, err := c.rootVolPoolName()
+	if err != nil {
+		return err
+	}
+
+	// Create the pool if it not yet exists.
+	if c.Pools == nil {
+		c.Pools = []*api.StoragePool{pool}
+		return nil
+	}
+
+	for i, existingPool := range c.Pools {
+		if existingPool.Name == rootVolPoolName {
+			c.Pools[i] = pool
+			return nil
+		}
+	}
+
+	// There already exists a root volume pool and it's name doesn't match the given pool.
+	return fmt.Errorf("Cannot apply invalid root volume pool")
+}
+
+// RootVolume returns an instance's root volume from the list of volumes.
+// The volume's name matches the one of the instance.
+func (c *Config) RootVolume() (*Volume, error) {
+	// First try obtaining the root volume for non-snapshot instances.
+	// In this case the Instance field is populated.
+	for _, volume := range c.Volumes {
+		if c.Instance == nil {
+			continue
+		}
+
+		if volume.Name == c.Instance.Name {
+			return volume, nil
+		}
+	}
+
+	// Second try fetching the single volume for snapshot instances.
+	// Snapshot instances don't have the Instance field populated.
+	// A snapshot is always represented by a single volume.
+	// Therefore reuse the same tooling as when retrieving a custom volume.
+	volume, err := c.primaryVolume()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get the snapshot instance's volume: %w", err)
+	}
+
+	return volume, nil
+}
+
+// CustomVolume returns the single custom volume.
+// Unlike RootVolume, CustomVolume always returns the first and only volume in the list.
+func (c *Config) CustomVolume() (*Volume, error) {
+	if c.Instance != nil {
+		return nil, fmt.Errorf("Instance config cannot be set for custom volumes")
+	}
+
+	volume, err := c.primaryVolume()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get custom volume: %w", err)
+	}
+
+	return volume, nil
 }

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -8,6 +8,9 @@ import (
 // The metadata is used both for exporting backups and for migration.
 const DefaultMetadataVersion = api.BackupMetadataVersion1
 
+// MaxMetadataVersion represents the latest supported metadata version.
+const MaxMetadataVersion = api.BackupMetadataVersion2
+
 // Config represents the config of a backup that can be stored in a backup.yaml file (or embedded in index.yaml).
 type Config struct {
 	Container       *api.Instance                `yaml:"container,omitempty"` // Used by VM backups too.

--- a/lxd/backup/config/backup_config.go
+++ b/lxd/backup/config/backup_config.go
@@ -9,7 +9,8 @@ import (
 
 // DefaultMetadataVersion represents the current default version of the format used when writing a backup's metadata.
 // The metadata is used both for exporting backups and for migration.
-const DefaultMetadataVersion = api.BackupMetadataVersion1
+// Starting from LXD 6.x onwards version 2 of the format is used.
+const DefaultMetadataVersion = api.BackupMetadataVersion2
 
 // MaxMetadataVersion represents the latest supported metadata version.
 const MaxMetadataVersion = api.BackupMetadataVersion2

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -36,6 +36,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/canonical/lxd/lxd/apparmor"
+	"github.com/canonical/lxd/lxd/backup/config"
 	"github.com/canonical/lxd/lxd/cgroup"
 	"github.com/canonical/lxd/lxd/daemon"
 	"github.com/canonical/lxd/lxd/db"
@@ -8319,7 +8320,8 @@ func (d *lxc) UpdateBackupFile() error {
 		return err
 	}
 
-	return pool.UpdateInstanceBackupFile(d, true, nil)
+	// Use the global metadata version.
+	return pool.UpdateInstanceBackupFile(d, true, config.DefaultMetadataVersion, nil)
 }
 
 // Info returns "lxc" and the currently loaded version of LXC.

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5406,16 +5406,21 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 		ClusterMove:        args.ClusterMoveSourceName != "",
 	}
 
+	rootVol, err := volSourceArgs.Info.Config.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
 	// Only send the snapshots that the target requests when refreshing.
 	if respHeader.GetRefresh() {
 		volSourceArgs.Snapshots = respHeader.GetSnapshotNames()
-		allSnapshots := volSourceArgs.Info.Config.VolumeSnapshots
+		allSnapshots := rootVol.Snapshots
 
 		// Ensure that only the requested snapshots are included in the migration index header.
-		volSourceArgs.Info.Config.VolumeSnapshots = make([]*api.StorageVolumeSnapshot, 0, len(volSourceArgs.Snapshots))
+		rootVol.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(volSourceArgs.Snapshots))
 		for i := range allSnapshots {
 			if shared.ValueInSlice(allSnapshots[i].Name, volSourceArgs.Snapshots) {
-				volSourceArgs.Info.Config.VolumeSnapshots = append(volSourceArgs.Info.Config.VolumeSnapshots, allSnapshots[i])
+				rootVol.Snapshots = append(rootVol.Snapshots, allSnapshots[i])
 			}
 		}
 	}
@@ -5671,7 +5676,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 			// snapshots as they don't need to have a final sync as not being modified.
 			volSourceArgs.FinalSync = true
 			volSourceArgs.Snapshots = nil
-			volSourceArgs.Info.Config.VolumeSnapshots = nil
+			rootVol.Snapshots = nil
 
 			err = pool.MigrateInstance(d, filesystemConn, volSourceArgs, d.op)
 			if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -40,6 +40,7 @@ import (
 	"github.com/canonical/lxd/client"
 	agentAPI "github.com/canonical/lxd/lxd-agent/api"
 	"github.com/canonical/lxd/lxd/apparmor"
+	"github.com/canonical/lxd/lxd/backup/config"
 	"github.com/canonical/lxd/lxd/cgroup"
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
@@ -8464,7 +8465,8 @@ func (d *qemu) UpdateBackupFile() error {
 		return err
 	}
 
-	return pool.UpdateInstanceBackupFile(d, true, nil)
+	// Use the global metadata version.
+	return pool.UpdateInstanceBackupFile(d, true, config.DefaultMetadataVersion, nil)
 }
 
 type cpuTopology struct {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6625,14 +6625,19 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 
 	// Only send the snapshots that the target requests when refreshing.
 	if respHeader.GetRefresh() {
+		rootVol, err := volSourceArgs.Info.Config.RootVolume()
+		if err != nil {
+			return fmt.Errorf("Failed getting the root volume: %w", err)
+		}
+
 		volSourceArgs.Snapshots = respHeader.GetSnapshotNames()
-		allSnapshots := volSourceArgs.Info.Config.VolumeSnapshots
+		allSnapshots := rootVol.Snapshots
 
 		// Ensure that only the requested snapshots are included in the migration index header.
-		volSourceArgs.Info.Config.VolumeSnapshots = make([]*api.StorageVolumeSnapshot, 0, len(volSourceArgs.Snapshots))
+		rootVol.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(volSourceArgs.Snapshots))
 		for i := range allSnapshots {
 			if shared.ValueInSlice(allSnapshots[i].Name, volSourceArgs.Snapshots) {
-				volSourceArgs.Info.Config.VolumeSnapshots = append(volSourceArgs.Info.Config.VolumeSnapshots, allSnapshots[i])
+				rootVol.Snapshots = append(rootVol.Snapshots, allSnapshots[i])
 			}
 		}
 	}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -431,14 +431,14 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string) (In
 
 	// Stop instance.Load() from expanding profile config from DB, and apply expanded config from
 	// backup file to local config. This way we can still see the devices even if DB not available.
-	instDBArgs.Config = backupConf.Container.ExpandedConfig
-	instDBArgs.Devices = deviceConfig.NewDevices(backupConf.Container.ExpandedDevices)
+	instDBArgs.Config = backupConf.Instance.ExpandedConfig
+	instDBArgs.Devices = deviceConfig.NewDevices(backupConf.Instance.ExpandedDevices)
 
 	// Set Node field to local node.
 	instDBArgs.Node = s.ServerName
 
 	p := api.Project{
-		Name: backupConf.Container.Project,
+		Name: backupConf.Instance.Project,
 	}
 
 	inst, err := Load(s, *instDBArgs, p)

--- a/lxd/migration/utils.go
+++ b/lxd/migration/utils.go
@@ -110,7 +110,12 @@ const (
 )
 
 var (
+	// ErrNoLiveMigrationSource indicates CRIU isn't installed on the source server.
 	ErrNoLiveMigrationSource = fmt.Errorf("%s CRIU isn't installed on the source server. %s on the source server", unableToLiveMigrate, toMigrateLive)
+
+	// ErrNoLiveMigrationTarget indicates CRIU isn't installed on the target server.
 	ErrNoLiveMigrationTarget = fmt.Errorf("%s CRIU isn't installed on the target server. %s on the target server", unableToLiveMigrate, toMigrateLive)
-	ErrNoLiveMigration       = fmt.Errorf("%s CRIU isn't installed. %s", unableToLiveMigrate, toMigrateLive)
+
+	// ErrNoLiveMigration indicates CRIU is not installed.
+	ErrNoLiveMigration = fmt.Errorf("%s CRIU isn't installed. %s", unableToLiveMigrate, toMigrateLive)
 )

--- a/lxd/migration/utils.go
+++ b/lxd/migration/utils.go
@@ -5,7 +5,7 @@ import (
 )
 
 // IndexHeaderVersion version of the index header to be sent/recv.
-const IndexHeaderVersion uint32 = 1
+const IndexHeaderVersion uint32 = 2
 
 // BTRFSFeatureMigrationHeader indicates a migration header will be sent/recv in data channel after index header.
 const BTRFSFeatureMigrationHeader = "migration_header"

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3246,7 +3246,7 @@ func (b *lxdBackend) CleanupInstancePaths(inst instance.Instance, _ *operations.
 }
 
 // BackupInstance creates an instance backup.
-func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name(), "optimized": optimized, "snapshots": snapshots})
 	l.Debug("BackupInstance started")
 	defer l.Debug("BackupInstance finished")
@@ -7017,7 +7017,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 }
 
 // UpdateInstanceBackupFile writes the instance's config to the backup.yaml file on the storage device.
-func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, op *operations.Operation) error {
+func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, version uint32, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("UpdateInstanceBackupFile started")
 	defer l.Debug("UpdateInstanceBackupFile finished")

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -731,7 +731,7 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 		return nil, nil, err
 	}
 
-	err = instancetype.ValidName(srcBackup.Config.Container.Name, false)
+	err = instancetype.ValidName(srcBackup.Config.Instance.Name, false)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -774,20 +774,30 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 	var volumeConfig map[string]string
 
-	if srcBackup.Config != nil && srcBackup.Config.Volume != nil {
-		err = ValidVolumeName(srcBackup.Config.Volume.Name)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		volumeConfig = srcBackup.Config.Volume.Config
+	// Check if the backup config contains a root volume and populate it for later use.
+	var rootVol *backupConfig.Volume
+	if srcBackup.Config == nil {
+		return nil, nil, fmt.Errorf("Backup config is missing")
 	}
+
+	// Returns an error if the backup doesn't contain a root volume.
+	rootVol, err = srcBackup.Config.RootVolume()
+	if err != nil {
+		return nil, nil, fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
+	err = ValidVolumeName(rootVol.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	volumeConfig = rootVol.Config
 
 	// Don't use GetNewVolume as the new volume' UUID got already set beforehand.
 	vol := b.GetVolume(volType, contentType, volStorageName, volumeConfig)
 
-	sourceSnapshots := make([]drivers.Volume, 0, len(srcBackup.Config.VolumeSnapshots))
-	for _, volSnap := range srcBackup.Config.VolumeSnapshots {
+	sourceSnapshots := make([]drivers.Volume, 0, len(rootVol.Snapshots))
+	for _, volSnap := range rootVol.Snapshots {
 		err = ValidVolumeName(volSnap.Name)
 		if err != nil {
 			return nil, nil, err
@@ -858,16 +868,14 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 		var volumeConfig map[string]string
 		volumeCreationDate := inst.CreationDate()
 
-		if srcBackup.Config != nil && srcBackup.Config.Volume != nil {
-			// If the backup restore interface provides volume config use it, otherwise use
-			// default volume config for the storage pool.
-			volumeDescription = srcBackup.Config.Volume.Description
-			volumeConfig = srcBackup.Config.Volume.Config
+		// If the backup restore interface provides volume config use it, otherwise use
+		// default volume config for the storage pool.
+		volumeDescription = rootVol.Description
+		volumeConfig = rootVol.Config
 
-			// Use volume's creation date if available.
-			if !srcBackup.Config.Volume.CreatedAt.IsZero() {
-				volumeCreationDate = srcBackup.Config.Volume.CreatedAt
-			}
+		// Use volume's creation date if available.
+		if !rootVol.CreatedAt.IsZero() {
+			volumeCreationDate = rootVol.CreatedAt
 		}
 
 		// Validate config and create database entry for new storage volume.
@@ -892,19 +900,19 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 					volumeSnapCreationDate = srcBackup.Config.Snapshots[i].CreatedAt
 				}
 
-				if len(srcBackup.Config.VolumeSnapshots) >= i-1 && srcBackup.Config.VolumeSnapshots[i] != nil && srcBackup.Config.VolumeSnapshots[i].Name == backupFileSnap {
+				if rootVol != nil && len(rootVol.Snapshots) >= i-1 && rootVol.Snapshots[i] != nil && rootVol.Snapshots[i].Name == backupFileSnap {
 					// If the backup restore interface provides volume snapshot config use it,
 					// otherwise use default volume config for the storage pool.
-					volumeSnapDescription = srcBackup.Config.VolumeSnapshots[i].Description
-					volumeSnapConfig = srcBackup.Config.VolumeSnapshots[i].Config
+					volumeSnapDescription = rootVol.Snapshots[i].Description
+					volumeSnapConfig = rootVol.Snapshots[i].Config
 
-					if srcBackup.Config.VolumeSnapshots[i].ExpiresAt != nil {
-						volumeSnapExpiryDate = *srcBackup.Config.VolumeSnapshots[i].ExpiresAt
+					if rootVol.Snapshots[i].ExpiresAt != nil {
+						volumeSnapExpiryDate = *rootVol.Snapshots[i].ExpiresAt
 					}
 
 					// Use volume's creation date if available.
-					if !srcBackup.Config.VolumeSnapshots[i].CreatedAt.IsZero() {
-						volumeSnapCreationDate = srcBackup.Config.VolumeSnapshots[i].CreatedAt
+					if !rootVol.Snapshots[i].CreatedAt.IsZero() {
+						volumeSnapCreationDate = rootVol.Snapshots[i].CreatedAt
 					}
 				}
 			}
@@ -1053,10 +1061,15 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		return fmt.Errorf("Failed generating instance copy config: %w", err)
 	}
 
+	rootVol, err := srcConfig.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
 	// Use the information from the backup config to create a list of all the source volume's snapshots.
 	// This way we don't have to retrieve them separately from the database.
-	sourceSnapshots := make([]drivers.Volume, 0, len(srcConfig.VolumeSnapshots))
-	for _, sourceSnap := range srcConfig.VolumeSnapshots {
+	sourceSnapshots := make([]drivers.Volume, 0, len(rootVol.Snapshots))
+	for _, sourceSnap := range rootVol.Snapshots {
 		snapshotName := drivers.GetSnapshotVolumeName(src.Name(), sourceSnap.Name)
 		snapshotStorageName := project.Instance(src.Project().Name, snapshotName)
 		sourceSnapshots = append(sourceSnapshots, b.GetVolume(volType, contentType, snapshotStorageName, sourceSnap.Config))
@@ -1066,20 +1079,20 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 	// Those were only required to create the list of source volume snapshots.
 	if !snapshots {
 		srcConfig.Snapshots = nil
-		srcConfig.VolumeSnapshots = nil
+		rootVol.Snapshots = nil
 	}
 
 	// If we are copying snapshots, retrieve a list of snapshots from source volume.
 	var snapshotNames []string
 	if snapshots {
-		snapshotNames = make([]string, 0, len(srcConfig.VolumeSnapshots))
-		for _, snapshot := range srcConfig.VolumeSnapshots {
+		snapshotNames = make([]string, 0, len(rootVol.Snapshots))
+		for _, snapshot := range rootVol.Snapshots {
 			snapshotNames = append(snapshotNames, snapshot.Name)
 		}
 	}
 
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
-	vol := b.GetNewVolume(volType, contentType, volStorageName, srcConfig.Volume.Config)
+	vol := b.GetNewVolume(volType, contentType, volStorageName, rootVol.Config)
 
 	volExists, err := b.driver.HasVolume(vol)
 	if err != nil {
@@ -1127,15 +1140,15 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		for i, snapName := range snapshotNames {
 			newSnapshotName := drivers.GetSnapshotVolumeName(inst.Name(), snapName)
 			var volumeSnapExpiryDate time.Time
-			if srcConfig.VolumeSnapshots[i].ExpiresAt != nil {
-				volumeSnapExpiryDate = *srcConfig.VolumeSnapshots[i].ExpiresAt
+			if rootVol.Snapshots[i].ExpiresAt != nil {
+				volumeSnapExpiryDate = *rootVol.Snapshots[i].ExpiresAt
 			}
 
 			newSnapshotStorageName := project.Instance(inst.Project().Name, newSnapshotName)
-			snapVol := b.GetNewVolume(volType, contentType, newSnapshotStorageName, srcConfig.VolumeSnapshots[i].Config)
+			snapVol := b.GetNewVolume(volType, contentType, newSnapshotStorageName, rootVol.Snapshots[i].Config)
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, vol.Type(), true, snapVol.Config(), srcConfig.VolumeSnapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
+			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, rootVol.Snapshots[i].Description, vol.Type(), true, snapVol.Config(), rootVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
 			if err != nil {
 				return err
 			}
@@ -1153,7 +1166,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 
 		// Get the src volume name on storage.
 		srcVolStorageName := project.Instance(src.Project().Name, src.Name())
-		srcVol := b.GetVolume(volType, contentType, srcVolStorageName, srcConfig.Volume.Config)
+		srcVol := b.GetVolume(volType, contentType, srcVolStorageName, rootVol.Config)
 
 		// Set the parent volume's UUID.
 		if b.driver.Info().PopulateParentVolumeUUID {
@@ -1289,12 +1302,12 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		return fmt.Errorf("Failed generating volume refresh config: %w", err)
 	}
 
-	// Use the source volume's description if not supplied.
-	if desc == "" {
-		desc = srcConfig.Volume.Description
+	customVol, err := srcConfig.CustomVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the custom volume: %w", err)
 	}
 
-	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(srcConfig.Volume.ContentType)
+	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(customVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -1320,9 +1333,9 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 
 	// Use the information from the backup config to create a list of all the source volume's snapshots.
 	// This way we don't have to retrieve them separately from the database.
-	sourceSnapshots := make([]drivers.Volume, 0, len(srcConfig.VolumeSnapshots))
-	for _, sourceSnap := range srcConfig.VolumeSnapshots {
-		snapshotName := drivers.GetSnapshotVolumeName(srcConfig.Volume.Name, sourceSnap.Name)
+	sourceSnapshots := make([]drivers.Volume, 0, len(customVol.Snapshots))
+	for _, sourceSnap := range customVol.Snapshots {
+		snapshotName := drivers.GetSnapshotVolumeName(customVol.Name, sourceSnap.Name)
 		snapshotStorageName := project.StorageVolume(srcProjectName, snapshotName)
 		sourceSnapshots = append(sourceSnapshots, b.GetVolume(drivers.VolumeTypeCustom, contentType, snapshotStorageName, sourceSnap.Config))
 	}
@@ -1330,14 +1343,14 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	// Unset the snapshots in the backup config if not requested by the caller.
 	// Those were only required to create the list of source volume snapshots.
 	if !snapshots {
-		srcConfig.VolumeSnapshots = nil
+		customVol.Snapshots = nil
 	}
 
 	revert := revert.New()
 	defer revert.Fail()
 
 	// Load the target volume from database.
-	dbVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeType(srcConfig.Volume.Type))
+	dbVol, err := VolumeDBGet(b, projectName, volName, drivers.VolumeType(customVol.Type))
 	if err != nil {
 		return err
 	}
@@ -1347,8 +1360,8 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	var snapshotNames []string
 	if snapshots {
 		// Compare snapshots.
-		sourceSnapshotComparable := make([]ComparableSnapshot, 0, len(srcConfig.VolumeSnapshots))
-		for _, sourceSnap := range srcConfig.VolumeSnapshots {
+		sourceSnapshotComparable := make([]ComparableSnapshot, 0, len(customVol.Snapshots))
+		for _, sourceSnap := range customVol.Snapshots {
 			sourceSnapshotComparable = append(sourceSnapshotComparable, ComparableSnapshot{
 				Name:         sourceSnap.Name,
 				CreationDate: sourceSnap.CreatedAt,
@@ -1382,11 +1395,11 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		}
 
 		// Ensure that only the requested snapshots are included in the source config.
-		allSnapshots := srcConfig.VolumeSnapshots
-		srcConfig.VolumeSnapshots = make([]*api.StorageVolumeSnapshot, 0, len(syncSourceSnapshotIndexes))
+		allSnapshots := customVol.Snapshots
+		customVol.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(syncSourceSnapshotIndexes))
 		for _, syncSourceSnapIndex := range syncSourceSnapshotIndexes {
 			snapshotNames = append(snapshotNames, allSnapshots[syncSourceSnapIndex].Name)
-			srcConfig.VolumeSnapshots = append(srcConfig.VolumeSnapshots, allSnapshots[syncSourceSnapIndex])
+			customVol.Snapshots = append(customVol.Snapshots, allSnapshots[syncSourceSnapIndex])
 		}
 	}
 
@@ -1394,15 +1407,15 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, dbVol.Config)
 
 	// Get the src volume name on storage.
-	srcVolStorageName := project.StorageVolume(srcProjectName, srcConfig.Volume.Name)
-	srcVol := srcPool.GetVolume(drivers.VolumeTypeCustom, contentType, srcVolStorageName, srcConfig.Volume.Config)
+	srcVolStorageName := project.StorageVolume(srcProjectName, customVol.Name)
+	srcVol := srcPool.GetVolume(drivers.VolumeTypeCustom, contentType, srcVolStorageName, customVol.Config)
 
 	if srcPool == b {
 		l.Debug("RefreshCustomVolume same-pool mode detected")
 
 		// Only refresh the snapshots that the target needs.
-		srcSnapVols := make([]string, 0, len(srcConfig.VolumeSnapshots))
-		for _, srcSnap := range srcConfig.VolumeSnapshots {
+		srcSnapVols := make([]string, 0, len(customVol.Snapshots))
+		for _, srcSnap := range customVol.Snapshots {
 			newSnapshotName := drivers.GetSnapshotVolumeName(dbVol.Name, srcSnap.Name)
 			snapExpiryDate := time.Time{}
 			if srcSnap.ExpiresAt != nil {
@@ -1495,7 +1508,7 @@ func (b *lxdBackend) RefreshCustomVolume(projectName string, srcProjectName stri
 		go func() {
 			err := srcPool.MigrateCustomVolume(srcProjectName, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
-				Name:               srcConfig.Volume.Name,
+				Name:               customVol.Name,
 				Snapshots:          snapshotNames,
 				MigrationType:      migrationTypes[0],
 				TrackProgress:      true, // Do use a progress tracker on sender.
@@ -1609,10 +1622,15 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		return fmt.Errorf("Failed generating instance refresh config: %w", err)
 	}
 
+	rootVol, err := srcConfig.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
 	// Ensure that only the requested snapshots are included in the source config.
-	allSnapshots := srcConfig.VolumeSnapshots
-	sourceSnapshots := make([]drivers.Volume, 0, len(srcConfig.VolumeSnapshots))
-	srcConfig.VolumeSnapshots = make([]*api.StorageVolumeSnapshot, 0, len(srcSnapshots))
+	allSnapshots := rootVol.Snapshots
+	sourceSnapshots := make([]drivers.Volume, 0, len(rootVol.Snapshots))
+	rootVol.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(srcSnapshots))
 	for i := range allSnapshots {
 		snapshotName := drivers.GetSnapshotVolumeName(src.Name(), allSnapshots[i].Name)
 		snapshotStorageName := project.Instance(src.Project().Name, snapshotName)
@@ -1631,7 +1649,7 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		}
 
 		if found {
-			srcConfig.VolumeSnapshots = append(srcConfig.VolumeSnapshots, allSnapshots[i])
+			rootVol.Snapshots = append(rootVol.Snapshots, allSnapshots[i])
 		}
 	}
 
@@ -1639,17 +1657,17 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 	// Those were only required to create the list of source volume snapshots.
 	if !snapshots {
 		srcConfig.Snapshots = nil
-		srcConfig.VolumeSnapshots = nil
+		rootVol.Snapshots = nil
 	}
 
 	// Get source volume construct.
 	srcVolStorageName := project.Instance(src.Project().Name, src.Name())
-	srcVol := b.GetVolume(volType, contentType, srcVolStorageName, srcConfig.Volume.Config)
+	srcVol := b.GetVolume(volType, contentType, srcVolStorageName, rootVol.Config)
 
 	// Get source snapshot volume constructs.
-	snapshotNames := make([]string, 0, len(srcConfig.VolumeSnapshots))
-	for i := range srcConfig.VolumeSnapshots {
-		snapshotNames = append(snapshotNames, srcConfig.VolumeSnapshots[i].Name)
+	snapshotNames := make([]string, 0, len(rootVol.Snapshots))
+	for i := range rootVol.Snapshots {
+		snapshotNames = append(snapshotNames, rootVol.Snapshots[i].Name)
 	}
 
 	revert := revert.New()
@@ -1673,19 +1691,19 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		l.Debug("RefreshInstance same-pool mode detected")
 
 		// Create database entries for new storage volume snapshots.
-		for i := range srcConfig.VolumeSnapshots {
-			newSnapshotName := drivers.GetSnapshotVolumeName(inst.Name(), srcConfig.VolumeSnapshots[i].Name)
+		for i := range rootVol.Snapshots {
+			newSnapshotName := drivers.GetSnapshotVolumeName(inst.Name(), rootVol.Snapshots[i].Name)
 
 			var volumeSnapExpiryDate time.Time
-			if srcConfig.VolumeSnapshots[i].ExpiresAt != nil {
-				volumeSnapExpiryDate = *srcConfig.VolumeSnapshots[i].ExpiresAt
+			if rootVol.Snapshots[i].ExpiresAt != nil {
+				volumeSnapExpiryDate = *rootVol.Snapshots[i].ExpiresAt
 			}
 
 			// Create a new snapshot volume with its own config and UUID.
-			snapVol := b.GetNewVolume(volType, contentType, newSnapshotName, srcConfig.VolumeSnapshots[i].Config)
+			snapVol := b.GetNewVolume(volType, contentType, newSnapshotName, rootVol.Snapshots[i].Config)
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, volType, true, snapVol.Config(), srcConfig.VolumeSnapshots[i].CreatedAt, volumeSnapExpiryDate, contentType, false, true)
+			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, rootVol.Snapshots[i].Description, volType, true, snapVol.Config(), rootVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, contentType, false, true)
 			if err != nil {
 				return err
 			}
@@ -2172,13 +2190,21 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 		return err
 	}
 
+	var rootVol *backupConfig.Volume
+	if srcInfo != nil && srcInfo.Config != nil {
+		rootVol, err = srcInfo.Config.RootVolume()
+		if err != nil {
+			return fmt.Errorf("Failed getting the root volume: %w", err)
+		}
+	}
+
 	// Prefer using existing volume config (to allow mounting existing volume correctly).
 	if dbVol != nil {
 		volumeConfig = dbVol.Config
 		volumeDescription = dbVol.Description
-	} else if srcInfo != nil && srcInfo.Config != nil && srcInfo.Config.Volume != nil {
-		volumeConfig = srcInfo.Config.Volume.Config
-		volumeDescription = srcInfo.Config.Volume.Description
+	} else if rootVol != nil {
+		volumeConfig = rootVol.Config
+		volumeDescription = rootVol.Description
 	} else {
 		volumeConfig = make(map[string]string)
 		volumeDescription = args.Description
@@ -2266,18 +2292,18 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 					snapCreationDate = srcInfo.Config.Snapshots[i].CreatedAt
 				}
 
-				if len(srcInfo.Config.VolumeSnapshots) >= i-1 && srcInfo.Config.VolumeSnapshots[i] != nil && srcInfo.Config.VolumeSnapshots[i].Name == snapName {
+				if rootVol != nil && len(rootVol.Snapshots) >= i-1 && rootVol.Snapshots[i] != nil && rootVol.Snapshots[i].Name == snapName {
 					// Check if snapshot volume config is available then use it.
-					snapDescription = srcInfo.Config.VolumeSnapshots[i].Description
-					snapConfig = srcInfo.Config.VolumeSnapshots[i].Config
+					snapDescription = rootVol.Snapshots[i].Description
+					snapConfig = rootVol.Snapshots[i].Config
 
-					if srcInfo.Config.VolumeSnapshots[i].ExpiresAt != nil {
-						snapExpiryDate = *srcInfo.Config.VolumeSnapshots[i].ExpiresAt
+					if rootVol.Snapshots[i].ExpiresAt != nil {
+						snapExpiryDate = *rootVol.Snapshots[i].ExpiresAt
 					}
 
 					// Use volume's creation date if available.
-					if !srcInfo.Config.VolumeSnapshots[i].CreatedAt.IsZero() {
-						snapCreationDate = srcInfo.Config.VolumeSnapshots[i].CreatedAt
+					if !rootVol.Snapshots[i].CreatedAt.IsZero() {
+						snapCreationDate = rootVol.Snapshots[i].CreatedAt
 					}
 				}
 			}
@@ -3034,12 +3060,21 @@ func (b *lxdBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCl
 		return fmt.Errorf("Migration info required")
 	}
 
-	if args.Info.Config == nil || args.Info.Config.Volume == nil || args.Info.Config.Volume.Config == nil {
+	if args.Info.Config == nil {
+		return fmt.Errorf("Migration config required")
+	}
+
+	rootVol, err := args.Info.Config.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
+	if rootVol.Config == nil {
 		return fmt.Errorf("Volume config is required")
 	}
 
-	if len(args.Snapshots) != len(args.Info.Config.VolumeSnapshots) {
-		return fmt.Errorf("Requested snapshots count (%d) doesn't match volume snapshot config count (%d)", len(args.Snapshots), len(args.Info.Config.VolumeSnapshots))
+	if len(args.Snapshots) != len(rootVol.Snapshots) {
+		return fmt.Errorf("Requested snapshots count (%d) doesn't match volume snapshot config count (%d)", len(args.Snapshots), len(rootVol.Snapshots))
 	}
 
 	// Load storage volume from database.
@@ -5330,17 +5365,22 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		return fmt.Errorf("Failed generating volume copy config: %w", err)
 	}
 
+	customVol, err := srcConfig.CustomVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the custom volume: %w", err)
+	}
+
 	// Use the source volume's config if not supplied.
 	if config == nil {
-		config = srcConfig.Volume.Config
+		config = customVol.Config
 	}
 
 	// Use the source volume's description if not supplied.
 	if desc == "" {
-		desc = srcConfig.Volume.Description
+		desc = customVol.Description
 	}
 
-	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(srcConfig.Volume.ContentType)
+	contentDBType, err := cluster.StoragePoolVolumeContentTypeFromName(customVol.ContentType)
 	if err != nil {
 		return err
 	}
@@ -5362,9 +5402,9 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 
 	// Use the information from the backup config to create a list of all the source volume's snapshots.
 	// This way we don't have to retrieve them separately from the database.
-	sourceSnapshots := make([]drivers.Volume, 0, len(srcConfig.VolumeSnapshots))
-	for _, sourceSnap := range srcConfig.VolumeSnapshots {
-		snapshotName := drivers.GetSnapshotVolumeName(srcConfig.Volume.Name, sourceSnap.Name)
+	sourceSnapshots := make([]drivers.Volume, 0, len(customVol.Snapshots))
+	for _, sourceSnap := range customVol.Snapshots {
+		snapshotName := drivers.GetSnapshotVolumeName(customVol.Name, sourceSnap.Name)
 		snapshotStorageName := project.StorageVolume(srcProjectName, snapshotName)
 		sourceSnapshots = append(sourceSnapshots, b.GetVolume(drivers.VolumeTypeCustom, contentType, snapshotStorageName, sourceSnap.Config))
 	}
@@ -5372,14 +5412,14 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	// Unset the snapshots in the backup config if not requested by the caller.
 	// Those were only required to create the list of source volume snapshots.
 	if !snapshots {
-		srcConfig.VolumeSnapshots = nil
+		customVol.Snapshots = nil
 	}
 
 	// If we are copying snapshots, retrieve a list of snapshots from source volume.
 	var snapshotNames []string
 	if snapshots {
-		snapshotNames = make([]string, 0, len(srcConfig.VolumeSnapshots))
-		for _, snapshot := range srcConfig.VolumeSnapshots {
+		snapshotNames = make([]string, 0, len(customVol.Snapshots))
+		for _, snapshot := range customVol.Snapshots {
 			snapshotNames = append(snapshotNames, snapshot.Name)
 		}
 	}
@@ -5388,8 +5428,8 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	defer revert.Fail()
 
 	// Get the src volume name on storage.
-	srcVolStorageName := project.StorageVolume(srcProjectName, srcConfig.Volume.Name)
-	srcVol := srcPool.GetVolume(drivers.VolumeTypeCustom, contentType, srcVolStorageName, srcConfig.Volume.Config)
+	srcVolStorageName := project.StorageVolume(srcProjectName, customVol.Name)
+	srcVol := srcPool.GetVolume(drivers.VolumeTypeCustom, contentType, srcVolStorageName, customVol.Config)
 
 	// If the source and target are in the same pool then use CreateVolumeFromCopy rather than
 	// migration system as it will be quicker.
@@ -5414,15 +5454,15 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 		for i, snapName := range snapshotNames {
 			newSnapshotName := drivers.GetSnapshotVolumeName(volName, snapName)
 			var volumeSnapExpiryDate time.Time
-			if srcConfig.VolumeSnapshots[i].ExpiresAt != nil {
-				volumeSnapExpiryDate = *srcConfig.VolumeSnapshots[i].ExpiresAt
+			if customVol.Snapshots[i].ExpiresAt != nil {
+				volumeSnapExpiryDate = *customVol.Snapshots[i].ExpiresAt
 			}
 
 			// Create a new snapshot volume with its own config and UUID.
-			snapVol := b.GetNewVolume(vol.Type(), contentType, newSnapshotName, srcConfig.VolumeSnapshots[i].Config)
+			snapVol := b.GetNewVolume(vol.Type(), contentType, newSnapshotName, customVol.Snapshots[i].Config)
 
 			// Validate config and create database entry for new storage volume.
-			err = VolumeDBCreate(b, projectName, newSnapshotName, srcConfig.VolumeSnapshots[i].Description, vol.Type(), true, snapVol.Config(), srcConfig.VolumeSnapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
+			err = VolumeDBCreate(b, projectName, newSnapshotName, customVol.Snapshots[i].Description, vol.Type(), true, snapVol.Config(), customVol.Snapshots[i].CreatedAt, volumeSnapExpiryDate, vol.ContentType(), false, true)
 			if err != nil {
 				return err
 			}
@@ -5504,7 +5544,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(projectName string, srcProjectNa
 	go func() {
 		err := srcPool.MigrateCustomVolume(srcProjectName, aEnd, &migration.VolumeSourceArgs{
 			IndexHeaderVersion: migration.IndexHeaderVersion,
-			Name:               srcConfig.Volume.Name,
+			Name:               customVol.Name,
 			Snapshots:          snapshotNames,
 			MigrationType:      migrationTypes[0],
 			TrackProgress:      true, // Do use a progress tracker on sender.
@@ -5670,12 +5710,21 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 		return fmt.Errorf("Migration info required")
 	}
 
-	if args.Info.Config == nil || args.Info.Config.Volume == nil || args.Info.Config.Volume.Config == nil {
+	if args.Info.Config == nil {
+		return fmt.Errorf("Migration config required")
+	}
+
+	customVol, err := args.Info.Config.CustomVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the custom volume: %w", err)
+	}
+
+	if customVol.Config == nil {
 		return fmt.Errorf("Volume config is required")
 	}
 
-	if len(args.Snapshots) != len(args.Info.Config.VolumeSnapshots) {
-		return fmt.Errorf("Requested snapshots count (%d) doesn't match volume snapshot config count (%d)", len(args.Snapshots), len(args.Info.Config.VolumeSnapshots))
+	if len(args.Snapshots) != len(customVol.Snapshots) {
+		return fmt.Errorf("Requested snapshots count (%d) doesn't match volume snapshot config count (%d)", len(args.Snapshots), len(customVol.Snapshots))
 	}
 
 	// Send migration index header frame with volume info and wait for receipt.
@@ -5688,7 +5737,7 @@ func (b *lxdBackend) MigrateCustomVolume(projectName string, conn io.ReadWriteCl
 		args.Refresh = *resp.Refresh
 	}
 
-	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, args.Info.Config.Volume.Config)
+	vol := b.GetVolume(drivers.VolumeTypeCustom, contentType, volStorageName, customVol.Config)
 
 	// Retrieve a list of snapshots.
 	allSourceSnapshots, err := VolumeDBSnapshotsGet(b, projectName, args.Name, drivers.VolumeTypeCustom)
@@ -5832,7 +5881,12 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(projectName string, conn io
 
 			// If the source snapshot config is available, use that.
 			if srcInfo != nil && srcInfo.Config != nil {
-				for _, srcSnap := range srcInfo.Config.VolumeSnapshots {
+				customVol, err := srcInfo.Config.CustomVolume()
+				if err != nil {
+					return fmt.Errorf("Failed getting the custom volume: %w", err)
+				}
+
+				for _, srcSnap := range customVol.Snapshots {
 					if srcSnap.Name != snapName {
 						continue
 					}
@@ -6417,11 +6471,12 @@ func (b *lxdBackend) UnmountCustomVolume(projectName, volName string, op *operat
 // volume directories and symlinks are restored as needed to make it operational with LXD.
 // Used during the recovery import stage.
 func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfig.Config, _ *operations.Operation) (revert.Hook, error) {
-	if poolVol.Volume == nil {
-		return nil, fmt.Errorf("Invalid pool volume config supplied")
+	customVol, err := poolVol.CustomVolume()
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting the custom volume: %w", err)
 	}
 
-	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": poolVol.Volume.Name})
+	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": customVol.Name})
 	l.Debug("ImportCustomVolume started")
 	defer l.Debug("ImportCustomVolume finished")
 
@@ -6429,22 +6484,22 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 	defer revert.Fail()
 
 	// Get the volume name on storage.
-	volStorageName := project.StorageVolume(projectName, poolVol.Volume.Name)
+	volStorageName := project.StorageVolume(projectName, customVol.Name)
 
 	// Copy volume config from backup file if present (so VolumeDBCreate can safely modify the copy if needed).
-	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(poolVol.Volume.ContentType), volStorageName, poolVol.Volume.Config)
+	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(customVol.ContentType), volStorageName, customVol.Config)
 
 	// Validate config and create database entry for restored storage volume.
-	err := VolumeDBCreate(b, projectName, poolVol.Volume.Name, poolVol.Volume.Description, drivers.VolumeTypeCustom, false, vol.Config(), poolVol.Volume.CreatedAt, time.Time{}, drivers.ContentType(poolVol.Volume.ContentType), false, true)
+	err = VolumeDBCreate(b, projectName, customVol.Name, customVol.Description, drivers.VolumeTypeCustom, false, vol.Config(), customVol.CreatedAt, time.Time{}, drivers.ContentType(customVol.ContentType), false, true)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { _ = VolumeDBDelete(b, projectName, poolVol.Volume.Name, drivers.VolumeTypeCustom) })
+	revert.Add(func() { _ = VolumeDBDelete(b, projectName, customVol.Name, drivers.VolumeTypeCustom) })
 
 	// Create the storage volume snapshot DB records.
-	for _, poolVolSnap := range poolVol.VolumeSnapshots {
-		fullSnapName := drivers.GetSnapshotVolumeName(poolVol.Volume.Name, poolVolSnap.Name)
+	for _, poolVolSnap := range customVol.Snapshots {
+		fullSnapName := drivers.GetSnapshotVolumeName(customVol.Name, poolVolSnap.Name)
 
 		// Copy volume config from backup file if present
 		// (so VolumeDBCreate can safely modify the copy if needed).
@@ -6466,7 +6521,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 	}
 
 	// Create snapshot mount paths and snapshot parent directory if needed.
-	for _, poolVolSnap := range poolVol.VolumeSnapshots {
+	for _, poolVolSnap := range customVol.Snapshots {
 		l.Debug("Ensuring instance snapshot mount path", logger.Ctx{"snapshot": poolVolSnap.Name})
 
 		snapVol, err := vol.NewSnapshot(poolVolSnap.Name)
@@ -6809,8 +6864,8 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 		return nil, fmt.Errorf("Unsupported volume type %q", vol.Type)
 	}
 
-	config := &backupConfig.Config{
-		Volume: &vol.StorageVolume,
+	volConfig := &backupConfig.Volume{
+		StorageVolume: vol.StorageVolume,
 	}
 
 	if snapshots {
@@ -6819,7 +6874,7 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 			return nil, err
 		}
 
-		config.VolumeSnapshots = make([]*api.StorageVolumeSnapshot, 0, len(dbVolSnaps))
+		volConfig.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(dbVolSnaps))
 		for i := range dbVolSnaps {
 			_, snapName, _ := api.GetParentAndSnapshotName(dbVolSnaps[i].Name)
 
@@ -6832,11 +6887,14 @@ func (b *lxdBackend) GenerateCustomVolumeBackupConfig(projectName string, volNam
 				CreatedAt:   dbVolSnaps[i].CreationDate,
 			}
 
-			config.VolumeSnapshots = append(config.VolumeSnapshots, &snapshot)
+			volConfig.Snapshots = append(volConfig.Snapshots, &snapshot)
 		}
 	}
 
-	return config, nil
+	return &backupConfig.Config{
+		Version: api.BackupMetadataVersion2,
+		Volumes: []*backupConfig.Volume{volConfig},
+	}, nil
 }
 
 // GenerateInstanceBackupConfig returns the backup config entry for this instance.
@@ -6858,9 +6916,13 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		return nil, err
 	}
 
+	volumeConfig := &backupConfig.Volume{
+		StorageVolume: volume.StorageVolume,
+	}
+
 	config := &backupConfig.Config{
-		Pool:   &b.db,
-		Volume: &volume.StorageVolume,
+		Version: api.BackupMetadataVersion2,
+		Pools:   []*api.StoragePool{&b.db},
 	}
 
 	// Add profiles from instance.
@@ -6870,10 +6932,10 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		config.Profiles[i] = &instProfiles[i]
 	}
 
-	// Only populate Container field for non-snapshot instances.
+	// Only populate Instance field for non-snapshot instances.
 	if !inst.IsSnapshot() {
 		var ok bool
-		config.Container, ok = ci.(*api.Instance)
+		config.Instance, ok = ci.(*api.Instance)
 		if !ok {
 			return nil, fmt.Errorf("Failed to cast %q into its API representation", inst.Name())
 		}
@@ -6903,7 +6965,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 				return nil, fmt.Errorf("Instance snapshot record count doesn't match instance snapshot volume record count")
 			}
 
-			config.VolumeSnapshots = make([]*api.StorageVolumeSnapshot, 0, len(dbVolSnaps))
+			volumeConfig.Snapshots = make([]*api.StorageVolumeSnapshot, 0, len(dbVolSnaps))
 			for i := range dbVolSnaps {
 				foundInstanceSnapshot := false
 				for _, snap := range snapshots {
@@ -6919,7 +6981,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 
 				_, snapName, _ := api.GetParentAndSnapshotName(dbVolSnaps[i].Name)
 
-				config.VolumeSnapshots = append(config.VolumeSnapshots, &api.StorageVolumeSnapshot{
+				volumeConfig.Snapshots = append(volumeConfig.Snapshots, &api.StorageVolumeSnapshot{
 					Name:        snapName,
 					Description: dbVolSnaps[i].Description,
 					ExpiresAt:   &dbVolSnaps[i].ExpiryDate,
@@ -6931,6 +6993,7 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		}
 	}
 
+	config.Volumes = []*backupConfig.Volume{volumeConfig}
 	return config, nil
 }
 
@@ -6962,8 +7025,13 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 		return err
 	}
 
+	rootVol, err := config.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
 	contentType := InstanceContentType(inst)
-	vol := b.GetVolume(volType, contentType, volStorageName, config.Volume.Config)
+	vol := b.GetVolume(volType, contentType, volStorageName, rootVol.Config)
 
 	// Only need to activate and mount the VM's config volume.
 	if inst.Type() == instancetype.VM {
@@ -6998,11 +7066,11 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 // CheckInstanceBackupFileSnapshots compares the snapshots on the storage device to those defined in the backup
 // config supplied and returns an error if they do not match.
 func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error) {
-	l := b.logger.AddContext(logger.Ctx{"project": projectName, "instance": backupConf.Container.Name})
+	l := b.logger.AddContext(logger.Ctx{"project": projectName, "instance": backupConf.Instance.Name})
 	l.Debug("CheckInstanceBackupFileSnapshots started")
 	defer l.Debug("CheckInstanceBackupFileSnapshots finished")
 
-	instType, err := instancetype.New(string(backupConf.Container.Type))
+	instType, err := instancetype.New(string(backupConf.Instance.Type))
 	if err != nil {
 		return nil, err
 	}
@@ -7013,16 +7081,21 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.C
 	}
 
 	// Get the volume name on storage.
-	volStorageName := project.Instance(projectName, backupConf.Container.Name)
+	volStorageName := project.Instance(projectName, backupConf.Instance.Name)
 
 	contentType := drivers.ContentTypeFS
 	if volType == drivers.VolumeTypeVM {
 		contentType = drivers.ContentTypeBlock
 	}
 
+	rootVol, err := backupConf.RootVolume()
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting the root volume: %w", err)
+	}
+
 	// Use the volume's config from the backup config.
 	// Some storage drivers might require the UUID to generate the volume name.
-	vol := b.GetVolume(volType, contentType, volStorageName, backupConf.Volume.Config)
+	vol := b.GetVolume(volType, contentType, volStorageName, rootVol.Config)
 
 	// Get a list of snapshots that exist on storage device.
 	driverSnapshots, err := vol.Snapshots(op)
@@ -7034,9 +7107,9 @@ func (b *lxdBackend) CheckInstanceBackupFileSnapshots(backupConf *backupConfig.C
 		return nil, fmt.Errorf("Snapshot count in backup config and storage device are different: %w", ErrBackupSnapshotsMismatch)
 	}
 
-	volSnaps := make([]drivers.Volume, 0, len(backupConf.VolumeSnapshots))
-	for _, snap := range backupConf.VolumeSnapshots {
-		snapName := drivers.GetSnapshotVolumeName(backupConf.Container.Name, snap.Name)
+	volSnaps := make([]drivers.Volume, 0, len(rootVol.Snapshots))
+	for _, snap := range rootVol.Snapshots {
+		snapName := drivers.GetSnapshotVolumeName(backupConf.Instance.Name, snap.Name)
 		volSnaps = append(volSnaps, b.GetVolume(volType, contentType, snapName, snap.Config))
 	}
 
@@ -7174,22 +7247,27 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 	}
 
 	// Run some consistency checks on the backup file contents.
-	if backupConf.Pool != nil {
-		if backupConf.Pool.Name != b.name {
-			return fmt.Errorf("Instance %q in project %q has pool name mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, backupConf.Pool.Name, b.name)
+	if backupConf.Pools != nil {
+		rootVolPool, err := backupConf.RootVolumePool()
+		if err != nil {
+			return fmt.Errorf("Failed getting the root volume's pool: %w", err)
 		}
 
-		if backupConf.Pool.Driver != b.Driver().Info().Name {
-			return fmt.Errorf("Instance %q in project %q has pool driver mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, backupConf.Pool.Driver, b.Driver().Name())
+		if rootVolPool.Name != b.name {
+			return fmt.Errorf("Instance %q in project %q has pool name mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Name, b.name)
+		}
+
+		if rootVolPool.Driver != b.Driver().Info().Name {
+			return fmt.Errorf("Instance %q in project %q has pool driver mismatch in its backup file (%q doesn't match's pool's %q)", instName, projectName, rootVolPool.Driver, b.Driver().Name())
 		}
 	}
 
-	if backupConf.Container == nil {
+	if backupConf.Instance == nil {
 		return fmt.Errorf("Instance %q in project %q has no instance information in its backup file", instName, projectName)
 	}
 
-	if instName != backupConf.Container.Name {
-		return fmt.Errorf("Instance %q in project %q has a different instance name in its backup file (%q)", instName, projectName, backupConf.Container.Name)
+	if instName != backupConf.Instance.Name {
+		return fmt.Errorf("Instance %q in project %q has a different instance name in its backup file (%q)", instName, projectName, backupConf.Instance.Name)
 	}
 
 	apiInstType, err := VolumeTypeToAPIInstanceType(volType)
@@ -7197,19 +7275,20 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 		return fmt.Errorf("Failed checking instance type for instance %q in project %q: %w", instName, projectName, err)
 	}
 
-	if apiInstType != api.InstanceType(backupConf.Container.Type) {
-		return fmt.Errorf("Instance %q in project %q has a different instance type in its backup file (%q)", instName, projectName, backupConf.Container.Type)
+	if apiInstType != api.InstanceType(backupConf.Instance.Type) {
+		return fmt.Errorf("Instance %q in project %q has a different instance type in its backup file (%q)", instName, projectName, backupConf.Instance.Type)
 	}
 
-	if backupConf.Volume == nil {
-		return fmt.Errorf("Instance %q in project %q has no volume information in its backup file", instName, projectName)
+	rootVol, err := backupConf.RootVolume()
+	if err != nil {
+		return fmt.Errorf("Instance %q in project %q has no volume information in its backup file: %w", instName, projectName, err)
 	}
 
-	if instName != backupConf.Volume.Name {
-		return fmt.Errorf("Instance %q in project %q has a different volume name in its backup file (%q)", instName, projectName, backupConf.Volume.Name)
+	if instName != rootVol.Name {
+		return fmt.Errorf("Instance %q in project %q has a different volume name in its backup file (%q)", instName, projectName, rootVol.Name)
 	}
 
-	instVolDBType, err := cluster.StoragePoolVolumeTypeFromName(backupConf.Volume.Type)
+	instVolDBType, err := cluster.StoragePoolVolumeTypeFromName(rootVol.Type)
 	if err != nil {
 		return fmt.Errorf("Failed checking instance volume type for instance %q in project %q: %w", instName, projectName, err)
 	}
@@ -7217,7 +7296,7 @@ func (b *lxdBackend) detectUnknownInstanceVolume(vol *drivers.Volume, projectVol
 	instVolType := VolumeDBTypeToType(instVolDBType)
 
 	if volType != instVolType {
-		return fmt.Errorf("Instance %q in project %q has a different volume type in its backup file (%q)", instName, projectName, backupConf.Volume.Type)
+		return fmt.Errorf("Instance %q in project %q has a different volume type in its backup file (%q)", instName, projectName, rootVol.Type)
 	}
 
 	// Add to volume to unknown volumes list for the project.
@@ -7333,8 +7412,8 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 		return fmt.Errorf("Failed custom volume validation: %w", err)
 	}
 
-	backupConf := &backupConfig.Config{
-		Volume: &api.StorageVolume{
+	customVol := &backupConfig.Volume{
+		StorageVolume: api.StorageVolume{
 			Name:        volName,
 			Type:        cluster.StoragePoolVolumeTypeNameCustom,
 			ContentType: apiContentType,
@@ -7349,11 +7428,15 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 		// Have to assume the snapshot volume config is same as parent.
 		snapVol := b.GetNewVolume(volType, contentType, snapFullName, vol.Config())
 
-		backupConf.VolumeSnapshots = append(backupConf.VolumeSnapshots, &api.StorageVolumeSnapshot{
+		customVol.Snapshots = append(customVol.Snapshots, &api.StorageVolumeSnapshot{
 			Name:        snapOnlyName, // Snapshot only name, not full name.
 			Config:      snapVol.Config(),
 			ContentType: apiContentType,
 		})
+	}
+
+	backupConf := &backupConfig.Config{
+		Volumes: []*backupConfig.Volume{customVol},
 	}
 
 	// Add to volume to unknown volumes list for the project.
@@ -7445,9 +7528,15 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 
 	var volumeConfig map[string]string
 
-	if poolVol != nil && poolVol.Volume != nil {
+	var rootVol *backupConfig.Volume
+	if poolVol != nil {
+		rootVol, err = poolVol.RootVolume()
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting the root volume: %w", err)
+		}
+
 		// Use volume config from backup file config if present.
-		volumeConfig = poolVol.Volume.Config
+		volumeConfig = rootVol.Config
 	}
 
 	// Generate the effective root device volume for instance.
@@ -7460,9 +7549,9 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 	if poolVol != nil {
 		creationDate := inst.CreationDate()
 
-		if poolVol.Volume != nil {
-			if !poolVol.Volume.CreatedAt.IsZero() {
-				creationDate = poolVol.Volume.CreatedAt
+		if rootVol != nil {
+			if !rootVol.CreatedAt.IsZero() {
+				creationDate = rootVol.CreatedAt
 			}
 		}
 
@@ -7474,9 +7563,9 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 
 		revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
 
-		if len(snapshots) > 0 && len(poolVol.VolumeSnapshots) > 0 {
+		if len(snapshots) > 0 && len(rootVol.Snapshots) > 0 {
 			// Create storage volume snapshot DB records from the entries in the backup file config.
-			for _, poolVolSnap := range poolVol.VolumeSnapshots {
+			for _, poolVolSnap := range rootVol.Snapshots {
 				fullSnapName := drivers.GetSnapshotVolumeName(inst.Name(), poolVolSnap.Name)
 
 				// Copy volume config from backup file if present,
@@ -7728,21 +7817,26 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 	l.Debug("CreateCustomVolumeFromBackup started")
 	defer l.Debug("CreateCustomVolumeFromBackup finished")
 
-	if srcBackup.Config == nil || srcBackup.Config.Volume == nil {
+	if srcBackup.Config == nil {
 		return fmt.Errorf("Valid volume config not found in index")
 	}
 
-	if len(srcBackup.Snapshots) != len(srcBackup.Config.VolumeSnapshots) {
+	customVol, err := srcBackup.Config.CustomVolume()
+	if err != nil {
+		return fmt.Errorf("Failed getting the custom volume: %w", err)
+	}
+
+	if len(srcBackup.Snapshots) != len(customVol.Snapshots) {
 		return fmt.Errorf("Valid volume snapshot config not found in index")
 	}
 
 	// Validate the names in the index.yaml file as these could be malicious.
-	err := ValidVolumeName(srcBackup.Name)
+	err = ValidVolumeName(srcBackup.Name)
 	if err != nil {
 		return err
 	}
 
-	err = ValidVolumeName(srcBackup.Config.Volume.Name)
+	err = ValidVolumeName(customVol.Name)
 	if err != nil {
 		return err
 	}
@@ -7754,7 +7848,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 		}
 	}
 
-	for _, snap := range srcBackup.Config.VolumeSnapshots {
+	for _, snap := range customVol.Snapshots {
 		err = ValidVolumeName(snap.Name)
 		if err != nil {
 			return err
@@ -7764,7 +7858,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 	// Check whether we are allowed to create volumes.
 	req := api.StorageVolumesPost{
 		StorageVolumePut: api.StorageVolumePut{
-			Config: srcBackup.Config.Volume.Config,
+			Config: customVol.Config,
 		},
 		Name: srcBackup.Name,
 	}
@@ -7782,21 +7876,21 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 	// Get the volume name on storage.
 	volStorageName := project.StorageVolume(srcBackup.Project, srcBackup.Name)
 
-	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(srcBackup.Config.Volume.ContentType), volStorageName, srcBackup.Config.Volume.Config)
+	vol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(customVol.ContentType), volStorageName, customVol.Config)
 
 	// Validate config and create database entry for new storage volume.
 	// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-	err = VolumeDBCreate(b, srcBackup.Project, srcBackup.Name, srcBackup.Config.Volume.Description, vol.Type(), false, vol.Config(), srcBackup.Config.Volume.CreatedAt, time.Time{}, vol.ContentType(), true, true)
+	err = VolumeDBCreate(b, srcBackup.Project, srcBackup.Name, customVol.Description, vol.Type(), false, vol.Config(), customVol.CreatedAt, time.Time{}, vol.ContentType(), true, true)
 	if err != nil {
 		return err
 	}
 
 	revert.Add(func() { _ = VolumeDBDelete(b, srcBackup.Project, srcBackup.Name, vol.Type()) })
 
-	sourceSnapshots := make([]drivers.Volume, 0, len(srcBackup.Config.VolumeSnapshots))
+	sourceSnapshots := make([]drivers.Volume, 0, len(customVol.Snapshots))
 
 	// Create database entries fro new storage volume snapshots.
-	for _, s := range srcBackup.Config.VolumeSnapshots {
+	for _, s := range customVol.Snapshots {
 		snapshot := s // Local var for revert.
 		snapName := snapshot.Name
 
@@ -7808,7 +7902,7 @@ func (b *lxdBackend) CreateCustomVolumeFromBackup(srcBackup backup.Info, srcData
 
 		fullSnapName := drivers.GetSnapshotVolumeName(srcBackup.Name, snapName)
 		snapVolStorageName := project.StorageVolume(srcBackup.Project, fullSnapName)
-		snapVol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(srcBackup.Config.Volume.ContentType), snapVolStorageName, snapshot.Config)
+		snapVol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(customVol.ContentType), snapVolStorageName, snapshot.Config)
 
 		// Validate config and create database entry for new storage volume.
 		// Strip unsupported config keys (in case the export was made from a different type of storage pool).

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -938,7 +938,8 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 		}
 
 		// Save any changes that have occurred to the instance's config to the on-disk backup.yaml file.
-		err = b.UpdateInstanceBackupFile(inst, false, op)
+		// Use the global metadata version.
+		err = b.UpdateInstanceBackupFile(inst, false, backupConfig.DefaultMetadataVersion, op)
 		if err != nil {
 			return fmt.Errorf("Failed updating backup file: %w", err)
 		}
@@ -3273,7 +3274,8 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 	}
 
 	// Ensure the backup file reflects current config.
-	err = b.UpdateInstanceBackupFile(inst, snapshots, op)
+	// Use the version requested by the caller to write the correct backup file format.
+	err = b.UpdateInstanceBackupFile(inst, snapshots, version, op)
 	if err != nil {
 		return err
 	}
@@ -3749,7 +3751,8 @@ func (b *lxdBackend) RenameInstanceSnapshot(inst instance.Instance, newName stri
 	})
 
 	// Ensure the backup file reflects current config.
-	err = b.UpdateInstanceBackupFile(inst, true, op)
+	// Use the global metadata version.
+	err = b.UpdateInstanceBackupFile(inst, true, backupConfig.DefaultMetadataVersion, op)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7035,11 +7035,6 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 		return err
 	}
 
-	data, err := yaml.Marshal(config)
-	if err != nil {
-		return err
-	}
-
 	// Get the volume name on storage.
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	volType, err := InstanceTypeToVolumeType(inst.Type())
@@ -7070,6 +7065,18 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshots 
 		}
 
 		err = f.Chmod(0400)
+		if err != nil {
+			return err
+		}
+
+		// Downgrade the config in case the old backup format was requested.
+		// Do this as one of the last steps to allow working on the latest format beforehand.
+		config, err = backup.ConvertFormat(config, version)
+		if err != nil {
+			return fmt.Errorf("Failed to convert backup config to version %d: %w", version, err)
+		}
+
+		data, err := yaml.Marshal(config)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5610,6 +5610,19 @@ func (b *lxdBackend) migrationIndexHeaderSend(l logger.Logger, indexHeaderVersio
 
 	// Send migration index header frame to target if applicable and wait for receipt.
 	if indexHeaderVersion > 0 {
+		// In case the remote is using header version 1,
+		// rewrite from the new to the old format to stay backwards compatible.
+		if indexHeaderVersion == 1 {
+			var err error
+
+			// Don't pass the index header version directly to ConvertFormat.
+			// The version of the index header might diverge from the backup metadata version.
+			info.Config, err = backup.ConvertFormat(info.Config, api.BackupMetadataVersion1)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to convert backup config to version %d: %w", api.BackupMetadataVersion1, err)
+			}
+		}
+
 		headerJSON, err := json.Marshal(info)
 		if err != nil {
 			return nil, fmt.Errorf("Failed encoding migration index header: %w", err)
@@ -5682,6 +5695,12 @@ func (b *lxdBackend) migrationIndexHeaderReceive(l logger.Logger, indexHeaderVer
 		err = conn.Close() // End the frame.
 		if err != nil {
 			return nil, fmt.Errorf("Failed closing migration index header response frame: %w", err)
+		}
+
+		// In all cases upgrade the format into the new one.
+		info.Config, err = backup.ConvertFormat(info.Config, api.BackupMetadataVersion2)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to convert backup config to version %d: %w", api.BackupMetadataVersion2, err)
 		}
 
 		l.Debug("Sent migration index header response", logger.Ctx{"version": indexHeaderVersion})

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -183,7 +183,7 @@ func (b *mockBackend) GenerateInstanceBackupConfig(inst instance.Instance, snaps
 }
 
 // UpdateInstanceBackupFile ...
-func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, op *operations.Operation) error {
+func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, snapshot bool, version uint32, op *operations.Operation) error {
 	return nil
 }
 
@@ -223,7 +223,7 @@ func (b *mockBackend) RefreshInstance(inst instance.Instance, src instance.Insta
 }
 
 // BackupInstance ...
-func (b *mockBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error {
+func (b *mockBackend) BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -72,7 +72,7 @@ type Pool interface {
 	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstance(inst instance.Instance, op *operations.Operation) error
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
-	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, op *operations.Operation) error
+	UpdateInstanceBackupFile(inst instance.Instance, snapshots bool, version uint32, op *operations.Operation) error
 	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) (revert.Hook, error)
@@ -80,7 +80,7 @@ type Pool interface {
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
-	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
+	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, version uint32, op *operations.Operation) error
 
 	GetInstanceUsage(inst instance.Instance) (*VolumeUsage, error)
 	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -6489,7 +6489,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -840,11 +840,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -861,17 +861,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +982,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1147,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1173,7 +1173,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1227,8 +1227,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1261,15 +1261,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1317,16 +1317,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,7 +1547,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1697,9 +1697,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1710,12 +1710,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1783,8 +1783,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1864,7 +1864,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1984,11 +1984,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2180,48 +2180,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2288,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,7 +2474,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2827,11 +2827,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2839,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,11 +2873,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2887,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,6 +2987,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3077,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3560,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3815,12 +3825,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4081,7 +4091,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4278,7 +4288,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4351,7 +4361,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4363,7 +4373,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4426,7 +4436,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4495,8 +4505,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4567,7 +4577,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4584,11 +4594,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4621,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4719,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4792,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4999,7 +5009,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5097,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5186,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5220,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5454,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5515,11 +5525,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5537,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5621,7 +5631,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5659,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5671,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5703,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5869,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6043,7 +6053,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6078,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6110,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6132,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6156,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6172,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6218,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6233,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6265,7 +6279,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6305,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6321,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6427,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,7 +6472,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6472,7 +6486,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6552,7 +6572,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6590,7 +6610,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6634,7 +6654,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6773,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,15 +6797,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6807,11 +6827,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6848,7 +6868,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7029,7 +7049,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7074,7 +7094,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7215,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7243,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7275,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7283,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7355,7 +7375,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7384,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7379,7 +7399,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7412,7 +7432,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7715,7 +7735,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7739,7 +7759,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7784,7 +7804,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -7182,7 +7182,7 @@ msgstr "Erstellt: %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -264,7 +264,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -727,7 +727,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh kann nur mit Containern verwendet werden"
@@ -751,7 +751,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -792,7 +792,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -805,15 +805,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -1014,7 +1014,7 @@ msgstr "Aliasname fehlt"
 msgid "Aliases already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
@@ -1033,7 +1033,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -1126,11 +1126,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
@@ -1148,17 +1148,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -1179,7 +1179,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1189,7 +1189,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -1272,7 +1272,7 @@ msgstr "ERSTELLT AM"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1294,7 +1294,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1452,8 +1452,8 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1478,7 +1478,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1494,7 +1494,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1515,7 +1515,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1535,8 +1535,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1570,15 +1570,15 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1630,16 +1630,16 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1854,7 +1854,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1884,7 +1884,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1910,7 +1910,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -2045,9 +2045,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -2058,12 +2058,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2131,8 +2131,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2222,7 +2222,7 @@ msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2267,7 +2267,7 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2355,11 +2355,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2443,7 +2443,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2497,7 +2497,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2573,52 +2573,52 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2631,7 +2631,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2685,12 +2685,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2739,7 +2739,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2774,7 +2774,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2806,7 +2806,7 @@ msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -2875,7 +2875,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2952,7 +2952,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3253,11 +3253,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3265,25 +3265,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3292,7 +3292,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3300,12 +3300,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3315,7 +3315,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3324,11 +3324,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3373,7 +3373,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3419,6 +3419,16 @@ msgstr ""
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "Ungültiges Ziel %s"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, fuzzy, c-format
+msgid "Invalid export version %q: %w"
+msgstr "Ungültiges Ziel %s"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -3515,7 +3525,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3559,12 +3569,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3691,11 +3701,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -4037,7 +4047,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
@@ -4107,12 +4117,12 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 #, fuzzy
 msgid "Manage images"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4131,7 +4141,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4327,12 +4337,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4619,7 +4629,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4819,7 +4829,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4897,7 +4907,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4909,7 +4919,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4972,7 +4982,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4981,7 +4991,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -5045,8 +5055,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -5117,7 +5127,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5137,12 +5147,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
@@ -5166,12 +5176,12 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5265,7 +5275,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -5304,7 +5314,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5344,16 +5354,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5583,7 +5593,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5679,7 +5689,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5770,7 +5780,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5807,16 +5817,16 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6073,7 +6083,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6138,11 +6148,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6152,7 +6162,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Show instance metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Profil %s erstellt\n"
@@ -6260,7 +6270,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6291,7 +6301,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show useful information about a cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6303,7 +6313,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Größe: %.2vMB\n"
@@ -6336,7 +6346,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6510,7 +6520,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6700,7 +6710,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6723,7 +6737,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6757,7 +6771,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
@@ -6780,7 +6794,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6804,7 +6818,7 @@ msgstr "unbekannter entfernter Instanz Name: %q"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6820,12 +6834,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6868,7 +6882,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6883,7 +6897,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6930,7 +6944,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6956,7 +6970,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6976,11 +6990,11 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7118,7 +7132,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7150,7 +7164,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7165,7 +7179,13 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7249,7 +7269,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
@@ -7294,7 +7314,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7370,7 +7390,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7591,7 +7611,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7600,7 +7620,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7609,7 +7629,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7617,7 +7637,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7641,7 +7661,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7649,7 +7669,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7657,7 +7677,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7700,7 +7720,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7708,7 +7728,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7787,7 +7807,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -8140,7 +8160,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8227,7 +8247,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8511,7 +8531,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8529,7 +8549,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8537,7 +8557,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8587,7 +8607,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -8595,7 +8615,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -8687,7 +8707,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8696,13 +8716,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8711,7 +8731,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -8744,7 +8764,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9051,7 +9071,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -9075,7 +9095,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -9120,8 +9140,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 
@@ -9185,10 +9205,6 @@ msgstr ""
 
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
-
-#, fuzzy
-#~ msgid "Invalid format %q"
-#~ msgstr "Ungültiges Ziel %s"
 
 #, fuzzy
 #~ msgid "Remote operation canceled by user"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -846,11 +846,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -867,17 +867,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -989,7 +989,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1039,7 +1039,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1154,8 +1154,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1180,7 +1180,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1217,7 +1217,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1234,8 +1234,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1268,15 +1268,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1324,16 +1324,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1557,7 +1557,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1620,7 +1620,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1712,9 +1712,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1725,12 +1725,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1798,8 +1798,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2005,11 +2005,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2086,7 +2086,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2139,7 +2139,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2149,7 +2149,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2206,48 +2206,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2260,7 +2260,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2314,12 +2314,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2368,7 +2368,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2403,7 +2403,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2432,7 +2432,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2500,7 +2500,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2567,7 +2567,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2575,7 +2575,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2866,11 +2866,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2878,25 +2878,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2912,11 +2912,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2926,7 +2926,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2934,11 +2934,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2982,7 +2982,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3026,6 +3026,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3116,7 +3126,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3160,12 +3170,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3285,11 +3295,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3601,7 +3611,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3665,11 +3675,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3688,7 +3698,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -3872,12 +3882,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4147,7 +4157,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4346,7 +4356,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4419,7 +4429,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4431,7 +4441,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4494,7 +4504,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4503,7 +4513,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4564,8 +4574,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4636,7 +4646,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4653,11 +4663,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4680,11 +4690,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4778,7 +4788,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4814,7 +4824,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4851,16 +4861,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5073,7 +5083,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5162,7 +5172,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5251,7 +5261,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5286,15 +5296,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5542,7 +5552,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5605,11 +5615,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5617,7 +5627,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5719,7 +5729,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5748,7 +5758,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5760,7 +5770,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5792,7 +5802,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5958,7 +5968,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6142,7 +6152,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6163,7 +6177,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
@@ -6196,7 +6210,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6218,7 +6232,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6242,7 +6256,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6258,12 +6272,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6304,7 +6318,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6319,7 +6333,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6365,7 +6379,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6391,7 +6405,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6408,11 +6422,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6544,7 +6558,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6575,7 +6589,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6589,7 +6603,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6669,7 +6689,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6707,7 +6727,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6751,7 +6771,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6870,19 +6890,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6894,15 +6914,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6924,11 +6944,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6965,7 +6985,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7146,7 +7166,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7191,7 +7211,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7332,7 +7352,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7340,11 +7360,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7372,7 +7392,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7380,7 +7400,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7472,7 +7492,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7481,13 +7501,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7496,7 +7516,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7529,7 +7549,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7832,7 +7852,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7856,7 +7876,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7901,8 +7921,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -6606,7 +6606,7 @@ msgstr "  Χρήση CPU:"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6933,7 +6933,7 @@ msgstr "Auto actualización: %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -266,7 +266,7 @@ msgstr ""
 "###\n"
 "### Observe que la huella se muestra pero no puede modificarse"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -657,7 +657,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -714,7 +714,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -771,7 +771,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -784,15 +784,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "El dispostivo ya existe: %s"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Acepta certificado"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -1092,11 +1092,11 @@ msgstr "Tipo de autenticación %s no está soportada por el servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
@@ -1113,17 +1113,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1143,7 +1143,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1153,7 +1153,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
@@ -1235,7 +1235,7 @@ msgstr "CREADO EN"
 msgid "CUDA Version: %v"
 msgstr "Versión de CUDA: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr "Cacheado: %s"
@@ -1251,7 +1251,7 @@ msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
 "local"
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1406,8 +1406,8 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1432,7 +1432,7 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1448,7 +1448,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1469,7 +1469,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1488,8 +1488,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1522,15 +1522,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1578,17 +1578,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
@@ -1790,7 +1790,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1820,7 +1820,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1846,7 +1846,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr "Eliminar imágenes"
 
@@ -1976,9 +1976,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1989,12 +1989,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2062,8 +2062,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
@@ -2145,7 +2145,7 @@ msgstr "Dispositivo: %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
@@ -2187,7 +2187,7 @@ msgstr "Disco:"
 msgid "Disks:"
 msgstr "Discos:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2272,11 +2272,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2353,7 +2353,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2416,7 +2416,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2475,50 +2475,50 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expira: %s"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr "Expira: %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr "Expira: nunca"
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 #, fuzzy
 msgid "Export instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
@@ -2531,7 +2531,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2585,12 +2585,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2639,7 +2639,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2674,7 +2674,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -2703,7 +2703,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
@@ -2772,7 +2772,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2839,7 +2839,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -2848,7 +2848,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3142,11 +3142,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3154,25 +3154,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3180,7 +3180,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3188,11 +3188,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3202,7 +3202,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3211,11 +3211,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3261,7 +3261,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
@@ -3307,6 +3307,16 @@ msgstr ""
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "Nombre del contenedor es: %s"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, fuzzy, c-format
+msgid "Invalid export version %q: %w"
+msgstr "Versión del cliente: %s\n"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -3398,7 +3408,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "IsSM: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3442,12 +3452,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Creado: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3574,11 +3584,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3896,7 +3906,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3960,11 +3970,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3983,7 +3993,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4166,12 +4176,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4452,7 +4462,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4649,7 +4659,7 @@ msgstr "Perfil %s eliminado"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4722,7 +4732,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4734,7 +4744,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4797,7 +4807,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4806,7 +4816,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4867,8 +4877,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4939,7 +4949,7 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Perfil para aplicar al nuevo contenedor"
@@ -4959,11 +4969,11 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Perfil %s creado"
@@ -4987,11 +4997,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5085,7 +5095,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr "Público: %s"
@@ -5121,7 +5131,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5160,16 +5170,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5385,7 +5395,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5479,7 +5489,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5568,7 +5578,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5604,15 +5614,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5860,7 +5870,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5923,11 +5933,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -5936,7 +5946,7 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -6038,7 +6048,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6067,7 +6077,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6079,7 +6089,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Auto actualización: %s"
@@ -6111,7 +6121,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6278,7 +6288,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6464,7 +6474,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6485,7 +6499,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
@@ -6519,7 +6533,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6541,7 +6555,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6565,7 +6579,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6581,12 +6595,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6629,7 +6643,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -6644,7 +6658,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6690,7 +6704,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6716,7 +6730,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6734,11 +6748,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6870,7 +6884,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6902,7 +6916,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6916,7 +6930,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6996,7 +7016,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -7034,7 +7054,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7085,7 +7105,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7228,22 +7248,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7258,17 +7278,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7295,12 +7315,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7346,7 +7366,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7566,7 +7586,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7621,7 +7641,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7796,7 +7816,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7806,12 +7826,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7844,7 +7864,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7852,7 +7872,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7944,7 +7964,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7953,13 +7973,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7968,7 +7988,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -8001,7 +8021,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8304,7 +8324,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8328,7 +8348,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8373,8 +8393,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -265,7 +265,7 @@ msgstr ""
 "### Prenez note que l'empreinte digitale (fingerprint ) est affichée mais ne "
 "peut pas être modifiée"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -666,7 +666,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -722,7 +722,7 @@ msgstr "--console fonctionne seulement avec une instance seule"
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded ne peut être utilisé avec un serveur"
 
@@ -742,7 +742,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh ne peut être utilisé qu'avec des instances"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target ne peut pas être utilisé avec des instances"
@@ -787,7 +787,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -801,16 +801,16 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Alias :"
 
@@ -1037,7 +1037,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accepter le certificat"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -1129,11 +1129,11 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
@@ -1151,17 +1151,17 @@ msgstr "Rendre l'image publique"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
@@ -1182,7 +1182,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1192,7 +1192,7 @@ msgstr "Clé de configuration invalide"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
@@ -1274,7 +1274,7 @@ msgstr "CRÉÉ À"
 msgid "CUDA Version: %v"
 msgstr "Afficher la version du client"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, fuzzy, c-format
 msgid "Cached: %s"
 msgstr "Créé : %s"
@@ -1288,7 +1288,7 @@ msgstr "Créé : %s"
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1446,8 +1446,8 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1472,7 +1472,7 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1516,7 +1516,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 #, fuzzy
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1537,8 +1537,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1572,15 +1572,15 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1632,17 +1632,17 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -1874,7 +1874,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1904,7 +1904,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1930,7 +1930,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 #, fuzzy
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
@@ -2071,9 +2071,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -2084,12 +2084,12 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2157,8 +2157,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2242,7 +2242,7 @@ msgstr "Serveur distant : %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
@@ -2287,7 +2287,7 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2376,11 +2376,11 @@ msgstr "Clé de configuration invalide"
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2465,7 +2465,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2519,7 +2519,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2529,7 +2529,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2604,53 +2604,53 @@ msgstr ""
 msgid "Expires at"
 msgstr "Expire : %s"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 #, fuzzy
 msgid "Export and download images"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
@@ -2664,7 +2664,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2718,12 +2718,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2773,7 +2773,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2808,7 +2808,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, fuzzy, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2838,7 +2838,7 @@ msgstr "Mode rapide (identique à --columns=nsacPt"
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -2910,7 +2910,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2977,7 +2977,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -2986,7 +2986,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3294,11 +3294,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
@@ -3306,26 +3306,26 @@ msgstr "Image copiée avec succès !"
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3335,7 +3335,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3343,12 +3343,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3358,7 +3358,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Import de l'image : %s"
@@ -3368,11 +3368,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3419,7 +3419,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
@@ -3465,6 +3465,16 @@ msgstr "Clé de configuration invalide"
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "Cible invalide %s"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, fuzzy, c-format
+msgid "Invalid export version %q: %w"
+msgstr "Afficher la version du client"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -3557,7 +3567,7 @@ msgstr "Cible invalide %s"
 msgid "IsSM: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
@@ -3602,12 +3612,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
@@ -3734,11 +3744,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -4122,7 +4132,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
@@ -4191,12 +4201,12 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr "Rendre l'image publique"
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 #, fuzzy
 msgid "Manage images"
 msgstr "Rendre l'image publique"
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4215,7 +4225,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -4413,12 +4423,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4709,7 +4719,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4910,7 +4920,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 #, fuzzy
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
@@ -4990,7 +5000,7 @@ msgid ""
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
@@ -5006,7 +5016,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 #, fuzzy
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
@@ -5074,7 +5084,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5083,7 +5093,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5148,8 +5158,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -5221,7 +5231,7 @@ msgstr "Profil %s supprimé de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -5241,12 +5251,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 #, fuzzy
 msgid "Profiles:"
 msgstr "Profils : %s"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Profils : %s"
@@ -5270,11 +5280,11 @@ msgstr "Profil %s ajouté à %s"
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5368,7 +5378,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -5407,7 +5417,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5449,17 +5459,17 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5690,7 +5700,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5803,7 +5813,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -5897,7 +5907,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5934,16 +5944,16 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6202,7 +6212,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6267,11 +6277,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6281,7 +6291,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Show instance metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Afficher la configuration étendue"
@@ -6395,7 +6405,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
@@ -6426,7 +6436,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show useful information about a cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6438,7 +6448,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Taille : %.2f Mo"
@@ -6471,7 +6481,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr "Source :"
 
@@ -6648,7 +6658,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6842,7 +6852,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6863,7 +6877,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6898,7 +6912,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
@@ -6923,7 +6937,7 @@ msgid ""
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6947,7 +6961,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6963,12 +6977,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -7012,7 +7026,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, fuzzy, c-format
 msgid "Type: %s"
@@ -7027,7 +7041,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -7074,7 +7088,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7100,7 +7114,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -7120,11 +7134,11 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7265,7 +7279,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7297,7 +7311,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -7312,7 +7326,13 @@ msgstr "Création du conteneur"
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7394,7 +7414,7 @@ msgstr "Nom : %s"
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
@@ -7439,7 +7459,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7518,7 +7538,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7754,7 +7774,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7766,7 +7786,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7778,7 +7798,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7786,7 +7806,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7810,7 +7830,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7818,7 +7838,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7826,7 +7846,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7872,7 +7892,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7880,7 +7900,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7977,7 +7997,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -8363,7 +8383,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8456,7 +8476,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8761,7 +8781,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8785,7 +8805,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8793,7 +8813,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8850,7 +8870,7 @@ msgstr "Swap (courant)"
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr "désactivé"
 
@@ -8858,7 +8878,7 @@ msgstr "désactivé"
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr "activé"
 
@@ -8950,7 +8970,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8959,13 +8979,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8974,7 +8994,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -9007,7 +9027,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -9332,7 +9352,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -9357,7 +9377,7 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr "non"
 
@@ -9402,8 +9422,8 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "oui"
 
@@ -9478,10 +9498,6 @@ msgstr "oui"
 
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr "%v (interrompre encore deux fois pour forcer)"
-
-#, fuzzy
-#~ msgid "Invalid format %q"
-#~ msgstr "Cible invalide %s"
 
 #, fuzzy
 #~ msgid "Remote operation canceled by user"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -7329,7 +7329,7 @@ msgstr "Utilisation : %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -844,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -865,17 +865,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1177,7 +1177,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1231,8 +1231,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1265,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1321,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,7 +1551,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1701,9 +1701,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1714,12 +1714,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1988,11 +1988,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2184,48 +2184,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2292,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,7 +2478,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2553,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2831,11 +2831,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2843,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,11 +2877,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2891,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2947,7 +2947,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,6 +2991,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3081,7 +3091,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3135,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3258,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3564,7 +3574,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3636,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3659,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3819,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4085,7 +4095,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4282,7 +4292,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4355,7 +4365,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4367,7 +4377,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4430,7 +4440,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4449,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4499,8 +4509,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4571,7 +4581,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4588,11 +4598,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4625,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4723,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4796,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5003,7 +5013,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5101,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5190,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5224,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5458,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5519,11 +5529,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5541,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5625,7 +5635,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5663,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5675,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5707,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5873,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6047,7 +6057,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6082,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6114,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6136,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6160,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6176,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6222,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6237,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6269,7 +6283,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6309,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6325,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6431,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6462,7 +6476,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6476,7 +6490,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6556,7 +6576,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6594,7 +6614,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6638,7 +6658,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6777,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,15 +6801,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6811,11 +6831,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6852,7 +6872,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7033,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7078,7 +7098,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7219,7 +7239,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7247,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7279,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7287,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7359,7 +7379,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7388,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7383,7 +7403,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7416,7 +7436,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7719,7 +7739,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7743,7 +7763,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7788,7 +7808,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -6493,7 +6493,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -6930,7 +6930,7 @@ msgstr "Aggiornamento automatico: %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -276,7 +276,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -662,7 +662,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -718,7 +718,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -773,7 +773,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -786,15 +786,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -989,7 +989,7 @@ msgstr "Nome dell'alias mancante"
 msgid "Aliases already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Alias:"
 
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Accetta certificato"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -1094,11 +1094,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1115,17 +1115,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1145,7 +1145,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1155,7 +1155,7 @@ msgstr "Proprietà errata: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
@@ -1237,7 +1237,7 @@ msgstr "CREATO IL"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1287,7 +1287,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1404,8 +1404,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1430,7 +1430,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1446,7 +1446,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1467,7 +1467,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1484,8 +1484,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1519,15 +1519,15 @@ msgstr "Creazione del container in corso"
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1575,16 +1575,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1787,7 +1787,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1817,7 +1817,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1972,9 +1972,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1985,12 +1985,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2058,8 +2058,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2141,7 +2141,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -2185,7 +2185,7 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Creazione del container in corso"
@@ -2270,11 +2270,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2404,7 +2404,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2414,7 +2414,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2472,50 +2472,50 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2528,7 +2528,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2582,12 +2582,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
@@ -2636,7 +2636,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2671,7 +2671,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2701,7 +2701,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2770,7 +2770,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2837,7 +2837,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -2846,7 +2846,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3136,11 +3136,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3148,25 +3148,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3174,7 +3174,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3182,11 +3182,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3196,7 +3196,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3205,11 +3205,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3254,7 +3254,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
@@ -3300,6 +3300,16 @@ msgstr ""
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "Proprietà errata: %s"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, fuzzy, c-format
+msgid "Invalid export version %q: %w"
+msgstr "Proprietà errata: %s"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -3392,7 +3402,7 @@ msgstr "Proprietà errata: %s"
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3436,12 +3446,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3568,11 +3578,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3892,7 +3902,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3959,11 +3969,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3982,7 +3992,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4167,12 +4177,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4451,7 +4461,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4648,7 +4658,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4723,7 +4733,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4735,7 +4745,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4798,7 +4808,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4807,7 +4817,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4869,8 +4879,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4941,7 +4951,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -4960,11 +4970,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4987,11 +4997,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5085,7 +5095,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5122,7 +5132,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5161,16 +5171,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5387,7 +5397,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5481,7 +5491,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5570,7 +5580,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5606,15 +5616,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5858,7 +5868,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5921,11 +5931,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -5934,7 +5944,7 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -6036,7 +6046,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6066,7 +6076,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr "Il nome del container è: %s"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6078,7 +6088,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Aggiornamento automatico: %s"
@@ -6110,7 +6120,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6279,7 +6289,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6465,7 +6475,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6486,7 +6500,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
@@ -6520,7 +6534,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6542,7 +6556,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6566,7 +6580,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6582,12 +6596,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6629,7 +6643,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6644,7 +6658,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6691,7 +6705,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6717,7 +6731,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6736,11 +6750,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6866,7 +6880,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6898,7 +6912,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6913,7 +6927,13 @@ msgstr "Creazione del container in corso"
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6993,7 +7013,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -7085,7 +7105,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7228,22 +7248,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr "Creazione del container in corso"
@@ -7258,17 +7278,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7295,12 +7315,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7346,7 +7366,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7566,7 +7586,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7621,7 +7641,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
@@ -7796,7 +7816,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -7806,12 +7826,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7844,7 +7864,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7852,7 +7872,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7944,7 +7964,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7953,13 +7973,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7968,7 +7988,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -8001,7 +8021,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8304,7 +8324,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8329,7 +8349,7 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr "no"
 
@@ -8374,8 +8394,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -7249,7 +7249,7 @@ msgstr "使い方: %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +252,7 @@ msgstr ""
 "###\n"
 "### Note that the fingerprint is shown but cannot be changed"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -654,7 +654,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -709,7 +709,7 @@ msgstr "--console は単一のインスタンスのときのみ指定できま�
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr "--expanded はサーバーでは使えません"
 
@@ -729,7 +729,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh はインスタンスの場合のみ使えます"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr "--target はインスタンスでは使えません"
@@ -762,7 +762,7 @@ msgstr "<remote> <new-name>"
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -777,15 +777,15 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -997,7 +997,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases already exists: %s"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "エイリアス:"
 
@@ -1013,7 +1013,7 @@ msgstr "すべてのサーバーアドレスが利用できません"
 msgid "Alternative certificate name"
 msgstr "別の証明署名"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -1105,11 +1105,11 @@ msgstr "認証タイプ '%s' はサーバではサポートされていません
 msgid "Auto negotiation: %v"
 msgstr "オートネゴシエーション: %v"
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr "自動更新は pull モードのときのみ有効です"
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
@@ -1126,17 +1126,17 @@ msgstr "利用可能なプロジェクト:"
 msgid "BASE IMAGE"
 msgstr "BASE IMAGE"
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1168,7 +1168,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
@@ -1249,7 +1249,7 @@ msgstr "CREATED AT"
 msgid "CUDA Version: %v"
 msgstr "CUDA バージョン: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
@@ -1262,7 +1262,7 @@ msgstr "キャッシュ:"
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
@@ -1300,7 +1300,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1420,8 +1420,8 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1446,7 +1446,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1462,7 +1462,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1487,7 +1487,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `none`)"
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない場合は none)"
 
@@ -1504,8 +1504,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1539,15 +1539,15 @@ msgstr "ステートフルなインスタンスをステートレスにコピー
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr "サーバ間でイメージをコピーします"
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1610,16 +1610,16 @@ msgstr "インスタンスをコピーします。スナップショットはコ
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr "仮想マシンイメージをコピーします"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -1820,7 +1820,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1849,7 +1849,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1875,7 +1875,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1914,7 +1914,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr "イメージを削除します"
 
@@ -2002,9 +2002,9 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -2015,12 +2015,12 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2088,8 +2088,8 @@ msgstr "警告を削除します"
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
@@ -2175,7 +2175,7 @@ msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
 "でした"
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -2217,7 +2217,7 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2304,11 +2304,11 @@ msgstr "信頼済みクライアント設定をYAMLで編集します"
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2381,7 +2381,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2446,7 +2446,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2456,7 +2456,7 @@ msgstr "イメージの取得中: %s"
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
@@ -2524,20 +2524,20 @@ msgstr ""
 msgid "Expires at"
 msgstr "失効日時"
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr "イメージをエクスポートしてダウンロードします"
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
@@ -2547,29 +2547,29 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr "インスタンスのバックアップをエクスポートします"
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
@@ -2582,7 +2582,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2636,12 +2636,12 @@ msgstr "クライアント %q に対する SFTP インスタンスの接続に�
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2690,7 +2690,7 @@ msgstr "リモートの追加に失敗しました"
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -2725,7 +2725,7 @@ msgstr "プロジェクトが見つけられませんでした: %w"
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
@@ -2754,7 +2754,7 @@ msgstr "Fast モード (--columns=nsacPt と同じ)"
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -2838,7 +2838,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2905,7 +2905,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -2914,7 +2914,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3207,11 +3207,11 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
@@ -3219,25 +3219,25 @@ msgstr "イメージのコピーが成功しました!"
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3245,7 +3245,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3256,11 +3256,11 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 #, fuzzy
 msgid ""
 "Import image into the image store\n"
@@ -3275,7 +3275,7 @@ msgstr ""
 "ディレクトリのインポートは Linux 上でのみ可能で、root で実行する必要がありま"
 "す。"
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr "イメージをイメージストアにインポートします"
 
@@ -3283,11 +3283,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3331,7 +3331,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
@@ -3378,6 +3378,16 @@ msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "不正なフォーマット %q"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, fuzzy, c-format
+msgid "Invalid export version %q: %w"
+msgstr "クライアントバージョン: %s\n"
 
 #: lxc/monitor.go:71
 #, c-format
@@ -3474,7 +3484,7 @@ msgstr "不正な送り先 %s"
 msgid "IsSM: %s (%s)"
 msgstr "IsSM: %s (%s)"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
@@ -3520,12 +3530,12 @@ msgstr "LXD サーバはクラスタの一部ではありません"
 msgid "Last Used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
@@ -3650,11 +3660,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 #, fuzzy
 msgid ""
 "List images\n"
@@ -4123,7 +4133,7 @@ msgstr "MTU"
 msgid "MTU: %d"
 msgstr "MTU: %d"
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr "イメージを public にする"
 
@@ -4188,11 +4198,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr "イメージのエイリアスを管理します"
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr "イメージを管理します"
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4224,7 +4234,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -4401,12 +4411,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4689,7 +4699,7 @@ msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 "複数のルールにマッチしました。すべて削除するには --force を指定してください"
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -4889,7 +4899,7 @@ msgstr "ネットワークゾーンレコード %s を削除しました"
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
@@ -4966,7 +4976,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
@@ -4978,7 +4988,7 @@ msgstr "\"カスタム\" のボリュームのみがスナップショットを�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
@@ -5041,7 +5051,7 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -5050,7 +5060,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5111,8 +5121,8 @@ msgstr "終了するには ctrl+c を押してください"
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -5185,7 +5195,7 @@ msgstr "プロファイル %s が %s から削除されました"
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr "新しいイメージに適用するプロファイル"
 
@@ -5202,11 +5212,11 @@ msgstr "移動先のインスタンスに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr "プロファイル:"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr "プロファイル: "
 
@@ -5229,11 +5239,11 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Project to use for the remote"
 msgstr "リモートで使用するプロジェクト"
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5333,7 +5343,7 @@ msgstr ""
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -5369,7 +5379,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5408,16 +5418,16 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5632,7 +5642,7 @@ msgstr "レンダー: %s (%s)"
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5728,7 +5738,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -5818,7 +5828,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5861,15 +5871,15 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定項目を設定します"
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -6166,7 +6176,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6229,11 +6239,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6242,7 +6252,7 @@ msgstr "インスタンスのメタデータファイルを表示します"
 msgid "Show instance metadata files"
 msgstr "インスタンスのメタデータファイルを表示します"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr "インスタンスもしくはサーバの設定を表示します"
 
@@ -6336,7 +6346,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
@@ -6365,7 +6375,7 @@ msgstr "信頼済みクライアントの設定を表示します"
 msgid "Show useful information about a cluster member"
 msgstr "クラスターメンバーについての情報を表示します"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
@@ -6377,7 +6387,7 @@ msgstr "ストレージプールの情報を表示します"
 msgid "Show warning"
 msgstr "警告を表示します"
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "サイズ: %.2fMB"
@@ -6409,7 +6419,7 @@ msgstr "ソケット %d:"
 msgid "Some instances failed to %s"
 msgstr "一部のインスタンスで %s が失敗しました"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr "取得元:"
 
@@ -6575,7 +6585,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6767,7 +6777,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
@@ -6790,7 +6804,7 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6832,7 +6846,7 @@ msgstr "スレッド:"
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスがクリーンにシャットダウンするまで待つ時間"
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
@@ -6861,7 +6875,7 @@ msgstr ""
 "さい\n"
 "仮想マシンの場合は \"lxc launch ubuntu:22.04 --vm\" と実行してみてください"
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6887,7 +6901,7 @@ msgstr "トランシーバータイプ: %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6903,12 +6917,12 @@ msgstr "転送モード。pull, push, relay のいずれか"
 msgid "Transfer mode. One of pull, push or relay."
 msgstr "転送モード。pull, push, relay のいずれか。"
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6952,7 +6966,7 @@ msgstr ""
 "確立する接続のタイプ: シリアルコンソールの場合は 'console'、SPICE でのグラ"
 "フィカル出力の場合は 'vga'"
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6967,7 +6981,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -7013,7 +7027,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7039,7 +7053,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -7056,11 +7070,11 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr "インスタンスもしくはサーバの設定を削除します"
 
@@ -7185,7 +7199,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7218,7 +7232,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr "コピー元の全てのプロファイルがターゲットに存在しません"
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -7232,7 +7246,13 @@ msgstr "上位デバイス"
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7317,7 +7337,7 @@ msgstr "WWN: %s"
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "スナップショットを含めずにインスタンスのみをバックアップするかどうか"
 
@@ -7358,7 +7378,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -7406,7 +7426,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7530,19 +7550,19 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr "[<remote>:]<image> <remote>:"
 
@@ -7555,15 +7575,15 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr "[<remote>:]<image> [<remote>:][<name>]"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7585,12 +7605,12 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
@@ -7628,7 +7648,7 @@ msgstr "[<remote>:]<instance> [[<remote>:]<instance>...]"
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
@@ -7822,7 +7842,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7869,7 +7889,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
@@ -8019,7 +8039,7 @@ msgstr "[<remote>:]<zone> <record> <type> <value>"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "[<remote>:]<zone> <record> [key=value...]"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr "[<remote>:][<instance>[/<snapshot>]]"
 
@@ -8027,11 +8047,11 @@ msgstr "[<remote>:][<instance>[/<snapshot>]]"
 msgid "[<remote>:][<instance>]"
 msgstr "[<remote>:][<instance>]"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
@@ -8061,7 +8081,7 @@ msgstr "現在値"
 msgid "description"
 msgstr "説明"
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr "無効"
 
@@ -8069,7 +8089,7 @@ msgstr "無効"
 msgid "driver"
 msgstr "ドライバ"
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr "有効"
 
@@ -8198,7 +8218,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 #, fuzzy
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
@@ -8216,7 +8236,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -8225,7 +8245,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8234,7 +8254,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -8278,7 +8298,7 @@ msgstr ""
 "   /etc/hosts ファイルを、インスタンス \"foo\" 内 (の /etc/hosts) にコピーし"
 "ます。"
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8729,7 +8749,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8760,7 +8780,7 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr "no"
 
@@ -8807,8 +8827,8 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "yes"
 
@@ -8900,9 +8920,6 @@ msgstr "yes"
 #~ msgid "%v (interrupt two more times to force)"
 #~ msgstr ""
 #~ "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
-
-#~ msgid "Invalid format %q"
-#~ msgstr "不正なフォーマット %q"
 
 #~ msgid "Remote operation canceled by user"
 #~ msgstr "リモート操作がユーザによってキャンセルされました"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -6489,7 +6489,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -840,11 +840,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -861,17 +861,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +982,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1147,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1173,7 +1173,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1227,8 +1227,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1261,15 +1261,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1317,16 +1317,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,7 +1547,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1697,9 +1697,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1710,12 +1710,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1783,8 +1783,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1864,7 +1864,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1984,11 +1984,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2180,48 +2180,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2288,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,7 +2474,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2827,11 +2827,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2839,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,11 +2873,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2887,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,6 +2987,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3077,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3560,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3815,12 +3825,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4081,7 +4091,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4278,7 +4288,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4351,7 +4361,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4363,7 +4373,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4426,7 +4436,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4495,8 +4505,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4567,7 +4577,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4584,11 +4594,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4621,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4719,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4792,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4999,7 +5009,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5097,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5186,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5220,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5454,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5515,11 +5525,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5537,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5621,7 +5631,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5659,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5671,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5703,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5869,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6043,7 +6053,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6078,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6110,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6132,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6156,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6172,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6218,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6233,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6265,7 +6279,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6305,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6321,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6427,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,7 +6472,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6472,7 +6486,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6552,7 +6572,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6590,7 +6610,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6634,7 +6654,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6773,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,15 +6797,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6807,11 +6827,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6848,7 +6868,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7029,7 +7049,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7074,7 +7094,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7215,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7243,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7275,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7283,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7355,7 +7375,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7384,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7379,7 +7399,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7412,7 +7432,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7715,7 +7735,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7739,7 +7759,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7784,7 +7804,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-03-03 09:58-0600\n"
+        "POT-Creation-Date: 2025-04-16 18:54+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -176,7 +176,7 @@ msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Note that the name is shown but cannot be modified"
 msgstr  ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid   "### This is a YAML representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -388,7 +388,7 @@ msgstr  ""
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -443,7 +443,7 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid   "--expanded cannot be used with a server"
 msgstr  ""
 
@@ -463,7 +463,7 @@ msgstr  ""
 msgid   "--refresh can only be used with instances"
 msgstr  ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843 lxc/info.go:461
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844 lxc/info.go:461
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
@@ -495,7 +495,7 @@ msgstr  ""
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid   "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr  ""
 
@@ -507,15 +507,15 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -698,7 +698,7 @@ msgstr  ""
 msgid   "Aliases already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid   "Aliases:"
 msgstr  ""
 
@@ -714,7 +714,7 @@ msgstr  ""
 msgid   "Alternative certificate name"
 msgstr  ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -798,11 +798,11 @@ msgstr  ""
 msgid   "Auto negotiation: %v"
 msgstr  ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid   "Auto update is only available in pull mode"
 msgstr  ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -819,17 +819,17 @@ msgstr  ""
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -847,7 +847,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -857,7 +857,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %s"
 msgstr  ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -938,7 +938,7 @@ msgstr  ""
 msgid   "CUDA Version: %v"
 msgstr  ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid   "Cached: %s"
 msgstr  ""
@@ -951,7 +951,7 @@ msgstr  ""
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
@@ -988,7 +988,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -1101,7 +1101,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:389 lxc/storage_volume.go:613 lxc/storage_volume.go:718 lxc/storage_volume.go:1020 lxc/storage_volume.go:1246 lxc/storage_volume.go:1375 lxc/storage_volume.go:1866 lxc/storage_volume.go:1964 lxc/storage_volume.go:2103 lxc/storage_volume.go:2263 lxc/storage_volume.go:2379 lxc/storage_volume.go:2440 lxc/storage_volume.go:2567 lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777 lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:389 lxc/storage_volume.go:613 lxc/storage_volume.go:718 lxc/storage_volume.go:1020 lxc/storage_volume.go:1246 lxc/storage_volume.go:1375 lxc/storage_volume.go:1866 lxc/storage_volume.go:1964 lxc/storage_volume.go:2103 lxc/storage_volume.go:2263 lxc/storage_volume.go:2379 lxc/storage_volume.go:2440 lxc/storage_volume.go:2567 lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1117,7 +1117,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1607 lxc/warning.go:93
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724 lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1136,7 +1136,7 @@ msgstr  ""
 msgid   "Compression algorithm to use (`none` for uncompressed)"
 msgstr  ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid   "Compression algorithm to use (none for uncompressed)"
 msgstr  ""
 
@@ -1152,7 +1152,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165 lxc/storage_volume.go:1197
+#: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600 lxc/project.go:370 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1165 lxc/storage_volume.go:1197
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1179,15 +1179,15 @@ msgstr  ""
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid   "Copy images between servers"
 msgstr  ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid   "Copy images between servers\n"
         "\n"
         "The auto-update flag instructs the server to keep this image up to date.\n"
@@ -1229,15 +1229,15 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:392
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278 lxc/storage_volume.go:392
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid   "Copy virtual machine images"
 msgstr  ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -1428,7 +1428,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1456,7 +1456,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1750
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:750 lxc/project.go:580 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1750
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1476,7 +1476,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1512,7 +1512,7 @@ msgstr  ""
 msgid   "Delete image aliases"
 msgstr  ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid   "Delete images"
 msgstr  ""
 
@@ -1580,7 +1580,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608 lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:309 lxc/storage_volume.go:385 lxc/storage_volume.go:606 lxc/storage_volume.go:715 lxc/storage_volume.go:802 lxc/storage_volume.go:907 lxc/storage_volume.go:1011 lxc/storage_volume.go:1232 lxc/storage_volume.go:1363 lxc/storage_volume.go:1525 lxc/storage_volume.go:1609 lxc/storage_volume.go:1862 lxc/storage_volume.go:1961 lxc/storage_volume.go:2088 lxc/storage_volume.go:2246 lxc/storage_volume.go:2367 lxc/storage_volume.go:2429 lxc/storage_volume.go:2565 lxc/storage_volume.go:2648 lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:488 lxc/cluster.go:532 lxc/cluster.go:590 lxc/cluster.go:681 lxc/cluster.go:775 lxc/cluster.go:898 lxc/cluster.go:982 lxc/cluster.go:1092 lxc/cluster.go:1180 lxc/cluster.go:1304 lxc/cluster.go:1334 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958 lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175 lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410 lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635 lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701 lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338 lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949 lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609 lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:35 lxc/profile.go:110 lxc/profile.go:185 lxc/profile.go:276 lxc/profile.go:358 lxc/profile.go:440 lxc/profile.go:498 lxc/profile.go:634 lxc/profile.go:710 lxc/profile.go:867 lxc/profile.go:955 lxc/profile.go:1015 lxc/profile.go:1104 lxc/profile.go:1168 lxc/project.go:31 lxc/project.go:97 lxc/project.go:197 lxc/project.go:268 lxc/project.go:404 lxc/project.go:478 lxc/project.go:598 lxc/project.go:663 lxc/project.go:751 lxc/project.go:795 lxc/project.go:856 lxc/project.go:923 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:21 lxc/restore.go:22 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:66 lxc/storage_volume.go:239 lxc/storage_volume.go:309 lxc/storage_volume.go:385 lxc/storage_volume.go:606 lxc/storage_volume.go:715 lxc/storage_volume.go:802 lxc/storage_volume.go:907 lxc/storage_volume.go:1011 lxc/storage_volume.go:1232 lxc/storage_volume.go:1363 lxc/storage_volume.go:1525 lxc/storage_volume.go:1609 lxc/storage_volume.go:1862 lxc/storage_volume.go:1961 lxc/storage_volume.go:2088 lxc/storage_volume.go:2246 lxc/storage_volume.go:2367 lxc/storage_volume.go:2429 lxc/storage_volume.go:2565 lxc/storage_volume.go:2649 lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1654,7 +1654,7 @@ msgstr  ""
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -1695,7 +1695,7 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid   "Display images from all projects"
 msgstr  ""
 
@@ -1772,11 +1772,11 @@ msgstr  ""
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -1848,7 +1848,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1784 lxc/warning.go:236
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766 lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1896,12 +1896,12 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082 lxc/project.go:726 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2179 lxc/storage_volume.go:2217
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid   "Error unsetting properties: %v"
 msgstr  ""
@@ -1950,47 +1950,47 @@ msgstr  ""
 msgid   "Expires at"
 msgstr  ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid   "Export and download images"
 msgstr  ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid   "Export and download images\n"
         "\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid   "Export custom storage volume"
 msgstr  ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid   "Export instance backups"
 msgstr  ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
@@ -2003,7 +2003,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142 lxc/image_alias.go:268
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143 lxc/image_alias.go:268
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2056,12 +2056,12 @@ msgstr  ""
 msgid   "Failed deleting instance snapshot %q in project %q: %w"
 msgstr  ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid   "Failed fetching fingerprint %q for alias %q: %w"
 msgstr  ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
@@ -2110,7 +2110,7 @@ msgstr  ""
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2145,7 +2145,7 @@ msgstr  ""
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
@@ -2173,7 +2173,7 @@ msgstr  ""
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -2233,7 +2233,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1626 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:727 lxc/project.go:480 lxc/project.go:925 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1626 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2293,7 +2293,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2301,7 +2301,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2577,11 +2577,11 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid   "Image copied successfully!"
 msgstr  ""
 
@@ -2589,25 +2589,25 @@ msgstr  ""
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2615,7 +2615,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2623,11 +2623,11 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid   "Import custom storage volumes"
 msgstr  ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid   "Import image into the image store\n"
         "\n"
         "Directory import is only available on Linux and must be performed as root.\n"
@@ -2635,7 +2635,7 @@ msgid   "Import image into the image store\n"
         "Descriptive properties can be set by providing key=value pairs. Example: os=Ubuntu release=noble variant=cloud."
 msgstr  ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid   "Import images into the image store"
 msgstr  ""
 
@@ -2643,11 +2643,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2691,7 +2691,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid   "Instance name must be specified"
 msgstr  ""
 
@@ -2735,6 +2735,16 @@ msgstr  ""
 #: lxc/list.go:649
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
+msgstr  ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid   "Invalid export version %q"
+msgstr  ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid   "Invalid export version %q: %w"
 msgstr  ""
 
 #: lxc/monitor.go:71
@@ -2822,7 +2832,7 @@ msgstr  ""
 msgid   "IsSM: %s (%s)"
 msgstr  ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
@@ -2863,12 +2873,12 @@ msgstr  ""
 msgid   "Last Used: %s"
 msgstr  ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid   "Last used: never"
 msgstr  ""
 
@@ -2985,11 +2995,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -3288,7 +3298,7 @@ msgstr  ""
 msgid   "MTU: %d"
 msgstr  ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid   "Make image public"
 msgstr  ""
 
@@ -3348,11 +3358,11 @@ msgstr  ""
 msgid   "Manage image aliases"
 msgstr  ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid   "Manage images"
 msgstr  ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid   "Manage images\n"
         "\n"
         "In LXD instances are created from images. Those images were themselves\n"
@@ -3370,7 +3380,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -3538,12 +3548,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3733,7 +3743,7 @@ msgstr  ""
 msgid   "Multiple rules match. Use --force to remove them all"
 msgstr  ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -3920,7 +3930,7 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid   "New aliases to add to the image"
 msgstr  ""
 
@@ -3992,7 +4002,7 @@ msgstr  ""
 msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
@@ -4004,7 +4014,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
@@ -4067,7 +4077,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1774 lxc/warning.go:213
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749 lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4075,7 +4085,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4133,7 +4143,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166 lxc/storage_volume.go:1198
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601 lxc/project.go:371 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1166 lxc/storage_volume.go:1198
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4198,7 +4208,7 @@ msgstr  ""
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid   "Profile to apply to the new image"
 msgstr  ""
 
@@ -4215,11 +4225,11 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid   "Profiles:"
 msgstr  ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid   "Profiles: "
 msgstr  ""
 
@@ -4242,11 +4252,11 @@ msgstr  ""
 msgid   "Project to use for the remote"
 msgstr  ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid   "Property not found"
 msgstr  ""
 
@@ -4324,7 +4334,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -4360,7 +4370,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4397,16 +4407,16 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4612,7 +4622,7 @@ msgstr  ""
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4698,7 +4708,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid   "SIZE"
 msgstr  ""
 
@@ -4786,7 +4796,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4816,15 +4826,15 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid   "Set image properties"
 msgstr  ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid   "Set instance or server configuration keys"
 msgstr  ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid   "Set instance or server configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -5036,7 +5046,7 @@ msgstr  ""
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid   "Set the key as an instance property"
 msgstr  ""
 
@@ -5093,11 +5103,11 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -5105,7 +5115,7 @@ msgstr  ""
 msgid   "Show instance metadata files"
 msgstr  ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid   "Show instance or server configurations"
 msgstr  ""
 
@@ -5197,7 +5207,7 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid   "Show the expanded configuration"
 msgstr  ""
 
@@ -5225,7 +5235,7 @@ msgstr  ""
 msgid   "Show useful information about a cluster member"
 msgstr  ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid   "Show useful information about images"
 msgstr  ""
 
@@ -5237,7 +5247,7 @@ msgstr  ""
 msgid   "Show warning"
 msgstr  ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid   "Size: %.2fMiB"
 msgstr  ""
@@ -5269,7 +5279,7 @@ msgstr  ""
 msgid   "Some instances failed to %s"
 msgstr  ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid   "Source:"
 msgstr  ""
 
@@ -5435,7 +5445,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1748 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1748 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5610,7 +5620,11 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid   "The server doesn't support setting the metadata format version"
+msgstr  ""
+
+#: lxc/move.go:316
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
@@ -5630,7 +5644,7 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
@@ -5658,7 +5672,7 @@ msgstr  ""
 msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -5679,7 +5693,7 @@ msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824 lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -5702,7 +5716,7 @@ msgstr  ""
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
@@ -5718,12 +5732,12 @@ msgstr  ""
 msgid   "Transfer mode. One of pull, push or relay."
 msgstr  ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5762,7 +5776,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1470
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1470
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5776,7 +5790,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -5820,7 +5834,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1790 lxc/warning.go:242
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772 lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5845,7 +5859,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5861,11 +5875,11 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid   "Unset image properties"
 msgstr  ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid   "Unset instance or server configuration keys"
 msgstr  ""
 
@@ -5981,7 +5995,7 @@ msgstr  ""
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
@@ -6010,7 +6024,7 @@ msgstr  ""
 msgid   "Update the target profile from the source if it already exists"
 msgstr  ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -6024,7 +6038,11 @@ msgstr  ""
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid   "Use a different metadata format version than the latest one supported by the server"
+msgstr  ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6102,7 +6120,7 @@ msgstr  ""
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid   "Whether or not to only backup the instance (without snapshots)"
 msgstr  ""
 
@@ -6134,7 +6152,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -6170,7 +6188,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6282,19 +6300,19 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid   "[<remote>:]<image> <remote>:"
 msgstr  ""
 
@@ -6306,15 +6324,15 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330 lxc/config_device.go:762 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330 lxc/config_device.go:762 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6334,11 +6352,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
@@ -6374,7 +6392,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr  ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
@@ -6538,7 +6556,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6578,7 +6596,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
@@ -6714,7 +6732,7 @@ msgstr  ""
 msgid   "[<remote>:]<zone> <record> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid   "[<remote>:][<instance>[/<snapshot>]]"
 msgstr  ""
 
@@ -6722,11 +6740,11 @@ msgstr  ""
 msgid   "[<remote>:][<instance>]"
 msgstr  ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid   "[<remote>:][<instance>] <key>"
 msgstr  ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
@@ -6754,7 +6772,7 @@ msgstr  ""
 msgid   "description"
 msgstr  ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid   "disabled"
 msgstr  ""
 
@@ -6762,7 +6780,7 @@ msgstr  ""
 msgid   "driver"
 msgstr  ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid   "enabled"
 msgstr  ""
 
@@ -6838,7 +6856,7 @@ msgid   "lxc config edit <instance> < instance.yaml\n"
         "    Update the instance configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will set a CPU limit of \"2\" for the instance.\n"
         "\n"
@@ -6846,17 +6864,17 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 instance."
 msgstr  ""
@@ -6883,7 +6901,7 @@ msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid   "lxc image edit <image>\n"
         "    Launch a text editor to edit the properties\n"
         "\n"
@@ -7135,7 +7153,7 @@ msgid   "lxc storage volume create p1 v1\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
@@ -7156,7 +7174,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid   "no"
 msgstr  ""
 
@@ -7201,7 +7219,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002 lxc/image.go:1207
 msgid   "yes"
 msgstr  ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-04-16 18:54+0200\n"
+        "POT-Creation-Date: 2025-04-16 19:01+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6039,7 +6039,7 @@ msgid   "Usage: %s"
 msgstr  ""
 
 #: lxc/export.go:48 lxc/storage_volume.go:2657
-msgid   "Use a different metadata format version than the latest one supported by the server"
+msgid   "Use a different metadata format version than the latest one supported by the server (to support imports on older LXD versions)"
 msgstr  ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -6716,7 +6716,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -267,7 +267,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -644,7 +644,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -699,7 +699,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -765,15 +765,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -964,7 +964,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1067,11 +1067,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1088,17 +1088,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1118,7 +1118,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1128,7 +1128,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1222,7 +1222,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1374,8 +1374,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1400,7 +1400,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1416,7 +1416,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1437,7 +1437,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1454,8 +1454,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1488,15 +1488,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1544,16 +1544,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1745,7 +1745,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1774,7 +1774,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1800,7 +1800,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1924,9 +1924,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1937,12 +1937,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2010,8 +2010,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2091,7 +2091,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2132,7 +2132,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2211,11 +2211,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2287,7 +2287,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2350,7 +2350,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2407,48 +2407,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2515,12 +2515,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2569,7 +2569,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2604,7 +2604,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2701,7 +2701,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2768,7 +2768,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2776,7 +2776,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3054,11 +3054,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3066,25 +3066,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3092,7 +3092,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3100,11 +3100,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3114,7 +3114,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3122,11 +3122,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3170,7 +3170,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3214,6 +3214,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3304,7 +3314,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3348,12 +3358,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3471,11 +3481,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3787,7 +3797,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3849,11 +3859,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3872,7 +3882,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4042,12 +4052,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4308,7 +4318,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4505,7 +4515,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4578,7 +4588,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4590,7 +4600,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4653,7 +4663,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4662,7 +4672,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4722,8 +4732,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4794,7 +4804,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4811,11 +4821,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4838,11 +4848,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4936,7 +4946,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4972,7 +4982,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5009,16 +5019,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5226,7 +5236,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5314,7 +5324,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5403,7 +5413,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5437,15 +5447,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5681,7 +5691,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5742,11 +5752,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5754,7 +5764,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5848,7 +5858,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5876,7 +5886,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5888,7 +5898,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5920,7 +5930,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6086,7 +6096,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6270,7 +6280,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6291,7 +6305,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6323,7 +6337,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6345,7 +6359,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6369,7 +6383,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6385,12 +6399,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6431,7 +6445,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6446,7 +6460,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6492,7 +6506,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6518,7 +6532,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6534,11 +6548,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6654,7 +6668,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6685,7 +6699,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6699,7 +6713,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6779,7 +6799,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6817,7 +6837,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6861,7 +6881,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6980,19 +7000,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7004,15 +7024,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7034,11 +7054,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7075,7 +7095,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7256,7 +7276,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7301,7 +7321,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7442,7 +7462,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7450,11 +7470,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7482,7 +7502,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7490,7 +7510,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7582,7 +7602,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7591,13 +7611,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7606,7 +7626,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7639,7 +7659,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7942,7 +7962,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7966,7 +7986,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8011,8 +8031,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6754,7 +6754,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -682,7 +682,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -737,7 +737,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -803,15 +803,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1105,11 +1105,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1126,17 +1126,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1156,7 +1156,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1247,7 +1247,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1260,7 +1260,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1297,7 +1297,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1412,8 +1412,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1438,7 +1438,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1475,7 +1475,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1492,8 +1492,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1526,15 +1526,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1582,16 +1582,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1783,7 +1783,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1812,7 +1812,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1874,7 +1874,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1962,9 +1962,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1975,12 +1975,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2048,8 +2048,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2129,7 +2129,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2170,7 +2170,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2249,11 +2249,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2325,7 +2325,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2378,7 +2378,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2388,7 +2388,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2445,48 +2445,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2553,12 +2553,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2607,7 +2607,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2642,7 +2642,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2671,7 +2671,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2739,7 +2739,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2806,7 +2806,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2814,7 +2814,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3092,11 +3092,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3104,25 +3104,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3130,7 +3130,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3138,11 +3138,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3152,7 +3152,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3208,7 +3208,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3252,6 +3252,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3342,7 +3352,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3386,12 +3396,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3509,11 +3519,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3825,7 +3835,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3887,11 +3897,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3910,7 +3920,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4080,12 +4090,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4346,7 +4356,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4543,7 +4553,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4616,7 +4626,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4628,7 +4638,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4691,7 +4701,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4700,7 +4710,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4760,8 +4770,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4832,7 +4842,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4849,11 +4859,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4876,11 +4886,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4974,7 +4984,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5010,7 +5020,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5047,16 +5057,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5264,7 +5274,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5352,7 +5362,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5441,7 +5451,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5475,15 +5485,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5719,7 +5729,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5780,11 +5790,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5792,7 +5802,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5886,7 +5896,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5914,7 +5924,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5926,7 +5936,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5958,7 +5968,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6124,7 +6134,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6308,7 +6318,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6329,7 +6343,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6361,7 +6375,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6383,7 +6397,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6407,7 +6421,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6423,12 +6437,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6469,7 +6483,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6484,7 +6498,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6530,7 +6544,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6556,7 +6570,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6572,11 +6586,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6692,7 +6706,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6723,7 +6737,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6737,7 +6751,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6817,7 +6837,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6855,7 +6875,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6899,7 +6919,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7018,19 +7038,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7042,15 +7062,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7072,11 +7092,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7113,7 +7133,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7294,7 +7314,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7339,7 +7359,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7480,7 +7500,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7488,11 +7508,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7520,7 +7540,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7528,7 +7548,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7620,7 +7640,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7629,13 +7649,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7644,7 +7664,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7677,7 +7697,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7980,7 +8000,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8004,7 +8024,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8049,8 +8069,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -6489,7 +6489,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -840,11 +840,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -861,17 +861,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +982,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1147,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1173,7 +1173,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1227,8 +1227,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1261,15 +1261,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1317,16 +1317,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,7 +1547,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1697,9 +1697,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1710,12 +1710,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1783,8 +1783,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1864,7 +1864,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1984,11 +1984,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2180,48 +2180,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2288,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,7 +2474,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2827,11 +2827,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2839,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,11 +2873,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2887,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,6 +2987,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3077,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3560,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3815,12 +3825,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4081,7 +4091,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4278,7 +4288,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4351,7 +4361,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4363,7 +4373,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4426,7 +4436,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4495,8 +4505,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4567,7 +4577,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4584,11 +4594,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4621,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4719,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4792,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4999,7 +5009,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5097,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5186,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5220,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5454,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5515,11 +5525,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5537,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5621,7 +5631,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5659,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5671,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5703,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5869,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6043,7 +6053,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6078,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6110,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6132,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6156,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6172,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6218,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6233,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6265,7 +6279,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6305,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6321,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6427,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,7 +6472,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6472,7 +6486,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6552,7 +6572,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6590,7 +6610,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6634,7 +6654,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6773,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,15 +6797,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6807,11 +6827,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6848,7 +6868,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7029,7 +7049,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7074,7 +7094,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7215,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7243,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7275,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7283,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7355,7 +7375,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7384,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7379,7 +7399,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7412,7 +7432,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7715,7 +7735,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7739,7 +7759,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7784,7 +7804,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -270,7 +270,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -668,7 +668,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -727,7 +727,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 #, fuzzy
 msgid "--expanded cannot be used with a server"
 msgstr "--refresh só pode ser usado com containers"
@@ -752,7 +752,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--refresh can only be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 #, fuzzy
 msgid "--target cannot be used with instances"
@@ -787,7 +787,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -800,15 +800,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -1007,7 +1007,7 @@ msgstr "Nome do alias ausente"
 msgid "Aliases already exists: %s"
 msgstr "Alias %s já existe"
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Aliases:"
 
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Aceitar certificado"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitetura: %s"
@@ -1118,11 +1118,11 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
@@ -1140,17 +1140,17 @@ msgstr "Criar projetos"
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -1170,7 +1170,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1180,7 +1180,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
@@ -1261,7 +1261,7 @@ msgstr "CRIADO EM"
 msgid "CUDA Version: %v"
 msgstr "Versão CUDA: %v"
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr "Em cache: %s"
@@ -1275,7 +1275,7 @@ msgstr "Em cache: %s"
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
@@ -1313,7 +1313,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1430,8 +1430,8 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1456,7 +1456,7 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1472,7 +1472,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1499,7 +1499,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 #, fuzzy
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1519,8 +1519,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1554,15 +1554,15 @@ msgstr "Ignorar o estado do container"
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr "Copiar imagens entre servidores"
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1611,17 +1611,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
@@ -1832,7 +1832,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1862,7 +1862,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1929,7 +1929,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -2026,9 +2026,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -2039,12 +2039,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2112,8 +2112,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
@@ -2197,7 +2197,7 @@ msgstr "Em cache: %s"
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
@@ -2241,7 +2241,7 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Criar projetos"
@@ -2329,11 +2329,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2418,7 +2418,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2471,7 +2471,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2481,7 +2481,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2539,48 +2539,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2593,7 +2593,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2647,12 +2647,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
@@ -2701,7 +2701,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2736,7 +2736,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2765,7 +2765,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2834,7 +2834,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -2910,7 +2910,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3208,11 +3208,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3220,25 +3220,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3247,7 +3247,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3255,11 +3255,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3269,7 +3269,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3277,11 +3277,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3325,7 +3325,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3370,6 +3370,16 @@ msgstr ""
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "Editar arquivos no container"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, fuzzy, c-format
+msgid "Invalid export version %q: %w"
+msgstr "Versão do cliente: %s\n"
 
 #: lxc/monitor.go:71
 #, fuzzy, c-format
@@ -3461,7 +3471,7 @@ msgstr "Editar arquivos no container"
 msgid "IsSM: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3505,12 +3515,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Criado: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3634,11 +3644,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3955,7 +3965,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -4022,11 +4032,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4045,7 +4055,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4236,12 +4246,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4519,7 +4529,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4716,7 +4726,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4789,7 +4799,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4801,7 +4811,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4864,7 +4874,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4873,7 +4883,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4934,8 +4944,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -5006,7 +5016,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 #, fuzzy
 msgid "Profile to apply to the new image"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
@@ -5026,12 +5036,12 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 #, fuzzy
 msgid "Profiles:"
 msgstr "Copiar perfis"
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 #, fuzzy
 msgid "Profiles: "
 msgstr "Copiar perfis"
@@ -5055,11 +5065,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5153,7 +5163,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5190,7 +5200,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5229,16 +5239,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5463,7 +5473,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5561,7 +5571,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5650,7 +5660,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5687,17 +5697,17 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 #, fuzzy
 msgid "Set instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5948,7 +5958,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6013,11 +6023,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -6027,7 +6037,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Show instance metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 #, fuzzy
 msgid "Show instance or server configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6134,7 +6144,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6165,7 +6175,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show useful information about a cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6177,7 +6187,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -6209,7 +6219,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6376,7 +6386,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6564,7 +6574,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6585,7 +6599,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
@@ -6619,7 +6633,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6641,7 +6655,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6665,7 +6679,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6681,12 +6695,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6729,7 +6743,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6744,7 +6758,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6791,7 +6805,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6817,7 +6831,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6837,12 +6851,12 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 #, fuzzy
 msgid "Unset instance or server configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6977,7 +6991,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -7009,7 +7023,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7024,7 +7038,13 @@ msgstr "Editar arquivos no container"
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7104,7 +7124,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -7142,7 +7162,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7191,7 +7211,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7328,21 +7348,21 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -7355,15 +7375,15 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7385,12 +7405,12 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7430,7 +7450,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7629,7 +7649,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7679,7 +7699,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
@@ -7841,7 +7861,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7849,11 +7869,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7885,7 +7905,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7893,7 +7913,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7985,7 +8005,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7994,13 +8014,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8009,7 +8029,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -8042,7 +8062,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8345,7 +8365,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8369,7 +8389,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8414,8 +8434,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "sim"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -7041,7 +7041,7 @@ msgstr "Criado: %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -274,7 +274,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the image properties.\n"
@@ -677,7 +677,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -732,7 +732,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -803,16 +803,16 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr "Принять сертификат"
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -1115,11 +1115,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
@@ -1137,17 +1137,17 @@ msgstr "Доступные команды:"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, fuzzy, c-format
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1177,7 +1177,7 @@ msgstr "Имя контейнера: %s"
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1260,7 +1260,7 @@ msgstr "СОЗДАН"
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1273,7 +1273,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1310,7 +1310,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1430,8 +1430,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1456,7 +1456,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1472,7 +1472,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1493,7 +1493,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1510,8 +1510,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1545,15 +1545,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1602,17 +1602,17 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 #, fuzzy
 msgid "Copy virtual machine images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -1823,7 +1823,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1853,7 +1853,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1917,7 +1917,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -2013,9 +2013,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -2026,12 +2026,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2099,8 +2099,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2182,7 +2182,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2227,7 +2227,7 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 #, fuzzy
 msgid "Display images from all projects"
 msgstr "Копирование образа: %s"
@@ -2311,11 +2311,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2395,7 +2395,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2448,7 +2448,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2458,7 +2458,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, fuzzy, c-format
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2519,53 +2519,53 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 #, fuzzy
 msgid "Export and download images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 #, fuzzy
 msgid "Export instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 #, fuzzy
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
@@ -2578,7 +2578,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2632,12 +2632,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, fuzzy, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
@@ -2686,7 +2686,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2721,7 +2721,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2895,7 +2895,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -3190,11 +3190,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3202,25 +3202,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3228,7 +3228,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3236,12 +3236,12 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3251,7 +3251,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 #, fuzzy
 msgid "Import images into the image store"
 msgstr "Копирование образа: %s"
@@ -3261,11 +3261,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3311,7 +3311,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
@@ -3356,6 +3356,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, fuzzy, c-format
+msgid "Invalid export version %q"
+msgstr "Имя контейнера: %s"
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3448,7 +3458,7 @@ msgstr "Имя контейнера: %s"
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3492,12 +3502,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3624,11 +3634,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3951,7 +3961,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -4018,11 +4028,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -4041,7 +4051,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4235,12 +4245,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4521,7 +4531,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4720,7 +4730,7 @@ msgstr " Использование сети:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4795,7 +4805,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4807,7 +4817,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4870,7 +4880,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4879,7 +4889,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4940,8 +4950,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -5012,7 +5022,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -5029,11 +5039,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -5056,11 +5066,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -5154,7 +5164,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -5190,7 +5200,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5230,17 +5240,17 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, fuzzy, c-format
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5461,7 +5471,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5556,7 +5566,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5645,7 +5655,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5681,15 +5691,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5939,7 +5949,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -6003,11 +6013,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6017,7 +6027,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Show instance metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -6121,7 +6131,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -6152,7 +6162,7 @@ msgstr "Копирование образа: %s"
 msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -6164,7 +6174,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, fuzzy, c-format
 msgid "Size: %.2fMiB"
 msgstr "Авто-обновление: %s"
@@ -6197,7 +6207,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6367,7 +6377,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6551,7 +6561,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6572,7 +6586,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 #, fuzzy
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
@@ -6605,7 +6619,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6627,7 +6641,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6651,7 +6665,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6667,12 +6681,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6714,7 +6728,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6729,7 +6743,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6775,7 +6789,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6801,7 +6815,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6819,11 +6833,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6957,7 +6971,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6989,7 +7003,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -7004,7 +7018,13 @@ msgstr "Копирование образа: %s"
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7084,7 +7104,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -7122,7 +7142,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7194,7 +7214,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7409,7 +7429,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7417,7 +7437,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7425,7 +7445,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7433,7 +7453,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 #, fuzzy
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
@@ -7457,7 +7477,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 #, fuzzy
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
@@ -7465,7 +7485,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7473,7 +7493,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7515,7 +7535,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7523,7 +7543,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7596,7 +7616,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 #, fuzzy
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
@@ -7937,7 +7957,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8022,7 +8042,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8299,7 +8319,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 #, fuzzy
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
@@ -8315,7 +8335,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
@@ -8323,7 +8343,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 #, fuzzy
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
@@ -8371,7 +8391,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -8379,7 +8399,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -8471,7 +8491,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -8480,13 +8500,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8495,7 +8515,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -8528,7 +8548,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -8831,7 +8851,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8855,7 +8875,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -8900,8 +8920,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr "да"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -7021,7 +7021,7 @@ msgstr "Авто-обновление: %s"
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -844,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -865,17 +865,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1177,7 +1177,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1231,8 +1231,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1265,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1321,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,7 +1551,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1701,9 +1701,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1714,12 +1714,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1988,11 +1988,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2184,48 +2184,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2292,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,7 +2478,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2553,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2831,11 +2831,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2843,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,11 +2877,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2891,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2947,7 +2947,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,6 +2991,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3081,7 +3091,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3135,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3258,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3564,7 +3574,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3636,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3659,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3819,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4085,7 +4095,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4282,7 +4292,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4355,7 +4365,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4367,7 +4377,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4430,7 +4440,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4449,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4499,8 +4509,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4571,7 +4581,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4588,11 +4598,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4625,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4723,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4796,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5003,7 +5013,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5101,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5190,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5224,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5458,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5519,11 +5529,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5541,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5625,7 +5635,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5663,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5675,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5707,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5873,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6047,7 +6057,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6082,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6114,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6136,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6160,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6176,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6222,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6237,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6269,7 +6283,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6309,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6325,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6431,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6462,7 +6476,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6476,7 +6490,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6556,7 +6576,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6594,7 +6614,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6638,7 +6658,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6777,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,15 +6801,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6811,11 +6831,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6852,7 +6872,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7033,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7078,7 +7098,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7219,7 +7239,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7247,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7279,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7287,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7359,7 +7379,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7388,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7383,7 +7403,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7416,7 +7436,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7719,7 +7739,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7743,7 +7763,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7788,7 +7808,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -6493,7 +6493,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -6493,7 +6493,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -844,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -865,17 +865,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1177,7 +1177,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1231,8 +1231,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1265,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1321,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,7 +1551,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1701,9 +1701,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1714,12 +1714,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1988,11 +1988,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2184,48 +2184,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2292,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,7 +2478,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2553,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2831,11 +2831,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2843,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,11 +2877,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2891,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2947,7 +2947,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,6 +2991,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3081,7 +3091,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3135,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3258,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3564,7 +3574,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3636,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3659,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3819,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4085,7 +4095,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4282,7 +4292,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4355,7 +4365,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4367,7 +4377,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4430,7 +4440,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4449,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4499,8 +4509,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4571,7 +4581,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4588,11 +4598,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4625,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4723,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4796,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5003,7 +5013,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5101,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5190,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5224,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5458,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5519,11 +5529,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5541,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5625,7 +5635,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5663,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5675,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5707,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5873,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6047,7 +6057,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6082,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6114,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6136,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6160,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6176,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6222,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6237,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6269,7 +6283,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6309,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6325,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6431,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6462,7 +6476,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6476,7 +6490,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6556,7 +6576,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6594,7 +6614,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6638,7 +6658,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6777,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,15 +6801,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6811,11 +6831,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6852,7 +6872,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7033,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7078,7 +7098,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7219,7 +7239,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7247,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7279,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7287,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7359,7 +7379,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7388,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7383,7 +7403,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7416,7 +7436,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7719,7 +7739,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7743,7 +7763,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7788,7 +7808,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -6489,7 +6489,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -492,7 +492,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -538,15 +538,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -753,7 +753,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -840,11 +840,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -861,17 +861,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -891,7 +891,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -982,7 +982,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -995,7 +995,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1032,7 +1032,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1147,8 +1147,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1173,7 +1173,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1227,8 +1227,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1261,15 +1261,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1317,16 +1317,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1547,7 +1547,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1573,7 +1573,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1697,9 +1697,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1710,12 +1710,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1783,8 +1783,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1864,7 +1864,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1905,7 +1905,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1984,11 +1984,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2180,48 +2180,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2288,12 +2288,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2342,7 +2342,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2377,7 +2377,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2474,7 +2474,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2549,7 +2549,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2827,11 +2827,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2839,25 +2839,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2865,7 +2865,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2873,11 +2873,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2887,7 +2887,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2895,11 +2895,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2943,7 +2943,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,6 +2987,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3077,7 +3087,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3121,12 +3131,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3244,11 +3254,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3560,7 +3570,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3622,11 +3632,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3645,7 +3655,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3815,12 +3825,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4081,7 +4091,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4278,7 +4288,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4351,7 +4361,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4363,7 +4373,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4426,7 +4436,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4435,7 +4445,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4495,8 +4505,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4567,7 +4577,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4584,11 +4594,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4611,11 +4621,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4709,7 +4719,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4745,7 +4755,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4782,16 +4792,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4999,7 +5009,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5087,7 +5097,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5176,7 +5186,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5210,15 +5220,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5454,7 +5464,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5515,11 +5525,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5527,7 +5537,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5621,7 +5631,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5649,7 +5659,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5661,7 +5671,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5693,7 +5703,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5859,7 +5869,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6043,7 +6053,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6064,7 +6078,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6096,7 +6110,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6118,7 +6132,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6142,7 +6156,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6158,12 +6172,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6204,7 +6218,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6219,7 +6233,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6265,7 +6279,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6291,7 +6305,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6307,11 +6321,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6427,7 +6441,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6458,7 +6472,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6472,7 +6486,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6552,7 +6572,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6590,7 +6610,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6634,7 +6654,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6753,19 +6773,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6777,15 +6797,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6807,11 +6827,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6848,7 +6868,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7029,7 +7049,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7074,7 +7094,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7215,7 +7235,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7223,11 +7243,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7255,7 +7275,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7263,7 +7283,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7355,7 +7375,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7364,13 +7384,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7379,7 +7399,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7412,7 +7432,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7715,7 +7735,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7739,7 +7759,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7784,7 +7804,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -193,7 +193,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -529,7 +529,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -542,15 +542,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -844,11 +844,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -865,17 +865,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -986,7 +986,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -999,7 +999,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1151,8 +1151,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1177,7 +1177,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1231,8 +1231,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1265,15 +1265,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1321,16 +1321,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1551,7 +1551,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1577,7 +1577,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1701,9 +1701,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1714,12 +1714,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1787,8 +1787,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1988,11 +1988,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2064,7 +2064,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2117,7 +2117,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2127,7 +2127,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2184,48 +2184,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2238,7 +2238,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2292,12 +2292,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2346,7 +2346,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2381,7 +2381,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2410,7 +2410,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2478,7 +2478,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2553,7 +2553,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2831,11 +2831,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2843,25 +2843,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2877,11 +2877,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2891,7 +2891,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2899,11 +2899,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2947,7 +2947,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,6 +2991,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3081,7 +3091,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3125,12 +3135,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3248,11 +3258,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3564,7 +3574,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3626,11 +3636,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3649,7 +3659,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3819,12 +3829,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4085,7 +4095,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4282,7 +4292,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4355,7 +4365,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4367,7 +4377,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4430,7 +4440,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4439,7 +4449,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4499,8 +4509,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4571,7 +4581,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4588,11 +4598,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4615,11 +4625,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4713,7 +4723,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4749,7 +4759,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4786,16 +4796,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5003,7 +5013,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5091,7 +5101,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5180,7 +5190,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5214,15 +5224,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5458,7 +5468,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5519,11 +5529,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5531,7 +5541,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5625,7 +5635,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5653,7 +5663,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5665,7 +5675,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5697,7 +5707,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5863,7 +5873,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6047,7 +6057,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6068,7 +6082,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6100,7 +6114,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6122,7 +6136,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6146,7 +6160,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6162,12 +6176,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6208,7 +6222,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6223,7 +6237,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6269,7 +6283,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6295,7 +6309,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6311,11 +6325,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6431,7 +6445,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6462,7 +6476,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6476,7 +6490,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6556,7 +6576,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6594,7 +6614,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6638,7 +6658,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6757,19 +6777,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6781,15 +6801,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6811,11 +6831,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6852,7 +6872,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7033,7 +7053,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7078,7 +7098,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7219,7 +7239,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7227,11 +7247,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7259,7 +7279,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7267,7 +7287,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7359,7 +7379,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7368,13 +7388,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7383,7 +7403,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7416,7 +7436,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7719,7 +7739,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7743,7 +7763,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7788,7 +7808,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -6493,7 +6493,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -6653,7 +6653,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -277,7 +277,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -581,7 +581,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -636,7 +636,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -656,7 +656,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -689,7 +689,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -702,15 +702,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -901,7 +901,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -917,7 +917,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -1004,11 +1004,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -1025,17 +1025,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1065,7 +1065,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1311,8 +1311,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1337,7 +1337,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1353,7 +1353,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1391,8 +1391,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1425,15 +1425,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1481,16 +1481,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1682,7 +1682,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1711,7 +1711,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1737,7 +1737,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1773,7 +1773,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1861,9 +1861,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1874,12 +1874,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1947,8 +1947,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -2028,7 +2028,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -2069,7 +2069,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -2148,11 +2148,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2224,7 +2224,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2287,7 +2287,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2344,48 +2344,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2398,7 +2398,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2452,12 +2452,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2506,7 +2506,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2541,7 +2541,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2570,7 +2570,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2638,7 +2638,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2705,7 +2705,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2713,7 +2713,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2991,11 +2991,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -3003,25 +3003,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3037,11 +3037,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -3051,7 +3051,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -3059,11 +3059,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3107,7 +3107,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3151,6 +3151,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3241,7 +3251,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3285,12 +3295,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3408,11 +3418,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3724,7 +3734,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3786,11 +3796,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3809,7 +3819,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3979,12 +3989,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4245,7 +4255,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4442,7 +4452,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4515,7 +4525,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4527,7 +4537,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4590,7 +4600,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4599,7 +4609,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4659,8 +4669,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4731,7 +4741,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4748,11 +4758,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4775,11 +4785,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4873,7 +4883,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4909,7 +4919,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4946,16 +4956,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5163,7 +5173,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5251,7 +5261,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5340,7 +5350,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5374,15 +5384,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5618,7 +5628,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5679,11 +5689,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5691,7 +5701,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5785,7 +5795,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5813,7 +5823,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5825,7 +5835,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5857,7 +5867,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -6023,7 +6033,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6207,7 +6217,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6228,7 +6242,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6260,7 +6274,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6282,7 +6296,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6306,7 +6320,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6322,12 +6336,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6368,7 +6382,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6383,7 +6397,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6429,7 +6443,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6455,7 +6469,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6471,11 +6485,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6591,7 +6605,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6622,7 +6636,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6636,7 +6650,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6716,7 +6736,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6754,7 +6774,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6798,7 +6818,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6917,19 +6937,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6941,15 +6961,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6971,11 +6991,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7012,7 +7032,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7193,7 +7213,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7238,7 +7258,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7379,7 +7399,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7387,11 +7407,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7419,7 +7439,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7427,7 +7447,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7519,7 +7539,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7528,13 +7548,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7543,7 +7563,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7576,7 +7596,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7879,7 +7899,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7903,7 +7923,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7948,8 +7968,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-04-16 18:54+0200\n"
+"POT-Creation-Date: 2025-04-16 19:01+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -6492,7 +6492,7 @@ msgstr ""
 #: lxc/export.go:48 lxc/storage_volume.go:2657
 msgid ""
 "Use a different metadata format version than the latest one supported by the "
-"server"
+"server (to support imports on older LXD versions)"
 msgstr ""
 
 #: lxc/export.go:45 lxc/storage_volume.go:2654

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-03-03 09:58-0600\n"
+"POT-Creation-Date: 2025-04-16 18:54+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1241
+#: lxc/config.go:1242
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be modified"
 msgstr ""
 
-#: lxc/image.go:419
+#: lxc/image.go:420
 msgid ""
 "### This is a YAML representation of the image properties.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1181
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -475,7 +475,7 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/config.go:497 lxc/config.go:817
+#: lxc/config.go:497 lxc/config.go:818
 msgid "--expanded cannot be used with a server"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "--refresh can only be used with instances"
 msgstr ""
 
-#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:636 lxc/config.go:843
+#: lxc/config.go:170 lxc/config.go:447 lxc/config.go:637 lxc/config.go:844
 #: lxc/info.go:461
 msgid "--target cannot be used with instances"
 msgstr ""
@@ -528,7 +528,7 @@ msgstr ""
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
-#: lxc/image.go:695
+#: lxc/image.go:696
 msgid ""
 "<tarball>|<directory>|<URL> [<rootfs tarball>] [<remote>:] [key=value...]"
 msgstr ""
@@ -541,15 +541,15 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
+#: lxc/alias.go:139 lxc/image.go:1144 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1145
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:195 lxc/image.go:1138 lxc/list.go:562
+#: lxc/cluster.go:195 lxc/image.go:1139 lxc/list.go:562
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Aliases already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1045
+#: lxc/image.go:1046
 msgid "Aliases:"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Alternative certificate name"
 msgstr ""
 
-#: lxc/image.go:1016 lxc/info.go:486
+#: lxc/image.go:1017 lxc/info.go:486
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -843,11 +843,11 @@ msgstr ""
 msgid "Auto negotiation: %v"
 msgstr ""
 
-#: lxc/image.go:200
+#: lxc/image.go:201
 msgid "Auto update is only available in pull mode"
 msgstr ""
 
-#: lxc/image.go:1055
+#: lxc/image.go:1056
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
@@ -864,17 +864,17 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:106
+#: lxc/export.go:142
 #, c-format
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2720
+#: lxc/storage_volume.go:2754
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2797
+#: lxc/export.go:228 lxc/storage_volume.go:2831
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:167
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:400 lxc/project.go:167
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Bad key=value pair: %s"
 msgstr ""
 
-#: lxc/image.go:816
+#: lxc/image.go:817
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -985,7 +985,7 @@ msgstr ""
 msgid "CUDA Version: %v"
 msgstr ""
 
-#: lxc/image.go:1054
+#: lxc/image.go:1055
 #, c-format
 msgid "Cached: %s"
 msgstr ""
@@ -998,7 +998,7 @@ msgstr ""
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
-#: lxc/image.go:233
+#: lxc/image.go:234
 msgid "Can't provide a name for the target image"
 msgstr ""
 
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1098
+#: lxc/config.go:703 lxc/config.go:1099
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1150,8 +1150,8 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
-#: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:555 lxc/config.go:777
+#: lxc/config.go:908 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
@@ -1176,7 +1176,7 @@ msgstr ""
 #: lxc/storage_volume.go:1964 lxc/storage_volume.go:2103
 #: lxc/storage_volume.go:2263 lxc/storage_volume.go:2379
 #: lxc/storage_volume.go:2440 lxc/storage_volume.go:2567
-#: lxc/storage_volume.go:2655 lxc/storage_volume.go:2819
+#: lxc/storage_volume.go:2658 lxc/storage_volume.go:2853
 msgid "Cluster member name"
 msgstr ""
 
@@ -1192,7 +1192,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/profile.go:724
+#: lxc/image.go:1118 lxc/list.go:132 lxc/profile.go:724
 #: lxc/storage_volume.go:1607 lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
-#: lxc/export.go:43
+#: lxc/export.go:46
 msgid "Compression algorithm to use (none for uncompressed)"
 msgstr ""
 
@@ -1230,8 +1230,8 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:864 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
-#: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
+#: lxc/config.go:356 lxc/config.go:1342 lxc/config_metadata.go:156
+#: lxc/config_trust.go:314 lxc/image.go:492 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:600
@@ -1264,15 +1264,15 @@ msgstr ""
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
-#: lxc/image.go:166
+#: lxc/image.go:167
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/image.go:158
+#: lxc/image.go:159
 msgid "Copy images between servers"
 msgstr ""
 
-#: lxc/image.go:159
+#: lxc/image.go:160
 msgid ""
 "Copy images between servers\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:278
+#: lxc/copy.go:63 lxc/image.go:172 lxc/move.go:68 lxc/profile.go:278
 #: lxc/storage_volume.go:392
 msgid "Copy to a project different from the source"
 msgstr ""
 
-#: lxc/image.go:169
+#: lxc/image.go:170
 msgid "Copy virtual machine images"
 msgstr ""
 
-#: lxc/image.go:288
+#: lxc/image.go:289
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -1521,7 +1521,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1493
+#: lxc/image.go:1024 lxc/info.go:497 lxc/storage_volume.go:1493
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1550,7 +1550,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1140 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
@@ -1576,7 +1576,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2654
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1612,7 +1612,7 @@ msgstr ""
 msgid "Delete image aliases"
 msgstr ""
 
-#: lxc/image.go:336 lxc/image.go:337
+#: lxc/image.go:337 lxc/image.go:338
 msgid "Delete images"
 msgstr ""
 
@@ -1700,9 +1700,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
-#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
-#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:543 lxc/config.go:773 lxc/config.go:905 lxc/config.go:958
+#: lxc/config.go:998 lxc/config.go:1053 lxc/config.go:1144 lxc/config.go:1175
+#: lxc/config.go:1229 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:230 lxc/config_device.go:327 lxc/config_device.go:410
 #: lxc/config_device.go:512 lxc/config_device.go:628 lxc/config_device.go:635
 #: lxc/config_device.go:768 lxc/config_device.go:853 lxc/config_metadata.go:28
@@ -1713,12 +1713,12 @@ msgstr ""
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
-#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
+#: lxc/exec.go:41 lxc/export.go:35 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:701
-#: lxc/file.go:1226 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
-#: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1451 lxc/image.go:1542 lxc/image.go:1608
-#: lxc/image.go:1672 lxc/image.go:1735 lxc/image_alias.go:24
+#: lxc/file.go:1226 lxc/image.go:39 lxc/image.go:160 lxc/image.go:338
+#: lxc/image.go:397 lxc/image.go:526 lxc/image.go:698 lxc/image.go:949
+#: lxc/image.go:1092 lxc/image.go:1452 lxc/image.go:1543 lxc/image.go:1609
+#: lxc/image.go:1673 lxc/image.go:1736 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
 #: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1786,8 +1786,8 @@ msgstr ""
 #: lxc/storage_volume.go:1862 lxc/storage_volume.go:1961
 #: lxc/storage_volume.go:2088 lxc/storage_volume.go:2246
 #: lxc/storage_volume.go:2367 lxc/storage_volume.go:2429
-#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2648
-#: lxc/storage_volume.go:2814 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2848 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
@@ -1867,7 +1867,7 @@ msgstr ""
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:726
+#: lxc/image.go:727
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -1908,7 +1908,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
+#: lxc/image.go:1120
 msgid "Display images from all projects"
 msgstr ""
 
@@ -1987,11 +1987,11 @@ msgstr ""
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
-#: lxc/image.go:395 lxc/image.go:396
+#: lxc/image.go:396 lxc/image.go:397
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1227 lxc/config.go:1228
+#: lxc/config.go:1228 lxc/config.go:1229
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2063,7 +2063,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/profile.go:766
+#: lxc/image.go:1162 lxc/list.go:622 lxc/profile.go:766
 #: lxc/storage_volume.go:1784 lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:463 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
+#: lxc/cluster.go:463 lxc/config.go:663 lxc/config.go:695 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:1082
@@ -2126,7 +2126,7 @@ msgstr ""
 msgid "Error setting properties: %v"
 msgstr ""
 
-#: lxc/config.go:656 lxc/config.go:688
+#: lxc/config.go:657 lxc/config.go:689
 #, c-format
 msgid "Error unsetting properties: %v"
 msgstr ""
@@ -2183,48 +2183,48 @@ msgstr ""
 msgid "Expires at"
 msgstr ""
 
-#: lxc/image.go:1029
+#: lxc/image.go:1030
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:1031
+#: lxc/image.go:1032
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:524
+#: lxc/image.go:525
 msgid "Export and download images"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:526
 msgid ""
 "Export and download images\n"
 "\n"
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2647 lxc/storage_volume.go:2648
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:34
 msgid "Export instance backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:35
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2651
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2780
+#: lxc/export.go:188 lxc/storage_volume.go:2814
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
 
-#: lxc/image.go:604
+#: lxc/image.go:605
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -2237,7 +2237,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1142 lxc/image.go:1143
 #: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
@@ -2291,12 +2291,12 @@ msgstr ""
 msgid "Failed deleting instance snapshot %q in project %q: %w"
 msgstr ""
 
-#: lxc/image.go:133
+#: lxc/image.go:134
 #, c-format
 msgid "Failed fetching fingerprint %q for alias %q: %w"
 msgstr ""
 
-#: lxc/image.go:124
+#: lxc/image.go:125
 #, c-format
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
@@ -2345,7 +2345,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:309 lxc/move.go:385
+#: lxc/move.go:311 lxc/move.go:387
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2380,7 +2380,7 @@ msgstr ""
 msgid "Failed to listen for connection: %w"
 msgstr ""
 
-#: lxc/copy.go:404
+#: lxc/copy.go:415
 #, c-format
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Filtering isn't supported yet"
 msgstr ""
 
-#: lxc/image.go:1014
+#: lxc/image.go:1015
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -2477,7 +2477,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1904
 #: lxc/cluster.go:125 lxc/cluster.go:983 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1119 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:996 lxc/config.go:997
+#: lxc/config.go:997 lxc/config.go:998
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1607 lxc/image.go:1608
+#: lxc/image.go:1608 lxc/image.go:1609
 msgid "Get image properties"
 msgstr ""
 
@@ -2830,11 +2830,11 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1523
+#: lxc/image.go:1524
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:305
+#: lxc/image.go:306
 msgid "Image copied successfully!"
 msgstr ""
 
@@ -2842,25 +2842,25 @@ msgstr ""
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
-#: lxc/image.go:680
+#: lxc/image.go:681
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1478
+#: lxc/image.go:365 lxc/image.go:1479
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1704
+#: lxc/image.go:445 lxc/image.go:1705
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
 
-#: lxc/image.go:918
+#: lxc/image.go:919
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1521
+#: lxc/image.go:1522
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2868,7 +2868,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2814
+#: lxc/storage_volume.go:2848
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2876,11 +2876,11 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2847
 msgid "Import custom storage volumes"
 msgstr ""
 
-#: lxc/image.go:697
+#: lxc/image.go:698
 msgid ""
 "Import image into the image store\n"
 "\n"
@@ -2890,7 +2890,7 @@ msgid ""
 "os=Ubuntu release=noble variant=cloud."
 msgstr ""
 
-#: lxc/image.go:696
+#: lxc/image.go:697
 msgid "Import images into the image store"
 msgstr ""
 
@@ -2898,11 +2898,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2821
+#: lxc/storage_volume.go:2855
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2895
+#: lxc/storage_volume.go:2929
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2946,7 +2946,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
+#: lxc/config.go:1023 lxc/config.go:1081 lxc/config.go:1200 lxc/config.go:1292
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,6 +2990,16 @@ msgstr ""
 #: lxc/list.go:649
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
+msgstr ""
+
+#: lxc/export.go:88 lxc/storage_volume.go:2720
+#, c-format
+msgid "Invalid export version %q"
+msgstr ""
+
+#: lxc/export.go:98 lxc/storage_volume.go:2730
+#, c-format
+msgid "Invalid export version %q: %w"
 msgstr ""
 
 #: lxc/monitor.go:71
@@ -3080,7 +3090,7 @@ msgstr ""
 msgid "IsSM: %s (%s)"
 msgstr ""
 
-#: lxc/image.go:167
+#: lxc/image.go:168
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
@@ -3124,12 +3134,12 @@ msgstr ""
 msgid "Last Used: %s"
 msgstr ""
 
-#: lxc/image.go:1035
+#: lxc/image.go:1036
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:1037
+#: lxc/image.go:1038
 msgid "Last used: never"
 msgstr ""
 
@@ -3247,11 +3257,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1091
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1092
 msgid ""
 "List images\n"
 "\n"
@@ -3563,7 +3573,7 @@ msgstr ""
 msgid "MTU: %d"
 msgstr ""
 
-#: lxc/image.go:165 lxc/image.go:704
+#: lxc/image.go:166 lxc/image.go:705
 msgid "Make image public"
 msgstr ""
 
@@ -3625,11 +3635,11 @@ msgstr ""
 msgid "Manage image aliases"
 msgstr ""
 
-#: lxc/image.go:37
+#: lxc/image.go:38
 msgid "Manage images"
 msgstr ""
 
-#: lxc/image.go:38
+#: lxc/image.go:39
 msgid ""
 "Manage images\n"
 "\n"
@@ -3648,7 +3658,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:956 lxc/config.go:957
+#: lxc/config.go:957 lxc/config.go:958
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3818,12 +3828,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:327 lxc/move.go:440
+#: lxc/move.go:329 lxc/move.go:451
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:352 lxc/move.go:445
+#: lxc/move.go:354 lxc/move.go:456
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4084,7 +4094,7 @@ msgstr ""
 msgid "Multiple rules match. Use --force to remove them all"
 msgstr ""
 
-#: lxc/image.go:728
+#: lxc/image.go:729
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -4281,7 +4291,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/image.go:168 lxc/image.go:705
+#: lxc/image.go:169 lxc/image.go:706
 msgid "New aliases to add to the image"
 msgstr ""
 
@@ -4354,7 +4364,7 @@ msgid ""
 "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2702
+#: lxc/storage_volume.go:2705
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
@@ -4366,7 +4376,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:805
+#: lxc/image.go:806
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
@@ -4429,7 +4439,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
+#: lxc/image.go:1141 lxc/list.go:567 lxc/network_zone.go:167 lxc/profile.go:749
 #: lxc/storage_volume.go:1774 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4438,7 +4448,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:853
+#: lxc/image.go:1146 lxc/remote.go:853
 msgid "PUBLIC"
 msgstr ""
 
@@ -4498,8 +4508,8 @@ msgstr ""
 
 #: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1869 lxc/cluster.go:865
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
-#: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
+#: lxc/config.go:1343 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config_trust.go:315 lxc/image.go:493 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:601
@@ -4570,7 +4580,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/image.go:172
+#: lxc/image.go:173
 msgid "Profile to apply to the new image"
 msgstr ""
 
@@ -4587,11 +4597,11 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/image.go:1067
+#: lxc/image.go:1068
 msgid "Profiles:"
 msgstr ""
 
-#: lxc/image.go:1065
+#: lxc/image.go:1066
 msgid "Profiles: "
 msgstr ""
 
@@ -4614,11 +4624,11 @@ msgstr ""
 msgid "Project to use for the remote"
 msgstr ""
 
-#: lxc/image.go:1040
+#: lxc/image.go:1041
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1655
+#: lxc/image.go:1656
 msgid "Property not found"
 msgstr ""
 
@@ -4712,7 +4722,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:1018
+#: lxc/image.go:1019
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -4748,7 +4758,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1545
+#: lxc/image.go:531 lxc/image.go:952 lxc/image.go:1546
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4785,16 +4795,16 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1450 lxc/image.go:1451
+#: lxc/image.go:1451 lxc/image.go:1452
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:426
+#: lxc/copy.go:437
 #, c-format
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1487
+#: lxc/image.go:1488
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5002,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1033
+#: lxc/config.go:1034
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5090,7 +5100,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1147
 msgid "SIZE"
 msgstr ""
 
@@ -5179,7 +5189,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1051 lxc/config.go:1052
+#: lxc/config.go:1052 lxc/config.go:1053
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5213,15 +5223,15 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1671 lxc/image.go:1672
+#: lxc/image.go:1672 lxc/image.go:1673
 msgid "Set image properties"
 msgstr ""
 
-#: lxc/config.go:541
+#: lxc/config.go:542
 msgid "Set instance or server configuration keys"
 msgstr ""
 
-#: lxc/config.go:542
+#: lxc/config.go:543
 msgid ""
 "Set instance or server configuration keys\n"
 "\n"
@@ -5457,7 +5467,7 @@ msgstr ""
 msgid "Set the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:555
+#: lxc/config.go:556
 msgid "Set the key as an instance property"
 msgstr ""
 
@@ -5518,11 +5528,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1541 lxc/image.go:1542
+#: lxc/image.go:1542 lxc/image.go:1543
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1173 lxc/config.go:1174
+#: lxc/config.go:1174 lxc/config.go:1175
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5530,7 +5540,7 @@ msgstr ""
 msgid "Show instance metadata files"
 msgstr ""
 
-#: lxc/config.go:771 lxc/config.go:772
+#: lxc/config.go:772 lxc/config.go:773
 msgid "Show instance or server configurations"
 msgstr ""
 
@@ -5624,7 +5634,7 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:775
+#: lxc/config.go:776
 msgid "Show the expanded configuration"
 msgstr ""
 
@@ -5652,7 +5662,7 @@ msgstr ""
 msgid "Show useful information about a cluster member"
 msgstr ""
 
-#: lxc/image.go:947 lxc/image.go:948
+#: lxc/image.go:948 lxc/image.go:949
 msgid "Show useful information about images"
 msgstr ""
 
@@ -5664,7 +5674,7 @@ msgstr ""
 msgid "Show warning"
 msgstr ""
 
-#: lxc/image.go:1015
+#: lxc/image.go:1016
 #, c-format
 msgid "Size: %.2fMiB"
 msgstr ""
@@ -5696,7 +5706,7 @@ msgstr ""
 msgid "Some instances failed to %s"
 msgstr ""
 
-#: lxc/image.go:1058
+#: lxc/image.go:1059
 msgid "Source:"
 msgstr ""
 
@@ -5862,7 +5872,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1148
 #: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1748 lxc/warning.go:216
@@ -6046,7 +6056,11 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:314
+#: lxc/export.go:112 lxc/storage_volume.go:2744
+msgid "The server doesn't support setting the metadata format version"
+msgstr ""
+
+#: lxc/move.go:316
 msgid "The source LXD server is not clustered"
 msgstr ""
 
@@ -6067,7 +6081,7 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/config.go:674
+#: lxc/config.go:675
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
@@ -6099,7 +6113,7 @@ msgstr ""
 msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
-#: lxc/image.go:1019
+#: lxc/image.go:1020
 msgid "Timestamps:"
 msgstr ""
 
@@ -6121,7 +6135,7 @@ msgid ""
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr ""
 
-#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:723 lxc/config.go:823
+#: lxc/config.go:306 lxc/config.go:503 lxc/config.go:724 lxc/config.go:824
 #: lxc/copy.go:144 lxc/info.go:346 lxc/network.go:914 lxc/storage.go:515
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
@@ -6145,7 +6159,7 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/image.go:170
+#: lxc/image.go:171
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
@@ -6161,12 +6175,12 @@ msgstr ""
 msgid "Transfer mode. One of pull, push or relay."
 msgstr ""
 
-#: lxc/image.go:827
+#: lxc/image.go:828
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:332
+#: lxc/copy.go:393 lxc/move.go:334
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6207,7 +6221,7 @@ msgid ""
 "SPICE graphical output"
 msgstr ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
+#: lxc/image.go:1018 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
 #: lxc/storage_volume.go:1470
 #, c-format
 msgid "Type: %s"
@@ -6222,7 +6236,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1149
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6268,7 +6282,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/profile.go:772
+#: lxc/image.go:1168 lxc/list.go:631 lxc/profile.go:772
 #: lxc/storage_volume.go:1790 lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6294,7 +6308,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1142 lxc/config.go:1143
+#: lxc/config.go:1143 lxc/config.go:1144
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6310,11 +6324,11 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1734 lxc/image.go:1735
+#: lxc/image.go:1735 lxc/image.go:1736
 msgid "Unset image properties"
 msgstr ""
 
-#: lxc/config.go:903 lxc/config.go:904
+#: lxc/config.go:904 lxc/config.go:905
 msgid "Unset instance or server configuration keys"
 msgstr ""
 
@@ -6430,7 +6444,7 @@ msgstr ""
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
-#: lxc/config.go:908
+#: lxc/config.go:909
 msgid "Unset the key as an instance property"
 msgstr ""
 
@@ -6461,7 +6475,7 @@ msgstr ""
 msgid "Update the target profile from the source if it already exists"
 msgstr ""
 
-#: lxc/image.go:1026
+#: lxc/image.go:1027
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -6475,7 +6489,13 @@ msgstr ""
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2653
+#: lxc/export.go:48 lxc/storage_volume.go:2657
+msgid ""
+"Use a different metadata format version than the latest one supported by the "
+"server"
+msgstr ""
+
+#: lxc/export.go:45 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6555,7 +6575,7 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -6593,7 +6613,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
+#: lxc/copy.go:98 lxc/move.go:300 lxc/move.go:376
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6637,7 +6657,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1089 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6756,19 +6776,19 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1540
+#: lxc/image.go:395 lxc/image.go:947 lxc/image.go:1541
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1733
+#: lxc/image.go:1607 lxc/image.go:1734
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1670
+#: lxc/image.go:1671
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:156
+#: lxc/image.go:157
 msgid "[<remote>:]<image> <remote>:"
 msgstr ""
 
@@ -6780,15 +6800,15 @@ msgstr ""
 msgid "[<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/image.go:523
+#: lxc/image.go:524
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1449
+#: lxc/image.go:335 lxc/image.go:1450
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:330
+#: lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:330
 #: lxc/config_device.go:762 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6810,11 +6830,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:1141
+#: lxc/config.go:996 lxc/config.go:1142
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1050
+#: lxc/config.go:1051
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6851,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:33
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
@@ -7032,7 +7052,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2846
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7077,7 +7097,7 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2646
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
@@ -7218,7 +7238,7 @@ msgstr ""
 msgid "[<remote>:]<zone> <record> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:98 lxc/config.go:770
+#: lxc/config.go:98 lxc/config.go:771
 msgid "[<remote>:][<instance>[/<snapshot>]]"
 msgstr ""
 
@@ -7226,11 +7246,11 @@ msgstr ""
 msgid "[<remote>:][<instance>]"
 msgstr ""
 
-#: lxc/config.go:391 lxc/config.go:902
+#: lxc/config.go:391 lxc/config.go:903
 msgid "[<remote>:][<instance>] <key>"
 msgstr ""
 
-#: lxc/config.go:540
+#: lxc/config.go:541
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
@@ -7258,7 +7278,7 @@ msgstr ""
 msgid "description"
 msgstr ""
 
-#: lxc/image.go:1004
+#: lxc/image.go:1005
 msgid "disabled"
 msgstr ""
 
@@ -7266,7 +7286,7 @@ msgstr ""
 msgid "driver"
 msgstr ""
 
-#: lxc/image.go:1006
+#: lxc/image.go:1007
 msgid "enabled"
 msgstr ""
 
@@ -7358,7 +7378,7 @@ msgid ""
 "    Update the instance configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:547
+#: lxc/config.go:548
 msgid ""
 "lxc config set [<remote>:]<instance> limits.cpu=2\n"
 "    Will set a CPU limit of \"2\" for the instance.\n"
@@ -7367,13 +7387,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1230
+#: lxc/config.go:1231
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1054
+#: lxc/config.go:1055
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7382,7 +7402,7 @@ msgid ""
 "the instance."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:37
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 instance."
@@ -7415,7 +7435,7 @@ msgid ""
 "   To push /etc/hosts into the instance \"foo\"."
 msgstr ""
 
-#: lxc/image.go:398
+#: lxc/image.go:399
 msgid ""
 "lxc image edit <image>\n"
 "    Launch a text editor to edit the properties\n"
@@ -7718,7 +7738,7 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2816
+#: lxc/storage_volume.go:2850
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7742,7 +7762,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:995 lxc/image.go:1000 lxc/image.go:1210
 msgid "no"
 msgstr ""
 
@@ -7787,7 +7807,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/cluster.go:628 lxc/delete.go:52 lxc/image.go:997 lxc/image.go:1002
+#: lxc/image.go:1207
 msgid "yes"
 msgstr ""

--- a/shared/api/backup.go
+++ b/shared/api/backup.go
@@ -1,0 +1,10 @@
+package api
+
+const (
+	// BackupMetadataVersion1 represents the original backup file format version.
+	BackupMetadataVersion1 uint32 = 1
+
+	// BackupMetadataVersion2 represents the updated backup file format version which is using
+	// restructured fields in order to be able to track custom storage volumes attached to the instance.
+	BackupMetadataVersion2 uint32 = 2
+)

--- a/shared/api/instance_backup.go
+++ b/shared/api/instance_backup.go
@@ -37,6 +37,12 @@ type InstanceBackupsPost struct {
 	//
 	// API extension: backup_compression_algorithm
 	CompressionAlgorithm string `json:"compression_algorithm" yaml:"compression_algorithm"`
+
+	// What backup format version to use
+	// Example: 1
+	//
+	// API extension: backup_metadata_version
+	Version uint32
 }
 
 // InstanceBackup represents a LXD instance backup.

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -10,6 +10,12 @@ type ServerEnvironment struct {
 	// Example: ["x86_64", "i686"]
 	Architectures []string `json:"architectures" yaml:"architectures"`
 
+	// Range of supported backup metadata versions
+	// Example: [1, 2]
+	//
+	// API extension: backup_metadata_version
+	BackupMetadataVersionRange []uint32 `json:"backup_metadata_version_range" yaml:"backup_metadata_version_range"`
+
 	// Server certificate as PEM encoded X509
 	// Example: X509 PEM certificate
 	Certificate string `json:"certificate" yaml:"certificate"`

--- a/shared/api/storage_pool_volume_backup.go
+++ b/shared/api/storage_pool_volume_backup.go
@@ -56,6 +56,12 @@ type StoragePoolVolumeBackupsPost struct {
 	// What compression algorithm to use
 	// Example: gzip
 	CompressionAlgorithm string `json:"compression_algorithm" yaml:"compression_algorithm"`
+
+	// What backup format version to use
+	// Example: 1
+	//
+	// API extension: backup_metadata_version
+	Version uint32
 }
 
 // StoragePoolVolumeBackupPost represents the fields available for the renaming of a volume backup

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -445,6 +445,7 @@ var APIExtensions = []string{
 	"container_bpf_delegation",
 	"override_snapshot_profiles_on_copy",
 	"resources_device_fs_uuid",
+	"backup_metadata_version",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/main.sh
+++ b/test/main.sh
@@ -45,7 +45,7 @@ import_subdir_files() {
 import_subdir_files includes
 
 echo "==> Checking for dependencies"
-check_dependencies lxd lxc curl dnsmasq jq git sqlite3 msgmerge msgfmt shuf setfacl socat swtpm dig
+check_dependencies lxd lxc curl dnsmasq jq yq git sqlite3 msgmerge msgfmt shuf setfacl socat swtpm dig
 
 if [ "${USER:-'root'}" != "root" ]; then
   echo "The testsuite must be run as root." >&2

--- a/test/main.sh
+++ b/test/main.sh
@@ -422,6 +422,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_backup_rename "backup rename"
     run_test test_backup_volume_export "backup volume export"
     run_test test_backup_export_import_instance_only "backup export and import instance only"
+    run_test test_backup_metadata "backup metadata checks for containers and custom storage volumes"
     run_test test_backup_volume_rename_delete "backup volume rename and delete"
     run_test test_backup_instance_uuid "backup instance and check instance UUIDs"
     run_test test_backup_volume_expiry "backup volume expiry"


### PR DESCRIPTION
Spec here https://docs.google.com/document/d/1AKm3Jgt08ovNShrrP27P7AIjbdtTZjc7RZ4fMpCiHK8/edit?tab=t.0

### Overview

This PR improves the storage volume metadata to be able to account for multiple volumes.
This is especially useful in case of instances to allow recovery of attached custom storage volumes.
It adds a new format identified by a new version field which can be set by the most recent CLI when exporting backups using `--export-version=(1|2)`.

Changing the format requires modifications for backup/restore and migration as both make use of the same data structures.
Importing backups from newer LXDs on older LXDs and being able to migrate from newer to older should still work seamlessly.

In addition a new API extension `backup_metadata_version` is added which acts as the gatekeeper for being able to set the version of the backup's format.

### Backport info

Most of the PR can be backported to 5.21, except the last commits indicating that this is only intended for 6.x going forward.
As the PR changes lots of lines, this should make backporting of other features much easier as the internal changes are getting backported whilst the artifacts that LXD writes to file still remain to use the old format (1).

### PR dependencies

PRs to fix the panic in case of invalid backup file format. This panic would currently happen when importing newer backups on older versions of LXD or when modifying the backup artifact:
* https://github.com/canonical/lxd/pull/15165 + https://github.com/canonical/lxd/pull/15168
* https://github.com/canonical/lxd/pull/15163
* https://github.com/canonical/lxd/pull/15164
* https://github.com/canonical/lxd/pull/15166

Connected PR in lxd-ci for tests: https://github.com/canonical/lxd-ci/pull/443
