### PR TITLE
lint: Fix new warnings from switching to `golangci-lint` v2

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1761,19 +1761,19 @@ func (c *cmdStorageVolumeList) parseColumns(clustered bool, allVolumes bool) ([]
 				return nil, errors.New(i18n.G("Can't specify column L when not clustered"))
 			}
 		}
-		c.flagColumns = strings.Replace(c.flagColumns, "L", "", -1)
+		c.flagColumns = strings.ReplaceAll(c.flagColumns, "L", "")
 	}
 
 	if allVolumes {
 		columnsShorthandMap['p'] = volumeColumn{Name: i18n.G("POOL"), Data: c.poolColumnData}
 	} else {
-		c.flagColumns = strings.Replace(c.flagColumns, "p", "", -1)
+		c.flagColumns = strings.ReplaceAll(c.flagColumns, "p", "")
 	}
 
 	if c.flagAllProjects {
 		columnsShorthandMap['e'] = volumeColumn{Name: i18n.G("PROJECT"), Data: c.projectColumnData}
 	} else {
-		c.flagColumns = strings.Replace(c.flagColumns, "e", "", -1)
+		c.flagColumns = strings.ReplaceAll(c.flagColumns, "e", "")
 	}
 
 	columnList := strings.Split(c.flagColumns, ",")

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -855,10 +855,7 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 	defer instOp.Done(err)
 
 	instancePath := storagePools.InstancePath(instanceType, projectName, backupConf.Container.Name, false)
