### PR TITLE
Rename `StoragePoolVolume{Content}Type` `Name` methods to `String`

### DIFF
--- a/lxd/db/cluster/storage_volume_type.go
+++ b/lxd/db/cluster/storage_volume_type.go
@@ -57,12 +57,12 @@ func StoragePoolVolumeTypeFromName(volTypeName string) (StoragePoolVolumeType, e
 	return StoragePoolVolumeTypeCustom, errors.New("Invalid storage volume type")
 }
 
-// Name gives the name of a StoragePoolVolumeType.
+// String gives the name of a StoragePoolVolumeType.
 //
 // # Safety
 // This function assumes that `t` is one of the StoragePoolVolumeType enums
 // defined above.
-func (t StoragePoolVolumeType) Name() string {
+func (t StoragePoolVolumeType) String() string {
 	switch t {
 	case StoragePoolVolumeTypeContainer:
 		return StoragePoolVolumeTypeNameContainer
@@ -123,12 +123,12 @@ func StoragePoolVolumeContentTypeFromName(contentTypeName string) (StoragePoolVo
 	return StoragePoolVolumeContentTypeFS, errors.New("Invalid volume content type name")
 }
 
-// Name gives the name of a StoragePoolVolumeContentType.
+// String gives the name of a StoragePoolVolumeContentType.
 //
 // # Safety
 // This function assumes that `t` is one of the StoragePoolVolumeContentType
 // enums defined above.
-func (t StoragePoolVolumeContentType) Name() string {
+func (t StoragePoolVolumeContentType) String() string {
 	switch t {
 	case StoragePoolVolumeContentTypeFS:
 		return StoragePoolVolumeContentTypeNameFS

--- a/lxd/db/storage_volume_snapshots.go
+++ b/lxd/db/storage_volume_snapshots.go
@@ -127,7 +127,7 @@ WHERE volumes.id=?
 		return StorageVolumeArgs{}, err
 	}
 
-	args.TypeName = args.Type.Name()
+	args.TypeName = args.Type.String()
 
 	return args, nil
 }

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -112,7 +112,7 @@ WHERE storage_volumes.id = ?
 		return StorageVolumeArgs{}, err
 	}
 
-	response.TypeName = response.Type.Name()
+	response.TypeName = response.Type.String()
 
 	return response, nil
 }
@@ -239,8 +239,8 @@ func (c *ClusterTx) GetStorageVolumes(ctx context.Context, memberSpecific bool, 
 			return err
 		}
 
-		vol.Type = volumeType.Name()
-		vol.ContentType = contentType.Name()
+		vol.Type = volumeType.String()
+		vol.ContentType = contentType.String()
 
 		volumes = append(volumes, &vol)
 
@@ -338,7 +338,7 @@ func (c *ClusterTx) GetLocalStoragePoolVolumeSnapshotsWithType(ctx context.Conte
 			return err
 		}
 
-		s.ContentType = contentType.Name()
+		s.ContentType = contentType.String()
 
 		snapshots = append(snapshots, s)
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5356,8 +5356,7 @@ func allowRemoveSecurityProtectionStart(state *state.State, poolName string, vol
 		return err
 	})
 	if err != nil {
-		volumeTypeName := volumeType.Name()
-		return fmt.Errorf(`Failed loading "%s/%s" from project %q: %w`, volumeTypeName, volumeName, volumeProject, err)
+		return fmt.Errorf(`Failed loading "%s/%s" from project %q: %w`, volumeType, volumeName, volumeProject, err)
 	}
 
 	if shared.IsFalseOrEmpty(dbVolume.Config["security.shared"]) {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -930,7 +930,7 @@ func volumeIsUsedByDevice(vol api.StorageVolume, inst *db.InstanceArgs, dev map[
 			return false, err
 		}
 
-		if inst.Name == vol.Name && rootVolumeDBType.Name() == vol.Type {
+		if inst.Name == vol.Name && rootVolumeDBType.String() == vol.Type {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
As requested in the review of https://github.com/canonical/lxd/pull/14885

Yields a few readability improvements in the disk device driver as well; kudos on the suggestion.