### PR TITLE
github: add issue form and template configuration

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,87 @@
+name: Bug report
+description: Create a report to help us improve
+title: "bug: "
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Note**: GitHub issues are used for bug reports. For support questions, please use [our forum](https://discourse.ubuntu.com/c/lxd/).
+
+        Please fill out the fields below to the best of your ability. Doing so will help us track down and reproduce your bug. 
+        
+        If a field does not apply to your bug, you can answer "n/a". Feel free to add more information where it makes sense.
+
+  - type: checkboxes
+    id: ack_searched
+    attributes:
+      label: Please confirm
+      options:
+        - label: I have searched existing issues to check if an issue already exists for the bug I encountered.
+          required: true
+
+  - type: input
+    id: distribution
+    attributes:
+      label: Distribution
+      description: Which Linux distribution are you using?
+    validations:
+      required: true
+
+  - type: input
+    id: distro_version
+    attributes:
+      label: Distribution version
+    validations:
+      required: true
+
+  - type: textarea
+    id: snap_list
+    attributes:
+      label: Output of "snap list --all lxd core20 core22 core24 snapd"
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: lxc_info
+    attributes:
+      label: Output of "lxc info" or system info if it fails
+      description: If "lxc info" fails, please provide kernel, LXC, LXD versions, and storage backend.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue_description
+    attributes:
+      label: Issue description
+      description: What were you doing, what happened, and what did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Step one
+        2. Step two
+        3. Step three
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: attachments
+    attributes:
+      label: Information to attach
+      description: If you have any of the following information, please attach them as text files.
+      options:
+        - label: Any relevant kernel output (`dmesg`)
+        - label: Container log (`lxc info NAME --show-log`)
+        - label: Container configuration (`lxc config show NAME --expanded`)
+        - label: Main daemon log (at `/var/log/lxd/lxd.log` or `/var/snap/lxd/common/lxd/logs/lxd.log`)
+        - label: Output of the client with `--debug`
+        - label: Output of the daemon with `--debug` (or use `lxc monitor` while reproducing the issue)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://discourse.ubuntu.com/c/lxd
+    about: Ask a question or request help in our community forum


### PR DESCRIPTION
This PR uses the new [issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) option to reproduce the legacy issue template at `.github/ISSUE_TEMPLATE.md` with web form fields. It adds to the contents of the legacy template a checkbox for the issue submitter to indicate they have searched for duplicate issues.

It also adds a configuration file that affects the [template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser). The configuration disables blank templates and sets a link in the template chooser to the Discourse forums for support/questions. 