### PR TITLE
doc: Untrusted TLS identity post endpoint description

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -7906,7 +7906,7 @@ paths:
                 - application/json
             description: |-
                 Adds a TLS identity as a trusted client.
-                In this mode, the `token` property must be set to the correct value.
+                In this mode, the `trust_token` property must be set to the correct value.
                 The certificate that the client sent during the TLS handshake will be added.
                 The `certificate` field must be omitted.
 

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -203,7 +203,7 @@ func identityAccessHandler(authenticationMethod string, entitlement auth.Entitle
 //  Add a TLS identity
 //
 //  Adds a TLS identity as a trusted client.
-//  In this mode, the `token` property must be set to the correct value.
+//  In this mode, the `trust_token` property must be set to the correct value.
 //  The certificate that the client sent during the TLS handshake will be added.
 //  The `certificate` field must be omitted.
 //


### PR DESCRIPTION
Replaces incorrect `token` with `trust_token`, as that is what is required for this endpoint to work.