### PR TITLE
Storage: Fix import of iso images smaller than 512B on ceph

### DIFF
--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -101,6 +101,15 @@ func (d *ceph) osdDeletePool() error {
 	return nil
 }
 
+func (d *ceph) roundUpTo512(a int64) int64 {
+	result := (a / 512) * 512
+	if a%512 != 0 {
+		result += 512
+	}
+
+	return result
+}
+
 // rbdCreateVolume creates an RBD storage volume.
 // Note that the default set of features is intentionally limited
 // by passing --image-feature explicitly. This is done to ensure that
@@ -130,6 +139,9 @@ func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
 	if d.config["ceph.osd.data_pool_name"] != "" {
 		cmd = append(cmd, "--data-pool", d.config["ceph.osd.data_pool_name"])
 	}
+
+	// Ceph allows writing only to images of size in multiples of 512B
+	sizeBytes = d.roundUpTo512(sizeBytes)
 
 	cmd = append(cmd,
 		"--size", fmt.Sprintf("%dB", sizeBytes),

--- a/test/suites/storage_volume_import.sh
+++ b/test/suites/storage_volume_import.sh
@@ -1,6 +1,9 @@
 test_storage_volume_import() {
-  truncate -s 25MiB foo.iso
-  truncate -s 25MiB foo.img
+  # Some storage types, such as lvm and ceph, support only 512-aligned image sizes
+  # Test with weird sizes of images
+  dd if=/dev/urandom of=foo.iso bs=359 count=1
+  dd if=/dev/urandom of=foo.img bs=1M count=1
+  echo -n "a" >> foo.img
 
   ensure_import_testimage
 


### PR DESCRIPTION
Ceph storage has a limitation that if the size of the image is less than 512B, the image is not writable.
Fixes: https://github.com/canonical/lxd/issues/15196