### PR TITLE
tests/suites/network.sh: Add test for fetching bridge info

### DIFF
--- a/.github/actions/install-lxd-runtimedeps/action.yml
+++ b/.github/actions/install-lxd-runtimedeps/action.yml
@@ -44,7 +44,8 @@ runs:
           uuid-runtime \
           xfsprogs \
           xz-utils \
-          zfsutils-linux
+          zfsutils-linux \
+          openvswitch-switch
 
         # reclaim some space
         sudo apt-get clean

--- a/test/suites/network.sh
+++ b/test/suites/network.sh
@@ -16,6 +16,24 @@ test_network() {
   lxc delete -f def0
   lxc network delete lxdt$$
 
+  # Check that we return bridge informatin for ovs bridges
+  systemctl start openvswitch-switch
+  ip link add dummy0 type dummy
+  ovs-vsctl add-br ovs-br0
+  ovs-vsctl add-port ovs-br0 dummy0 tag=9
+  lxc network info ovs-br0 | grep -qF "Bridge:"
+
+  # Check that we are able to return linux bridge information if ovs service is disabled
+  systemctl stop openvswitch-switch
+  ip link add native-br0 type bridge
+  lxc network info native-br0 | grep -qF "Bridge:"
+
+  # Cleanup
+  systemctl start openvswitch-switch
+  ovs-vsctl del-br ovs-br0
+  sudo ip link delete native-br0
+  ip link delete dummy0
+
   # Standard bridge with random subnet and a bunch of options
   lxc network create lxdt$$
   lxc network set lxdt$$ dns.mode dynamic


### PR DESCRIPTION
This tests makes sure that we are able to retrieve OVS bridge information as well as native linux bridge information after disabling the openvswitch service using "$ lxc network info <bridge>".