### PR TITLE
client/connection: use LegacyCurvesOnly for simplestreams connections

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -267,7 +267,10 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper)
+	// Do not include modern post-quantum curves in the ClientHello to avoid
+	// compatibility issues (connection resets) with broken middleboxes that
+	// can't handle large ClientHello messages split over multiple TCP packets.
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, true, args.Proxy, args.TransportWrapper)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +340,7 @@ func httpsLXD(ctx context.Context, requestURL string, args *ConnectionArgs) (Ins
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy, args.TransportWrapper)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, false, args.Proxy, args.TransportWrapper)
 	if err != nil {
 		return nil, err
 	}

--- a/client/util.go
+++ b/client/util.go
@@ -18,13 +18,29 @@ import (
 
 // tlsHTTPClient creates an HTTP client with a specified Transport Layer Security (TLS) configuration.
 // It takes in parameters for client certificates, keys, Certificate Authority, server certificates,
-// a boolean for skipping verification, a proxy function, and a transport wrapper function.
+// a boolean for skipping verification, a boolean for including only legacy curves in ClientHello, a
+// proxy function, and a transport wrapper function.
 // It returns the HTTP client with the provided configurations and handles any errors that might occur during the setup process.
-func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) HTTPTransporter) (*http.Client, error) {
+func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, legacyCurvesOnly bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) HTTPTransporter) (*http.Client, error) {
 	// Get the TLS configuration
 	tlsConfig, err := shared.GetTLSConfigMem(tlsClientCert, tlsClientKey, tlsCA, tlsServerCert, insecureSkipVerify)
 	if err != nil {
 		return nil, err
+	}
+
+	// If legacyCurvesOnly is true, don't include the post-quantum curve
+	// (`X25519MLKEM768` or `X25519Kyber768Draft00`) in the list of supported
+	// curves. Those extra curves causes the ClientHello message to be too
+	// large to fit in a single packet, causing some broken middleboxes to reset
+	// the connection because they failed to reassemble the TCP packets.
+	if legacyCurvesOnly {
+		// Matches the default list of curves in Go 1.23 with `GODEBUG=tlskyber=0,tlsmlkem=0`
+		tlsConfig.CurvePreferences = []tls.CurveID{
+			tls.X25519,
+			tls.CurveP256,
+			tls.CurveP384,
+			tls.CurveP521,
+		}
 	}
 
 	// Define the http transport


### PR DESCRIPTION
The modern post-quantum curve that has been enabled by default with [Go 1.23+](https://go.dev/doc/go1.23) causes the `ClientHello` message to be much bigger than before due to MLKEM/Kyber needing big `key_share`. This size inflation sometimes causes the `ClientHello` message to be split over multiple (usually 2) TCP packets.

This message splitting can confuse broken middleboxes and lead them to abort the connection (`connection reset by peer`). This problem is well explained [here](https://tldr.fail/).

Those middleboxes are more likely to be intercepting connections to images servers (`images:`, `ubuntu:`, etc) than `lxc` to `lxd` communication. As such, do not use modern post-quantum curves when dealing with `simplestreams` remote.

Addresses #14839.