### PR TITLE
API: Don't panic if instance backup config is invalid (stable-5.0)

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -655,6 +655,10 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		return err
 	}
 
+	if backupConf.Container == nil {
+		return fmt.Errorf("Instance definition in backup config is missing")
+	}
+
 	if allowNameOverride && instName != "" {
 		backupConf.Container.Name = instName
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -617,6 +618,14 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 	bInfo, err := backup.GetInfo(backupFile, s.OS, backupFile.Name())
 	if err != nil {
 		return response.BadRequest(err)
+	}
+
+	if bInfo.Config == nil {
+		return response.BadRequest(errors.New("Backup config is missing"))
+	}
+
+	if bInfo.Config.Container == nil {
+		return response.BadRequest(errors.New("Instance definition in backup config is missing"))
 	}
 
 	// Check project permissions.


### PR DESCRIPTION
This in in preparation for https://github.com/canonical/lxd/pull/15129.
It only applies for instances, custom storage volumes are not affected.

In case a backup using the newer version gets imported on LXD 5.x, it should not panic.
The same applies in case the backup file was intentionally/unintentionally modified.