### PR TITLE
lxd/bgp: Rework start/stop logic (from Incus)

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -996,7 +996,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			return fmt.Errorf("Cannot convert BGP ASN to uint32: Upper bound exceeded")
 		}
 
-		err := s.BGP.Reconfigure(address, uint32(asn), net.ParseIP(routerid))
+		err := s.BGP.Configure(address, uint32(asn), net.ParseIP(routerid))
 		if err != nil {
 			return fmt.Errorf("Failed reconfiguring BGP: %w", err)
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1708,18 +1708,6 @@ func (d *Daemon) init() error {
 
 	// Setup BGP listener.
 	d.bgp = bgp.NewServer()
-	if bgpAddress != "" && bgpASN != 0 && bgpRouterID != "" {
-		if bgpASN > math.MaxUint32 {
-			return fmt.Errorf("Cannot convert BGP ASN to uint32: Upper bound exceeded")
-		}
-
-		err := d.bgp.Start(bgpAddress, uint32(bgpASN), net.ParseIP(bgpRouterID))
-		if err != nil {
-			return err
-		}
-
-		logger.Info("Started BGP server")
-	}
 
 	// Setup DNS listener.
 	d.dns = dns.NewServer(d.db.Cluster, func(name string, full bool) (*dns.Zone, error) {
@@ -1769,6 +1757,19 @@ func (d *Daemon) init() error {
 	}
 
 	// Setup tertiary listeners that may use managed network addresses and must be started after networks.
+	if bgpAddress != "" && bgpASN != 0 && bgpRouterID != "" {
+		if bgpASN > math.MaxUint32 {
+			return fmt.Errorf("Cannot convert BGP ASN to uint32: Upper bound exceeded")
+		}
+
+		err := d.bgp.Start(bgpAddress, uint32(bgpASN), net.ParseIP(bgpRouterID))
+		if err != nil {
+			return err
+		}
+
+		logger.Info("Started BGP server")
+	}
+
 	dnsAddress := d.localConfig.DNSAddress()
 	if dnsAddress != "" {
 		err = d.dns.Start(dnsAddress)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1762,7 +1762,7 @@ func (d *Daemon) init() error {
 			return fmt.Errorf("Cannot convert BGP ASN to uint32: Upper bound exceeded")
 		}
 
-		err := d.bgp.Start(bgpAddress, uint32(bgpASN), net.ParseIP(bgpRouterID))
+		err := d.bgp.Configure(bgpAddress, uint32(bgpASN), net.ParseIP(bgpRouterID))
 		if err != nil {
 			return err
 		}

--- a/test/suites/network_forward.sh
+++ b/test/suites/network_forward.sh
@@ -7,7 +7,7 @@ test_network_forward() {
 
   lxc network create bgpbr # Bridge to start BGP listener on.
 
-  bgpIP=$(lxc network ls | grep bgpbr | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+  bgpIP=$(lxc network get bgpbr ipv4.address | cut -d/ -f1)
 
   lxc network create "${netName}" \
         ipv4.address=192.0.2.1/24 \

--- a/test/suites/network_forward.sh
+++ b/test/suites/network_forward.sh
@@ -5,6 +5,10 @@ test_network_forward() {
   firewallDriver=$(lxc info | awk -F ":" '/firewall:/{gsub(/ /, "", $0); print $2}')
   netName=lxdt$$
 
+  lxc network create bgpbr # Bridge to start BGP listener on.
+
+  bgpIP=$(lxc network ls | grep bgpbr | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}')
+
   lxc network create "${netName}" \
         ipv4.address=192.0.2.1/24 \
         ipv6.address=fd42:4242:4242:1010::1/64
@@ -27,6 +31,15 @@ test_network_forward() {
 
   # Check forward is exported via BGP prefixes.
   lxc query /internal/testing/bgp | grep "198.51.100.1/32"
+
+  # Enable the BGP listener
+  lxc config set core.bgp_address="${bgpIP}:8874"
+  lxc config set core.bgp_asn=65536
+  lxc config set core.bgp_routerid="${bgpIP}"
+
+  # Check that the listener survives a restart of LXD
+  shutdown_lxd "${LXD_DIR}"
+  respawn_lxd "${LXD_DIR}" true
 
   lxc network forward delete "${netName}" 198.51.100.1
 


### PR DESCRIPTION
Includes cherry-pick from https://github.com/lxc/incus/pull/1761.

**Changes:**   
- BGP listener is now started after all the networks are set up.
-  Predefined network forwards are now added correctly during the BGP listener start up.
- Extended test/suites/network_forward to test the BGP listener start up and subsequent restart of LXD daemon.