### PR TITLE
VM: Use full device name in qemu's `device_id`

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4074,6 +4074,13 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 
 	qemuDeviceSerial := qemuDeviceNamePrefix + escapedDeviceName
 	qemuDev["serial"] = qemuDeviceSerial
+
+	// Trim the serial down to 36 characters if longer than that, since this is the max size of a serial in QEMU.
+	// Do not hash as to not break older guests that were relying on QEMU to reduce the size of the device serial.
+	if len(qemuDeviceSerial) > 36 {
+		qemuDev["serial"] = qemuDeviceSerial[:36]
+	}
+
 	if bus == "virtio-scsi" {
 		qemuDev["device_id"] = qemuDeviceSerial
 		qemuDev["channel"] = 0

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4071,10 +4071,11 @@ func (d *qemu) addDriveConfig(qemuDev map[string]any, bootIndexes map[string]int
 	}
 
 	qemuDev["drive"] = qemuDevDrive
-	qemuDev["serial"] = qemuDeviceNamePrefix + escapedDeviceName
 
+	qemuDeviceSerial := qemuDeviceNamePrefix + escapedDeviceName
+	qemuDev["serial"] = qemuDeviceSerial
 	if bus == "virtio-scsi" {
-		qemuDev["device_id"] = qemuDeviceNameOrID(qemuDeviceNamePrefix, driveConf.DevName, "", qemuDeviceNameMaxLength)
+		qemuDev["device_id"] = qemuDeviceSerial
 		qemuDev["channel"] = 0
 		qemuDev["lun"] = 1
 		qemuDev["bus"] = "qemu_scsi.0"


### PR DESCRIPTION
In QEMU 9.1.1, using the device serial as a default for its ID fails if the serial is longer than 20 characters (https://github.com/lxc/incus/issues/1536). So a cherry pick that we performed from Incus made it so we explicitly provide the `device_id` (https://github.com/canonical/lxd/pull/15154/commits/e0f99467da0ae6431c716d1ce6a66d41d34d104b). This changed the format the `device_id` takes and broke our tests (https://github.com/canonical/lxd-ci/actions/runs/13923914369/job/38963532720).

This proposes an improvement to the format of `device_id`. I concluded from manually testing that we don't have a lenght limit for `device_id`, we can just use the full `lxd_<escaped_lxd_device_name>`. lxc-ci tests are adapted in https://github.com/canonical/lxd-ci/pull/434.