### PR TITLE
lxc/file: Use the file extension of the edited file for the temp file (from Incus)

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -418,7 +418,7 @@ func (c *cmdFileEdit) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create temp file
-	f, err := os.CreateTemp("", "lxd_file_edit_")
+	f, err := os.CreateTemp("", "lxd_file_edit_*"+filepath.Ext(args[0]))
 	if err != nil {
 		return fmt.Errorf(i18n.G("Unable to create a temporary file: %v"), err)
 	}


### PR DESCRIPTION
To help with syntax highlighting

(cherry picked from commit 7d456f725477e136473b68e8cdae595c23d6ae1f)

License: Apache-2.0