### PR TITLE
lxd: Don't panic if backup config is invalid (stable-4.0)

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -569,6 +569,10 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		return err
 	}
 
+	if backupConf.Container == nil {
+		return fmt.Errorf("Instance definition in backup config is missing")
+	}
+
 	if allowNameOverride && instName != "" {
 		backupConf.Container.Name = instName
 	}


### PR DESCRIPTION
This in in preparation for https://github.com/canonical/lxd/pull/15129.
It only applies for instances, custom storage volumes are not affected.

In case a backup using the newer version gets imported on LXD 4.x, it should not panic.
The same applies in case the backup file was intentionally/unintentionally modified.