### PR TITLE
doc: hard-code additional link titles

### DIFF
--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,5 +1,6 @@
 ---
-discourse: lxc:[LXD&#32;cluster&#32;on&#32;Raspberry&#32;Pi&#32;4](9076),lxc:[Introducing&#32;MicroCloud](15871)
+discourse: lxc:[LXD&#32;cluster&#32;on&#32;Raspberry&#32;Pi&#32;4](9076)
+relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
 ---
 
 (clustering)=

--- a/doc/explanation/authorization.md
+++ b/doc/explanation/authorization.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:[Identity&#32;and&#32;Access&#32;Management&#32;for&#32;LXD](41516)
+discourse: '[Identity&#32;and&#32;Access&#32;Management&#32;for&#32;LXD](41516)'
 ---
 
 (authorization)=

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:15728
+discourse: lxc:[Scriptlet&#32;based&#32;instance&#32;placement&#32;scheduler](15728)
 ---
 
 (exp-clusters)=

--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:8767,lxc:7519,lxc:9281
+discourse: lxc:[Overview&#32;-&#32;GUI&#32;inside&#32;Containers](8767),lxc:[Running&#32;virtual&#32;machines&#32;with&#32;LXD&#32;4.0](7519),lxc:[Install&#32;any&#32;OS&#32;via&#32;ISO&#32;in&#32;a&#32;Virtual&#32;machine/VM](9281)
 relatedlinks: '[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubuntu.com/blog/lxd-virtual-machines-an-overview)'
 ---
 

--- a/doc/explanation/lxd_lxc.md
+++ b/doc/explanation/lxd_lxc.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:24
+discourse: lxc:[Comparing&#32;LXD&#32;vs.&#32;LXC](24)
 ---
 
 (lxd-lxc)=

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://www.youtube.com/watch?v=QyXOOE_4cm0
+relatedlinks: '[Running&#32;LXD&#32;in&#32;production&#32;-&#32;YouTube](https://www.youtube.com/watch?v=QyXOOE_4cm0)'
 ---
 
 (performance-tuning)=

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://linuxcontainers.org/lxc/security/
+relatedlinks: '[Linux&#32;containers&#32;security](https://linuxcontainers.org/lxc/security/)'
 ---
 
 (exp-security)=

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:15871
+relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
 ---
 
 (cluster-form)=

--- a/doc/howto/cluster_groups.md
+++ b/doc/howto/cluster_groups.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:12716
+discourse: lxc:[Cluster&#32;server&#32;grouping](12716)
 ---
 
 (howto-cluster-groups)=

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:11330
+discourse: lxc:[Cluster&#32;member&#32;evacuation](11330)
 ---
 
 (cluster-manage)=

--- a/doc/howto/disaster_recovery.md
+++ b/doc/howto/disaster_recovery.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:11296
+discourse: lxc:[New&#32;disaster&#32;recovery&#32;tool](11296)
 ---
 
 (disaster-recovery)=

--- a/doc/howto/grafana.md
+++ b/doc/howto/grafana.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: https://grafana.com/grafana/dashboards/19131-lxd/
+relatedlinks: '[LXD&#32;Grafana&#32;dashboard](https://grafana.com/grafana/dashboards/19131-lxd/)'
 ---
 
 (grafana)=

--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:14345
+discourse: lxc:[Using&#32;lxd-migrate&#32;to&#32;convert&#32;a&#32;physical&#32;host&#32;to&#32;a&#32;container](14345)
 ---
 
 (import-machines-to-instances)=

--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:9223
+discourse: lxc:[GUI&#32;in&#32;Virtual&#32;Machines/VMs](9223)
 ---
 
 (instances-console)=

--- a/doc/howto/instances_troubleshoot.md
+++ b/doc/howto/instances_troubleshoot.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:7362
+discourse: lxc:[How&#32;to&#32;best&#32;ask&#32;questions&#32;on&#32;Discourse](7362)
 ---
 
 (instances-troubleshoot)=

--- a/doc/howto/move_instances.md
+++ b/doc/howto/move_instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:16635
+discourse: lxc:[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](16635)
 ---
 
 (move-instances)=

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:13223
+discourse: lxc:[Network&#32;ACL&#32;logging](13223)
 ---
 
 (network-acls)=

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:11567
+discourse: lxc:[BGP&#32;address/route&#32;advertisement](11567)
 ---
 
 (network-bgp)=

--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:10034,lxc:9953
+discourse: lxc:[Lxd&#32;bridge&#32;doesn't&#32;work&#32;with&#32;IPv4&#32;and&#32;UFW&#32;with&#32;nftables](10034),lxc:[LXD&#32;and&#32;Docker&#32;Firewall&#32;Redux&#32;-&#32;How&#32;to&#32;deal&#32;with&#32;FORWARD&#32;policy&#32;set&#32;to&#32;drop](9953)
 ---
 
 (network-bridge-firewall)=

--- a/doc/howto/network_forwards.md
+++ b/doc/howto/network_forwards.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:11801
+discourse: lxc:[Floating&#32;IP&#32;addresses](11801)
 ---
 
 (network-forwards)=

--- a/doc/howto/network_load_balancers.md
+++ b/doc/howto/network_load_balancers.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:14317
+discourse: lxc:[Network&#32;load-balancers&#32;(OVN)](14317)
 ---
 
 (network-load-balancers)=

--- a/doc/howto/network_ovn_peers.md
+++ b/doc/howto/network_ovn_peers.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:12165
+discourse: lxc:[OVN&#32;network&#32;to&#32;network&#32;routing](12165)
 ---
 
 (network-ovn-peers)=

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:12033,lxc:13128
+discourse: lxc:[Built-in&#32;DNS&#32;server](12033),lxc:[Custom&#32;DNS&#32;records&#32;in&#32;network&#32;zones](13128)
 ---
 
 (network-zones)=

--- a/doc/howto/snap.md
+++ b/doc/howto/snap.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:[Managing&#32;the&#32;LXD&#32;snap&#32;package](37214)
+discourse: '[Managing&#32;the&#32;LXD&#32;snap&#32;package](37214)'
 ---
 
 (howto-snap)=

--- a/doc/howto/storage_move_volume.md
+++ b/doc/howto/storage_move_volume.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:10877
+discourse: lxc:[Migrate&#32;from&#32;one&#32;storage&#32;pool&#32;to&#32;another](10877)
 ---
 
 (howto-storage-move-volume)=

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:1333
+discourse: lxc:[How&#32;to&#32;resize&#32;ZFS&#32;used&#32;in&#32;LXD](1333)
 ---
 
 (howto-storage-pools)=

--- a/doc/reference/devices_proxy.md
+++ b/doc/reference/devices_proxy.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:8355
+discourse: lxc:[Using&#32;proxy&#32;device&#32;to&#32;forward&#32;network&#32;connections&#32;from&#32;host&#32;to&#32;container&#32;in&#32;NAT&#32;mode](8355)
 ---
 
 (devices-proxy)=

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:7322
+discourse: lxc:[Getting&#32;universally&#32;routable&#32;IPv6&#32;Addresses&#32;for&#32;your&#32;Linux&#32;Containers&#32;on&#32;Ubuntu&#32;18.04&#32;with&#32;LXD&#32;4.0&#32;on&#32;a&#32;VPS](7322)
 ---
 
 (network-bridge)=

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:11033
+discourse: lxc:[OVN&#32;high&#32;availability&#32;cluster&#32;tutorial](11033)
 ---
 
 (network-ovn)=

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,6 +1,6 @@
 ---
-discourse: ubuntu:[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)
-relatedlinks: https://www.youtube.com/watch?v=pM0EgUqj2a0
+discourse: '[New&#32;LXD&#32;image&#32;server&#32;available&#32;(images.lxd.canonical.com)](43824),[Image&#32;server&#32;infrastructure](16647)'
+relatedlinks: '[Deploying&#32;a&#32;new&#32;LXD&#32;image&#32;server&#32;-&#32;YouTube](https://www.youtube.com/watch?v=pM0EgUqj2a0)'
 ---
 
 (remote-image-servers)=

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:15457
+discourse: lxc:[Introducing&#32;MicroCeph](15457)
 ---
 
 (storage-ceph)=

--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:15457
+discourse: lxc:[Introducing&#32;MicroCeph](15457)
 ---
 
 (storage-cephfs)=

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -1,6 +1,6 @@
 ---
-discourse: lxc:14579,lxc:15457
-relatedlinks: https://youtube.com/watch?v=kVLGbvRU98A
+discourse: lxc:[LXD&#32;object&#32;storage&#32;(S3&#32;API)](14579),lxc:[Introducing&#32;MicroCeph](15457)
+relatedlinks: '[Ceph&#32;and&#32;a&#32;LXD&#32;cluster&#32;-&#32;YouTube](https://youtube.com/watch?v=kVLGbvRU98A)'
 ---
 
 (storage-cephobject)=

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -1,5 +1,5 @@
 ---
-discourse: lxc:15872
+discourse: lxc:[ZFS&#32;block&#32;mode](15872)
 ---
 
 (storage-zfs)=

--- a/doc/reference/uefi_variables.md
+++ b/doc/reference/uefi_variables.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:[LXD&#32;VM&#32;instance&#32;EFI&#32;Variables&#32;edit&#32;CLI](42313)
+discourse: '[LXD&#32;VM&#32;instance&#32;EFI&#32;Variables&#32;edit&#32;CLI](42313)'
 ---
 
 # UEFI variables for VMs

--- a/doc/reference/vm_live_migration_internals.md
+++ b/doc/reference/vm_live_migration_internals.md
@@ -1,5 +1,5 @@
 ---
-discourse: ubuntu:[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](50734)
+discourse: '[Online&#32;VM&#32;live-migration&#32;(QEMU&#32;to&#32;QEMU)](50734)'
 ---
 
 (vm-live-migration-internals)=


### PR DESCRIPTION
More `discourse:` and `relatedlinks` titles updated for hard-coded titles instead of fetching at build. Continuation of https://github.com/canonical/lxd/pull/15131 - I missed a bunch in my original search that were nested inside folders.