### PR TITLE
cloud-init: Allow `none` for `cloud-init.ssh-keys.*`

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -297,7 +297,7 @@ config:
 
 To inject SSH keys into LXD instances for an arbitrary user, use the configuration key `cloud-init.ssh-keys.<keyName>`.
 
-Use the format `<user>:<key>` for its value, where `<user>` is a Linux username and `<key>` can be either a pure SSH public key or an import ID for a key hosted elsewhere. For example, `root:gh:githubUser` and `myUser:ssh-keyAlg publicKeyHash` are valid values.
+Use the format `<user>:<key>` for its value, where `<user>` is a Linux username and `<key>` can be either a pure SSH public key or an import ID for a key hosted elsewhere. For example, `root:gh:githubUser` and `myUser:ssh-keyAlg publicKeyHash` are valid values. To prevent a particular SSH key from being inherited from a profile by an instance, edit the instance configuration by setting the `cloud-init.ssh-keys.<keyName>` key that references the target SSH key to `none`, and the key will not be injected.
 
 The contents of the `cloud-init.ssh-keys.<keyName>` keys are merged into both {config:option}`instance-cloud-init:cloud-init.vendor-data` and {config:option}`instance-cloud-init:cloud-init.user-data` before being passed to the guest, following the `cloud-config` specification. (See the {ref}`cloud-init documentation <cloud-init:about-cloud-config>` for details.) Therefore, keys defined via `cloud-init.ssh-keys.<keyName>` cannot be applied if LXD cannot parse the existing `cloud-init.vendor-data` and `cloud-init.user-data` for that instance. This might occur if those keys are not in YAML format or contain invalid YAML. Other configuration formats are not yet supported.
 

--- a/lxd/cloudinit/config.go
+++ b/lxd/cloudinit/config.go
@@ -156,7 +156,7 @@ func extractAdditionalSSHKeys(instanceConfig map[string]string) map[string]*user
 		if strings.HasPrefix(key, "cloud-init.ssh-keys.") {
 			user, sshKey, found := strings.Cut(value, ":")
 
-			// If the "cloud-init.ssh-keys." is badly formatted, skip it.
+			// If the "cloud-init.ssh-keys." is badly formatted or is "none", skip it.
 			if !found {
 				continue
 			}

--- a/shared/validate/validate.go
+++ b/shared/validate/validate.go
@@ -807,6 +807,11 @@ func IsCloudInitUserData(value string) error {
 // IsUserSSHKey checks value is a valid SSH public key for cloud-init.ssh-keys.
 // This should take the format {user}:{key}, and neither part can be empty.
 func IsUserSSHKey(value string) error {
+	// A "none" value can be used to avoid inheriting an SSH key from a profile.
+	if value == "none" {
+		return nil
+	}
+
 	user, key, _ := strings.Cut(value, ":")
 
 	if key == "" {


### PR DESCRIPTION
A `none` value can be used to avoid inheriting an SSH key from profile configuration.