### PR TITLE
LVM: Fix ref count inconsistency

### DIFF
--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -1007,7 +1007,7 @@ func (d *lvm) DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 	}
 
 	if lvExists {
-		_, err = d.UnmountVolume(snapVol, false, op)
+		_, err = d.UnmountVolumeSnapshot(snapVol, op)
 		if err != nil {
 			return fmt.Errorf("Error unmounting LVM logical volume: %w", err)
 		}

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -791,7 +791,7 @@ func (d *lvm) MountVolume(vol Volume, op *operations.Operation) error {
 }
 
 // UnmountVolume unmounts volume if mounted and not in use. Returns true if this unmounted the volume.
-// keepBlockDev indicates if backing block device should be not be deactivated when volume is unmounted.
+// keepBlockDev indicates if backing block device should not be deactivated when volume is unmounted.
 func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operation) (bool, error) {
 	unlock, err := vol.MountLock()
 	if err != nil {

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -834,6 +834,8 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 			return false, fmt.Errorf("Failed to unmount LVM logical volume: %w", err)
 		}
 
+		d.logger.Debug("Unmounted logical volume", logger.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
+
 		ourUnmount = true
 	} else if vol.contentType == ContentTypeBlock {
 		volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], vol.volType, vol.contentType, vol.name)
@@ -847,10 +849,6 @@ func (d *lvm) UnmountVolume(vol Volume, keepBlockDev bool, op *operations.Operat
 		if err != nil {
 			return false, err
 		}
-
-		d.logger.Debug("Unmounted logical volume", logger.Ctx{"volName": vol.name, "path": mountPath, "keepBlockDev": keepBlockDev})
-
-		ourUnmount = true
 	} else {
 		// Since activation of the LV on mount is unconditional, the activation
 		// refcount needs to be updated regardless of whether we actually

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -1169,13 +1169,22 @@ func (d *lvm) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (b
 
 	refCount := snapVol.MountRefCountDecrement()
 
+	// For VMs, unmount the filesystem volume.
+	if snapVol.IsVMBlock() {
+		fsVol := snapVol.NewVMBlockFilesystemVolume()
+		ourUnmount, err = d.UnmountVolumeSnapshot(fsVol, op)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if refCount > 0 {
+		d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": snapVol.name, "refCount": refCount})
+		return false, ErrInUse
+	}
+
 	// Check if already mounted.
 	if snapVol.contentType == ContentTypeFS && filesystem.IsMountPoint(mountPath) {
-		if refCount > 0 {
-			d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": snapVol.name, "refCount": refCount})
-			return false, ErrInUse
-		}
-
 		err = TryUnmount(mountPath, 0)
 		if err != nil {
 			return false, fmt.Errorf("Failed to unmount LVM snapshot volume: %w", err)
@@ -1198,37 +1207,23 @@ func (d *lvm) UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (b
 			}
 		}
 
-		// We only deactivate filesystem volumes if an unmount was needed to better align with our
-		// unmount return value indicator.
-		_, err = d.deactivateVolume(snapVol)
-		if err != nil {
-			return false, err
-		}
-
 		ourUnmount = true
 	} else if snapVol.contentType == ContentTypeBlock {
-		// For VMs, unmount the filesystem volume.
-		if snapVol.IsVMBlock() {
-			fsVol := snapVol.NewVMBlockFilesystemVolume()
-			ourUnmount, err = d.UnmountVolumeSnapshot(fsVol, op)
-			if err != nil {
-				return false, err
-			}
-		}
-
 		volDevPath := d.lvmDevPath(d.config["lvm.vg_name"], snapVol.volType, snapVol.contentType, snapVol.name)
 		if shared.PathExists(volDevPath) {
 			if refCount > 0 {
 				d.logger.Debug("Skipping unmount as in use", logger.Ctx{"volName": snapVol.name, "refCount": refCount})
 				return false, ErrInUse
 			}
+		}
+	}
 
-			_, err = d.deactivateVolume(snapVol)
-			if err != nil {
-				return false, err
-			}
-
-			ourUnmount = true
+	// We only deactivate filesystem volumes if an unmount was needed to better align with our
+	// unmount return value indicator.
+	if ourUnmount {
+		_, err = d.deactivateVolume(snapVol)
+		if err != nil {
+			return false, err
 		}
 	}
 


### PR DESCRIPTION
Fixes the problem caught in https://github.com/canonical/lxd-ci/actions/runs/13923914369/job/38963535130.

When deleting a snapshot for a running instance, its deactivation ref count was decremented to 0, which prompted LXD to thing deativating the volume group was safe, when in fact the VM root volume that is part of the same volume groups as the snapshot was still in use as the VM was running.

To fix this, we first use `UnmountVolumeSnapshot` instead of `UnmountVolume` when deleting snapshots and rework `UnmountVolumeSnapshot` to decrement the ref count only if the snapshot was just unmounted.