-	isPrivileged := false
-	if backupConf.Container.Config["security.privileged"] == "" {
-		isPrivileged = true
-	}
+	isPrivileged := backupConf.Container.Config["security.privileged"] == ""
 
 	err = storagePools.CreateContainerMountpoint(instanceMountPoint, instancePath, isPrivileged)
 	if err != nil {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1668,11 +1668,12 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 			// Convert options into flags.
 			for _, opt := range mount.Opts {
-				if opt == "bind" {
+				switch opt {
+				case "bind":
 					flags |= unix.MS_BIND
-				} else if opt == "rbind" {
+				case "rbind":
 					flags |= unix.MS_BIND | unix.MS_REC
-				} else if opt == "ro" {
+				case "ro":
 					flags |= unix.MS_RDONLY
 				}
 			}
@@ -1840,11 +1841,12 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 
 	// Revert the currently applied on-disk idmap.
 	if diskIdmap != nil {
-		if storageType == "zfs" {
+		switch storageType {
+		case "zfs":
 			err = diskIdmap.UnshiftRootfs(d.RootfsPath(), storageDrivers.ShiftZFSSkipper)
-		} else if storageType == "btrfs" {
+		case "btrfs":
 			err = storageDrivers.UnshiftBtrfsRootfs(d.RootfsPath(), diskIdmap)
-		} else {
+		default:
 			err = diskIdmap.UnshiftRootfs(d.RootfsPath(), nil)
 		}
 
@@ -1859,11 +1861,12 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 	// idmap of the container now. Otherwise we will later instruct LXC to
 	// make use of idmapped storage.
 	if nextIdmap != nil && idmapType == idmap.IdmapStorageNone {
-		if storageType == "zfs" {
+		switch storageType {
+		case "zfs":
 			err = nextIdmap.ShiftRootfs(d.RootfsPath(), storageDrivers.ShiftZFSSkipper)
-		} else if storageType == "btrfs" {
+		case "btrfs":
 			err = storageDrivers.ShiftBtrfsRootfs(d.RootfsPath(), nextIdmap)
-		} else {
+		default:
 			err = nextIdmap.ShiftRootfs(d.RootfsPath(), nil)
 		}
 
@@ -6502,11 +6505,12 @@ func (d *lxc) migrate(args *instance.CriuMigrationArgs) error {
 				return fmt.Errorf("Storage type: %w", err)
 			}
 
-			if storageType == "zfs" {
+			switch storageType {
+			case "zfs":
 				err = idmapset.ShiftRootfs(args.StateDir, storageDrivers.ShiftZFSSkipper)
-			} else if storageType == "btrfs" {
+			case "btrfs":
 				err = storageDrivers.ShiftBtrfsRootfs(args.StateDir, idmapset)
-			} else {
+			default:
 				err = idmapset.ShiftRootfs(args.StateDir, nil)
 			}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -387,10 +387,7 @@ type lxc struct {
 }
 
 func idmapSize(state *state.State, isolatedStr string, size string) (int64, error) {
-	isolated := false
-	if shared.IsTrue(isolatedStr) {
-		isolated = true
-	}
+	isolated := shared.IsTrue(isolatedStr)
 
 	var idMapSize int64
 	if size == "" || size == "auto" {
@@ -418,10 +415,7 @@ func idmapSize(state *state.State, isolatedStr string, size string) (int64, erro
 var idmapLock sync.Mutex
 
 func findIdmap(state *state.State, cName string, isolatedStr string, configBase string, configSize string, rawIdmap string) (*idmap.IdmapSet, int64, error) {
-	isolated := false
-	if shared.IsTrue(isolatedStr) {
-		isolated = true
-	}
+	isolated := shared.IsTrue(isolatedStr)
 
 	rawMaps, err := idmap.ParseRawIdmap(rawIdmap)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2718,7 +2718,7 @@ func (d *qemu) generateConfigShare() error {
 				return fmt.Errorf("Failed getting info for existing lxd-agent install %q: %w", lxdAgentInstallPath, err)
 			}
 
-			if lxdAgentInstallInfo.ModTime() == lxdAgentSrcInfo.ModTime() && lxdAgentInstallInfo.Size() == lxdAgentSrcInfo.Size() {
+			if lxdAgentInstallInfo.ModTime().Equal(lxdAgentSrcInfo.ModTime()) && lxdAgentInstallInfo.Size() == lxdAgentSrcInfo.Size() {
 				lxdAgentNeedsInstall = false
 			}
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5656,7 +5656,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		// If security.protection.start is being removed, we need to make sure that
 		// our root disk device is not attached to another instance.
 		if shared.IsTrue(oldExpandedConfig["security.protection.start"]) && shared.IsFalseOrEmpty(d.expandedConfig["security.protection.start"]) {
-			err := allowRemoveSecurityProtectionStart(d.state, newRootDev["pool"], d.common.name, &d.common.project)
+			err := allowRemoveSecurityProtectionStart(d.state, newRootDev["pool"], d.name, &d.project)
 			if err != nil {
 				return err
 			}

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -135,7 +135,7 @@ func validConfigKey(os *sys.OS, key string, value string, instanceType instancet
 	// Check if the key is a valid prefix and whether or not it requires a subkey.
 	knownPrefixes := append(instancetype.ConfigKeyPrefixesAny, instancetype.ConfigKeyPrefixesContainer...)
 	if strings.HasSuffix(key, ".") {
-		if !(key == instancetype.ConfigVolatilePrefix || shared.ValueInSlice(key, knownPrefixes)) {
+		if key != instancetype.ConfigVolatilePrefix && !shared.ValueInSlice(key, knownPrefixes) {
 			// Not a known prefix.
 			return fmt.Errorf("Unknown configuration key: %q", key)
 		}
@@ -156,7 +156,7 @@ func validConfigKey(os *sys.OS, key string, value string, instanceType instancet
 		}
 
 		_, existsAny := instancetype.InstanceConfigKeysAny[key]
-		if !(exists || existsAny) {
+		if !exists && !existsAny {
 			return fmt.Errorf("%q isn't supported for %q", key, instanceType)
 		}
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7070,12 +7070,14 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 			return nil, fmt.Errorf("Storage driver returned unexpected VM volume with filesystem content type (%q)", poolVol.Name())
 		}
 
-		if volType == drivers.VolumeTypeVM || volType == drivers.VolumeTypeContainer {
+		switch volType {
+		case drivers.VolumeTypeVM, drivers.VolumeTypeContainer:
 			err = b.detectUnknownInstanceVolume(&poolVol, projectVols, op)
 			if err != nil {
 				return nil, err
 			}
-		} else if volType == drivers.VolumeTypeCustom {
+
+		case drivers.VolumeTypeCustom:
 			// Get a new volume from the one returned by the storage driver.
 			// This sets a new UUID for the volume that will be used later on for its database entry.
 			poolVol = b.GetNewVolume(poolVol.Type(), poolVol.ContentType(), poolVol.Name(), poolVol.Config())
@@ -7083,7 +7085,8 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 			if err != nil {
 				return nil, err
 			}
-		} else if volType == drivers.VolumeTypeBucket {
+
+		case drivers.VolumeTypeBucket:
 			// Get a new volume from the one returned by the storage driver.
 			// This sets a new UUID for the volume that will be used later on for its database entry.
 			poolVol = b.GetNewVolume(poolVol.Type(), poolVol.ContentType(), poolVol.Name(), poolVol.Config())
@@ -7278,11 +7281,12 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 	contentType := vol.ContentType()
 	var apiContentType string
 
-	if contentType == drivers.ContentTypeBlock {
+	switch contentType {
+	case drivers.ContentTypeBlock:
 		apiContentType = cluster.StoragePoolVolumeContentTypeNameBlock
-	} else if contentType == drivers.ContentTypeISO {
+	case drivers.ContentTypeISO:
 		apiContentType = cluster.StoragePoolVolumeContentTypeNameISO
-	} else if contentType == drivers.ContentTypeFS {
+	case drivers.ContentTypeFS:
 		apiContentType = cluster.StoragePoolVolumeContentTypeNameFS
 
 		// Detect block volume filesystem (by mounting it (if not already) with filesystem probe mode).
@@ -7311,7 +7315,8 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 			// Record detected filesystem in config.
 			vol.Config()["block.filesystem"] = blockFS
 		}
-	} else {
+
+	default:
 		return fmt.Errorf("Unknown custom volume content type %q", contentType)
 	}
 


### PR DESCRIPTION
Whilst rebasing https://github.com/canonical/lxd/pull/15129 I found new linter warnings due to the switch of `golangci-lint` to v2. 
I have decided to move the bits into a separate PR to reduce the changes in the original PR.