### PR TITLE
Require GHA pinning

### DIFF
--- a/.github/actions/require-gha-pinning/action.yml
+++ b/.github/actions/require-gha-pinning/action.yml
@@ -1,0 +1,19 @@
+name: Require GHA pinning
+description: Require all GitHub actions to be pinned to a full SHA1 hash commit
+
+runs:
+  using: composite
+  steps:
+    - name: Check if all GHA are pinned
+      shell: bash
+      run: |
+        set -eux
+        [ -d .github/workflows/ ]
+
+        # List all actions (`uses:`), ignore those with "foo@FULL.SHA1.HASH.COMMIT # v4.2.1", ignore those shipped by the current repo or the trusted Canonical org.
+        UNPINNED_ACTIONS="$(git grep '\buses:' .github/workflows/ | grep -vE 'uses: [^@]+@[0-9a-f]{40} # .+' | grep -vE 'uses: (\./\.|canonical/)' || true)"
+        if [ -n "${UNPINNED_ACTIONS:-}" ]; then
+          echo "Unpinned GitHub actions found:"
+          echo "${UNPINNED_ACTIONS}"
+          exit 1
+        fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -501,7 +501,7 @@ jobs:
           cd lxd-ui
           dotrun install
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
           node-version: 20
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,9 @@ jobs:
           # A non-shallow clone is needed for the Differential ShellCheck
           fetch-depth: 0
 
+      - name: Require GHA pinning
+        uses: ./.github/actions/require-gha-pinning
+
       - name: Tune disk performance
         uses: ./.github/actions/tune-disk-performance
 


### PR DESCRIPTION
This PR is supposed to fail until I bring in the commit to pin the `actions/setup-node@v4`.

**Update:** this failed as needed until the last commit  was added.