### PR TITLE
feat(doc): add steps to verify lxd host support for vms

### DIFF
--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -68,6 +68,18 @@ If you prefer a different installation method, or use a Linux distribution that 
    This will create a minimal setup with default options.
    If you want to tune the initialization options, see {ref}`initialize` for more information.
 
+1. LXD supports both {ref}`containers-and-vms`. For LXD virtual machines, your host system must be capable of KVM virtualization. To check this, run the following command:
+
+       lxc info | grep -FA2 'instance_types'
+
+   The following output indicates that your host system is capable of virtualization:
+
+       instance_types:
+       - container
+       - virtual-machine
+
+   If `virtual-machine` fails to appear in the output, this indicates that the host system is not capable of virtualization. In this case, LXD can only be used for containers. You can proceed with this tutorial to learn about using containers, but disregard the steps that refer to virtual machines.
+
 <!-- Include end tutorial installation -->
 
 ## Launch and inspect instances


### PR DESCRIPTION
Currently tutorial provide steps to create both container and virtual machine instances. But it doesn't verify lxd host support for kvm virtualization. Due to this if user try to create a virtual machine on a non-supported lxd host following error will be prompted.

```
Launching ubuntu-vm
Error: Failed instance creation: No suitable cluster member could be found
```

This change will add additional steps to the tutorial to install cpu-checker and check output of kvm-ok status. Similar approach is followed in MAAS documentation.