### PR TITLE
API: Don't panic if backup config is missing (stable-4.0)

### DIFF
--- a/lxd/backup/backup_config.go
+++ b/lxd/backup/backup_config.go
@@ -97,6 +97,10 @@ func UpdateInstanceConfigStoragePool(c *db.Cluster, b Info, mountPath string) er
 			return err
 		}
 
+		if backup.Container == nil {
+			return fmt.Errorf("Instance definition in backup config is missing")
+		}
+
 		rootDiskDeviceFound := false
 
 		// Change the pool in the backup.yaml.


### PR DESCRIPTION
Follow up on https://github.com/canonical/lxd/pull/15165.

The field is still accessed down the line (the code is structured differently in 4.0 therefore I have missed this bit).
The previous PR only had half of the fixes.