### PR TITLE
doc: add localhost:8080 to linkcheck_ignore

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -159,6 +159,8 @@ linkcheck_ignore = [
     'https://127.0.0.1:8443/1.0',
     'https://web.libera.chat/#lxd',
     'http://localhost:8000',
+    'http://localhost:8080',
+    'http://localhost:8080/admin',
     r'/lxd/en/latest/api/.*',
     r'/api/.*',
     # Those links may fail from time to time


### PR DESCRIPTION
Links to `localhost:8080` and `localhost:8080/admin` I added in recently merged Keycloak docs (https://github.com/canonical/lxd/pull/15216) are not passing linkcheck (the Keycloak docs PR skipped the linkcheck test). This PR adds them to the linkcheck_ignore list.