### PR TITLE
Do not use Go toolchain directive

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,6 +160,19 @@ jobs:
             echo "OK: ${bin} is between ${min} and ${max}MiB"
           done <<< ${SIZES}
 
+      - name: Check binaries were compiled with the Go minimum version
+        run: |
+          set -eux
+
+          # Check which Go version was used to compile each of the lxc/lxd binaries
+          GOMIN="$(sed -n 's/^GOMIN=\([0-9.]\+\)$/\1/p' Makefile)"
+          UNEXPECTED_GO_VER="$(go version -v ~/go/bin/lxc* ~/go/bin/lxd* | grep -vF ": go${GOMIN}" || true)"
+          if [ -n "${UNEXPECTED_GO_VER:-}" ]; then
+            echo "Some binaries were compiled with an unexpected Go version (!= ${GOMIN}):"
+            echo "${UNEXPECTED_GO_VER}"
+            exit 1
+          fi
+
       - name: Make GOCOVERDIR
         run: mkdir -p "${GOCOVERDIR}"
         if: env.GOCOVERDIR != ''

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ CGO_LDFLAGS_ALLOW ?= (-Wl,-wrap,pthread_create)|(-Wl,-z,now)
 SPHINXENV=doc/.sphinx/venv/bin/activate
 SPHINXPIPPATH=doc/.sphinx/venv/bin/pip
 GOMIN=1.23.3
+GOTOOLCHAIN=local
+export GOTOOLCHAIN
 GOCOVERDIR ?= $(shell go env GOCOVERDIR)
 DQLITE_BRANCH=master
 


### PR DESCRIPTION
We don't want to use any [Go toolchain](https://go.dev/doc/toolchain) as it introduces another variable (an uncontrolled one at that) in the testing matrix.