### PR TITLE
github: Use `microovn waitready`

### DIFF
--- a/.github/actions/setup-microovn/action.yml
+++ b/.github/actions/setup-microovn/action.yml
@@ -25,4 +25,5 @@ runs:
 
           sudo snap install microovn --channel "${{ inputs.microovn-channel }}"
           sudo microovn cluster bootstrap
+          sudo microovn waitready
           sudo microovn status


### PR DESCRIPTION
CI fails occasionally due to race:
```
+ sudo microovn cluster bootstrap
Error: Post "http://control.socket/core/control": dial unix /var/snap/microovn/common/state/control.socket: connect: no such file or directory
```

MicroOVN added support for a `waitready` subcommand for us in https://github.com/canonical/microovn/pull/225, we just need to use it.

MicroCeph is [not affected](https://github.com/canonical/microceph/blob/210e20f30bba4b3e0c9247bdd6539d70f1ccedfb/microceph/cmd/microceph/cluster_bootstrap.go#L80).