### PR TITLE
doc: update code of conduct and its link (stable-5.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ even when part of a larger set. You may find `git commit -s` useful.
 
 ## Code of Conduct
 
-When contributing, you must adhere to the Code of Conduct, which is available at: [`https://github.com/canonical/lxd/blob/main/CODE_OF_CONDUCT.md`](https://github.com/canonical/lxd/blob/main/CODE_OF_CONDUCT.md)
+When contributing, you must adhere to the [Ubuntu Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct).
 
 <!-- Include end contributing -->
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -39,7 +39,7 @@ It’s an open source project that warmly welcomes community projects, contribut
 
 The LXD project is sponsored by [Canonical Ltd](https://www.canonical.com).
 
-- [Code of Conduct](https://github.com/canonical/lxd/blob/main/CODE_OF_CONDUCT.md)
+- [Code of Conduct](https://ubuntu.com/community/ethos/code-of-conduct)
 - [Contribute to the project](contributing.md)
 - [Release announcements](https://discourse.ubuntu.com/c/lxd/news/)
 - [Release tarballs](https://github.com/canonical/lxd/releases/)


### PR DESCRIPTION
Replaces third-party Code of Conduct with Ubuntu Code of Conduct per https://github.com/canonical/lxd/pull/15113#issuecomment-2710247105.