### PR TITLE
Network: Fix bridge fan mode by adding "/" back into `fanAddress()` output

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2644,7 +2644,7 @@ func (n *bridge) fanAddress(underlay *net.IPNet, overlay *net.IPNet) (cidr strin
 
 	ipBytes[3] = 1
 
-	return ipBytes.String() + fmt.Sprint(overlaySize), dev, ipStr, err
+	return ipBytes.String() + "/" + fmt.Sprint(overlaySize), dev, ipStr, err
 }
 
 func (n *bridge) addressForSubnet(subnet *net.IPNet) (net.IP, string, error) {


### PR DESCRIPTION
Fixes 376c6a69c4d3bdb697564da12fcef6c20d8d0b68

Addresses https://github.com/canonical/lxd/issues/15212