### PR TITLE
github: fix regex allow list for local actions

### DIFF
--- a/.github/actions/require-gha-pinning/action.yml
+++ b/.github/actions/require-gha-pinning/action.yml
@@ -10,8 +10,8 @@ runs:
         set -eux
         [ -d .github/workflows/ ]
 
-        # List all actions (`uses:`), ignore those with "foo@FULL.SHA1.HASH.COMMIT # v4.2.1", ignore those shipped by the current repo or the trusted Canonical org.
-        UNPINNED_ACTIONS="$(git grep '\buses:' .github/workflows/ | grep -vE 'uses: [^@]+@[0-9a-f]{40} # .+' | grep -vE 'uses: (\./\.|canonical/)' || true)"
+        # List all actions (`uses:`), ignore those with "foo@FULL.SHA1.HASH.COMMIT # v4.2.1", ignore those shipped by the current repo (`./`) or the trusted Canonical org (`canonical/`).
+        UNPINNED_ACTIONS="$(git grep '\buses:' .github/workflows/ | grep -vE 'uses: [^@]+@[0-9a-f]{40} # .+' | grep -vE 'uses: (\.|canonical)/' || true)"
         if [ -n "${UNPINNED_ACTIONS:-}" ]; then
           echo "Unpinned GitHub actions found:"
           echo "${UNPINNED_ACTIONS}"


### PR DESCRIPTION
The old pattern authorized local aliases with `./.` prefix but `./` is also a legitimate way to refer to local actions. That was found when working on [`canonical/setup-lxd`](https://github.com/canonical/setup-lxd/pull/27). This one is special as it's an action itself.