### PR TITLE
lxd/storage/drivers/pure: Unmap volume when connection is freshly created

### DIFF
--- a/lxd/storage/drivers/driver_pure_util.go
+++ b/lxd/storage/drivers/driver_pure_util.go
@@ -1270,7 +1270,7 @@ func (d *pure) mapVolume(vol Volume) (cleanup revert.Hook, err error) {
 	// returned (outer) reverter. Unmap ensures the target is disconnected only when
 	// no other device is using it.
 	outerReverter := revert.New()
-	if !connCreated {
+	if connCreated {
 		outerReverter.Add(func() { _ = d.unmapVolume(vol) })
 	}
 


### PR DESCRIPTION
Fixes left-over volumes on the PureStorage array when volume creation fails.

The `unmapVolume` must be added to `outerReverter` when we are the first to associate (connect) the volume with the PureStorage host. The comment above is correct, just the condition was wrong.

Fixes #15210 