### PR TITLE
doc: update contributing guide links to 5.21 docs (stable-5.21)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,4 +136,4 @@ If you add or update configuration options, regenerate and commit the documentat
 
 ## More information
 
-For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://documentation.ubuntu.com/lxd/en/latest/contributing/) in the documentation.
+For more information, including details about contributing to the code as well as the documentation for LXD, see [How to contribute to LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/contributing/) in the documentation.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,8 +1,8 @@
 # LXD documentation
 
-The LXD documentation is available at: <https://documentation.ubuntu.com/lxd/en/latest/>
+The LXD documentation is available at: <https://documentation.ubuntu.com/lxd/en/stable-5.21/>
 
-GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://documentation.ubuntu.com/lxd/en/latest/).
+GitHub provides a basic rendering of the documentation as well, but important features like includes and clickable links are missing. Therefore, we recommend reading the [published documentation](https://documentation.ubuntu.com/lxd/en/stable-5.21/).
 
 ## How it works
 
@@ -13,7 +13,7 @@ GitHub provides a basic rendering of the documentation as well, but important fe
 LXD's documentation is built with [Sphinx](https://www.sphinx-doc.org) and hosted on [Read the Docs](https://about.readthedocs.com/).
 
 It is written in [Markdown](https://commonmark.org/) with [MyST](https://myst-parser.readthedocs.io/) extensions.
-For syntax help and guidelines, see the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) and the [documentation cheat sheet](https://documentation.ubuntu.com/lxd/en/latest/doc-cheat-sheet-myst/) ([source](https://raw.githubusercontent.com/canonical/lxd/main/doc/doc-cheat-sheet-myst.md)).
+For syntax help and guidelines, see the [MyST style guide](https://canonical-documentation-with-sphinx-and-readthedocscom.readthedocs-hosted.com/style-guide-myst/) and the [documentation cheat sheet](https://documentation.ubuntu.com/lxd/en/stable-5.21/doc-cheat-sheet-myst/) ([source](https://raw.githubusercontent.com/canonical/lxd/main/doc/doc-cheat-sheet-myst.md)).
 
 For structuring, the documentation uses the [Diátaxis](https://diataxis.fr/) approach.
 


### PR DESCRIPTION
Update links to point to 5.21 docs per https://github.com/canonical/lxd/pull/15092#discussion_r1977123112
(Code of Conduct replacement from that PR already backported via https://github.com/canonical/lxd/pull/15125)