### PR TITLE
test: Add wait_for_add call during test_container_devices_nic_bridged_filtering

### DIFF
--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -818,6 +818,8 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ip a add 192.0.2.2/24 dev eth0
   lxc exec "${ctPrefix}A" -- ip a add 2001:db8::2/64 dev eth0
 
+  wait_for_dad "${ctPrefix}A" eth0
+
   # Check basic connectivity without any filtering.
   lxc exec "${ctPrefix}A" -- ping -c2 -W5 192.0.2.1
   lxc exec "${ctPrefix}A" -- ping -c2 -W5 2001:db8::1


### PR DESCRIPTION
Sometimes we see a ping failure to the gateway in our tests after adding the IPs to the container. Perhaps this is caused by Duplicate Address Detection not yet completing and the IPs being in tentative state.

```
lxc exec nt22616A -- ip a add 192.0.2.2/24 dev eth0
lxc exec nt22616A -- ip a add 2001:db8::2/64 dev eth0
lxc exec nt22616A -- ping -c2 -W5 192.0.2.1
PING 192.0.2.1 (192.0.2.1): 56 data bytes
64 bytes from 192.0.2.1: seq=0 ttl=64 time=0.079 ms
64 bytes from 192.0.2.1: seq=1 ttl=64 time=0.057 ms

--- 192.0.2.1 ping statistics ---
2 packets transmitted, 2 packets received, 0% packet loss
round-trip min/avg/max = 0.057/0.068/0.079 ms

lxc exec nt22616A -- ping -c2 -W5 2001:db8::1
PING 2001:db8::1 (2001:db8::1): 56 data bytes

--- 2001:db8::1 ping statistics ---
2 packets transmitted, 0 packets received, 100% packet loss
```