### PR TITLE
Firewall: Fix regression in nftables port range rules

### DIFF
--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -941,7 +941,7 @@ func (d Nftables) aclRulePortToACLMatch(direction string, portCriteria ...string
 	for _, portCriterion := range portCriteria {
 		criterionParts := strings.SplitN(portCriterion, "-", 2)
 		if len(criterionParts) > 1 {
-			fieldParts = append(fieldParts, criterionParts[0]+criterionParts[1])
+			fieldParts = append(fieldParts, criterionParts[0]+"-"+criterionParts[1])
 		} else {
 			fieldParts = append(fieldParts, criterionParts[0])
 		}


### PR DESCRIPTION
Fixes regression from 3725dbc78ca8f51b076639a7d5118ec36b46da10

Missing "-" in generated nftables rules.

Fixes https://github.com/canonical/lxd/issues/15257