### PR TITLE
doc: show annotations in microcloud docs integration

### DIFF
--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -5,6 +5,12 @@ relatedlinks: '[MicroCloud](https://canonical.com/microcloud)'
 (cluster-form)=
 # How to form a cluster
 
+````{only} integrated
+```{note}
+MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles forming a LXD cluster. Following MicroCloud setup, LXD cluster commands can be used on the MicroCloud.
+```
+````
+
 When forming a LXD cluster, you start with a bootstrap server.
 This bootstrap server can be an existing LXD server or a newly installed one.
 

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -1,6 +1,12 @@
 (initialize)=
 # How to initialize LXD
 
+````{only} integrated
+```{note}
+MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles the initialization of LXD.
+```
+````
+
 Before you can create a LXD instance, you must configure and initialize LXD.
 
 ## Interactive configuration

--- a/doc/howto/network_create.md
+++ b/doc/howto/network_create.md
@@ -1,6 +1,12 @@
 (network-create)=
 # How to create a network
 
+````{only} integrated
+```{note}
+MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles forming a network. Following MicroCloud setup, LXD networking commands can be used with the MicroCloud.
+```
+````
+
 To create a managed network, use the [`lxc network`](lxc_network.md) command and its subcommands.
 Append `--help` to any command to see more information about its usage and available flags.
 

--- a/doc/howto/network_ovn_setup.md
+++ b/doc/howto/network_ovn_setup.md
@@ -1,6 +1,12 @@
 (network-ovn-setup)=
 # How to set up OVN with LXD
 
+````{only} integrated
+```{note}
+MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles OVN network setup.
+```
+````
+
 See the following sections for how to set up a basic OVN network, either as a standalone network or to host a small LXD cluster.
 
 ## Set up a standalone OVN network

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -5,6 +5,12 @@ discourse: "[Building&#32;custom&#32;LXD&#32;binaries&#32;for&#32;side&#32;loadi
 (installing)=
 # How to install LXD
 
+````{only} integrated
+```{note}
+MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles the installation and configuration of LXD.
+```
+````
+
 The easiest way to install LXD is to {ref}`install one of the available packages <installing-from-package>`, but you can also {ref}`install LXD from the sources <installing-from-source>`.
 
 After installing LXD, make sure you have a `lxd` group on your system.

--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -1,6 +1,14 @@
 (first-steps)=
 # First steps with LXD
 
+````{only} integrated
+
+```{note}
+MicroCloud users can disregard the instructions on this page, because the MicroCloud setup process handles the installation and initialization of LXD.
+```
+
+````
+
 This tutorial guides you through the first steps with LXD.
 It covers installing and initializing LXD, creating and configuring some instances, interacting with the instances, and creating snapshots.
 

--- a/doc/tutorial/ui.md
+++ b/doc/tutorial/ui.md
@@ -1,6 +1,14 @@
 (tutorial-ui)=
 # Getting started with the UI
 
+````{only} integrated
+
+```{note}
+MicroCloud users can skip the first Install and initialize LXD section and begin at the {ref}`Access the UI <tutorial-ui-access>` section. The MicroCloud setup process handles LXD installation and initialization.
+```
+
+````
+
 This tutorial gives a quick introduction to using the LXD UI.
 It covers installing and initializing LXD, getting access to the UI, and carrying out some standard operations like creating, configuring, and interacting with instances, configuring storage, and using projects.
 
@@ -16,6 +24,7 @@ Ensure that you have 20 GiB free disk space before starting this tutorial.
     :end-before: <!-- Include end tutorial installation -->
 ```
 
+(tutorial-ui-access)=
 ## Access the UI
 
 You access the LXD UI through your browser.


### PR DESCRIPTION
This PR adds hidden annotations in certain LXD pages that only appear when viewed through the [MicroCloud docs integration](https://canonical-microcloud.readthedocs-hosted.com/en/latest/lxd).

Their purpose is to advise MicroCloud users when they are viewing parts of the LXD documentation that are not relevant for MicroCloud (such as LXD initialization instructions, since MicroCloud handles initializing LXD), or only partially relevant (such as the UI tutorial, where the latter part about using the UI is relevant, but the initial part about installing LXD is not).