### PR TITLE
Storage: Reference counts for LVM LV activation

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3529,7 +3529,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	_, err = d.mount()
 	if err != nil {
 		op.Done(err)
-		return err
+		return fmt.Errorf("Failed mounting instance: %w", err)
 	}
 
 	revert.Add(func() { _ = d.unmount() })
@@ -3548,7 +3548,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	err = d.unmount()
 	if err != nil {
 		op.Done(err)
-		return err
+		return fmt.Errorf("Failed unmounting instance: %w", err)
 	}
 
 	revert.Success()
@@ -3557,7 +3557,7 @@ func (d *lxc) Restore(sourceContainer instance.Instance, stateful bool) error {
 	err = pool.RestoreInstanceSnapshot(d, sourceContainer, nil)
 	if err != nil {
 		op.Done(err)
-		return err
+		return fmt.Errorf("Failed to restore snapshot rootfs: %w", err)
 	}
 
 	// Restore the configuration.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -804,54 +804,44 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 
 	refCount := vol.MountRefCountDecrement()
 
+	// For VMs, unmount the filesystem volume.
+	if vol.IsVMBlock() {
+		fsVol := vol.NewVMBlockFilesystemVolume()
+		ourUnmount, err = d.UnmountVolume(fsVol, false, op)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if refCount > 0 {
+		d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": vol.name, "refCount": refCount})
+		return false, ErrInUse
+	}
+
 	// Check if already mounted.
 	if vol.contentType == ContentTypeFS && filesystem.IsMountPoint(mountPath) {
-		if refCount > 0 {
-			d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": vol.name, "refCount": refCount})
-			return false, ErrInUse
-		}
-
 		err = TryUnmount(mountPath, 0)
 		if err != nil {
 			return false, fmt.Errorf("Failed to unmount LVM logical volume: %w", err)
 		}
 
-		d.logger.Debug("Unmounted logical volume", logger.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
-
-		// We only deactivate filesystem volumes if an unmount was needed to better align with our
-		// unmount return value indicator.
-		if !keepBlockDev {
-			_, err = d.deactivateVolume(vol)
-			if err != nil {
-				return false, err
-			}
-		}
-
 		ourUnmount = true
 	} else if vol.contentType == ContentTypeBlock {
-		// For VMs, unmount the filesystem volume.
-		if vol.IsVMBlock() {
-			fsVol := vol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolume(fsVol, false, op)
-			if err != nil {
-				return false, err
-			}
-		}
-
 		volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
-		if !keepBlockDev && shared.PathExists(volDevPath) {
-			if refCount > 0 {
-				d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": vol.name, "refCount": refCount})
-				return false, ErrInUse
-			}
+		keepBlockDev = keepBlockDev || !shared.PathExists(volDevPath)
+	}
 
-			_, err = d.deactivateVolume(vol)
-			if err != nil {
-				return false, err
-			}
-
-			ourUnmount = true
+	// We only deactivate filesystem volumes if an unmount was needed to better align with our
+	// unmount return value indicator.
+	if ourUnmount && !keepBlockDev {
+		_, err = d.deactivateVolume(vol)
+		if err != nil {
+			return false, err
 		}
+
+		d.logger.Debug("Unmounted logical volume", logger.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
+
+		ourUnmount = true
 	}
 
 	return ourUnmount, nil

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -808,12 +809,20 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 	if vol.IsVMBlock() {
 		fsVol := vol.NewVMBlockFilesystemVolume()
 		ourUnmount, err = d.UnmountVolume(fsVol, false, op)
-		if err != nil {
+
+		// If the VMBlockFilesystem volume is still in use, we use the refCount
+		// of the block volume instead.
+		if err != nil && !errors.Is(err, ErrInUse) {
 			return false, err
 		}
 	}
 
 	if refCount > 0 {
+		// The LVM driver keeps track of activations separately from mounts, see
+		// d.activationRefCountName.
+		// Ensure that the activation refcount is also updated when deactivation
+		// would normally be skipped.
+		d.activationRefCountDecrement(vol)
 		d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": vol.name, "refCount": refCount})
 		return false, ErrInUse
 	}
@@ -842,6 +851,13 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 		d.logger.Debug("Unmounted logical volume", logger.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
 
 		ourUnmount = true
+	} else {
+		// Since activation of the LV on mount is unconditional, the activation
+		// refcount needs to be updated regardless of whether we actually
+		// deactivated the volume or not; the refcount represents the number of
+		// deactivations that are expected based on the number of times activate
+		// is called; it doesn't have anything to do with the real state of the LV.
+		d.activationRefCountDecrement(vol)
 	}
 
 	return ourUnmount, nil


### PR DESCRIPTION
When a thick LVM volume is activated, its snapshots are activated, and vice versa.

When I introduced snapshot attachment for VM volumes (https://github.com/canonical/lxd/pull/14930), it became possible for a snapshot to be mounted independently of its parent volume. The [previous logic](https://github.com/canonical/lxd/commit/44d4b432fb032fc57084afe4cad08d71979c7ae1) (see https://github.com/canonical/lxd/issues/10302) allowed for snapshots to be mounted while their parent volumes were mounted, but not vice versa.

In order to correctly identify when an LV can be safely deactivated, this introduces a reference count for LVs to prevent deactivation of an LV which was activated by another instance/operation.