### PR TITLE
lxd: Prevent deleting non-empty project

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1041,12 +1041,8 @@ func projectIsEmpty(ctx context.Context, project *cluster.Project, tx *db.Cluste
 		return false, err
 	}
 
-	if len(profiles) > 0 {
-		// Consider the project empty if it is only used by the default profile.
-		if len(profiles) == 1 && profiles[0].Name == "default" {
-			return true, nil
-		}
-
+	// Consider the project empty if it is only used by the default profile.
+	if len(profiles) > 1 || (len(profiles) == 1 && profiles[0].Name != "default") {
 		return false, nil
 	}
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -661,7 +661,7 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2 --refresh
     LXD_DIR="${LXD_ONE_DIR}" lxc project create foo
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2 --target-project foo
-    LXD_DIR="${LXD_ONE_DIR}" lxc project delete foo
+    ! LXD_DIR="${LXD_ONE_DIR}" lxc project delete foo || false
 
     # Check renaming storage volume works.
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume create pool1 vol2 --target=node1
@@ -675,7 +675,9 @@ test_clustering_storage() {
     # Delete pool and check cleaned up.
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol1 --target=node1
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol1 --target=node2
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol1 --target=node2 --project=foo
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume delete pool1 vol3 --target=node2
+    LXD_DIR="${LXD_ONE_DIR}" lxc project delete foo
     LXD_DIR="${LXD_TWO_DIR}" lxc storage delete pool1
     ! stat "${LXD_ONE_SOURCE}/containers" || false
     ! stat "${LXD_TWO_SOURCE}/containers" || false


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/15179.  

Fixed early return in `projectIsEmpty()` by simplifying if statement to check associated profiles.